### PR TITLE
chore: rename recipes/ to examples/

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Reactor Cookbook
 
-Practical, runnable recipes for building with the Reactor platform — short,
-self-contained examples you copy, run, and adapt, not reference documentation.
+Practical, runnable examples for building with the Reactor platform — short,
+self-contained code you copy, run, and adapt, not reference documentation.
 For API references and guides, see the platform docs.
 
 ## Structure
 
-Each recipe lives in its own folder under [`recipes/`](./recipes), with a
-README explaining what it does and the code to run it. A recipe should run
-on its own: clone the repo, `cd` into the recipe's folder, follow its README.
+Each example lives in its own folder under [`examples/`](./examples), with a
+README explaining what it does and the code to run it. An example should run
+on its own: clone the repo, `cd` into the example's folder, follow its README.
 
 ## Contributing
 
-Adding a recipe? Give it its own folder under `recipes/` named for what it
+Adding an example? Give it its own folder under `examples/` named for what it
 does (not the API it happens to call), and a README that leads with the
 problem it solves.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,13 +1,13 @@
-# Recipes
+# Examples
 
-One folder per recipe, named for the problem it solves (e.g.
+One folder per example, named for the problem it solves (e.g.
 `adaptive-bitrate-streaming/`, not `reactor-webrtc-set-bitrate/`). Each
-recipe folder is self-contained and has its own README covering:
+example folder is self-contained and has its own README covering:
 
 - What it does and when you'd reach for it
 - Prerequisites (versions, credentials, environment)
 - How to run it
 - Notes on anything surprising in the code
 
-Nothing lives directly in this folder besides this file — every recipe gets
+Nothing lives directly in this folder besides this file — every example gets
 its own subfolder.


### PR DESCRIPTION
## Summary
- Renames the `recipes/` folder to `examples/` and updates the wording in
  the root README and the folder's own README to match.

🤖 Generated with Claude Code