### PR TITLE
Add DreamZero-YAM bridge example

### DIFF
--- a/robotics/sim/README.md
+++ b/robotics/sim/README.md
@@ -9,10 +9,10 @@ physics simulator against the same served policies, using the Python
 
 ## Quickstarts
 
-**[`notebooks/`](./notebooks)** holds six runnable Python scripts, each with a
-guide, that drive a **hosted** Reactor robotics policy by replaying recorded
-observations. **No simulator, no GPU, no model weights**: `uv sync`, an API
-key, and a few minutes. Open the one for your model; there is no reading order.
+**[`notebooks/`](./notebooks)** holds seven runnable Python examples: six
+recorded-observation replays and one live robot bridge. **No simulator, no GPU,
+no model weights**: `uv sync`, an API key, and a few minutes. Open the one for
+your model; there is no reading order.
 
 - [`lingbot_va_quickstart.md`](./notebooks/lingbot_va_quickstart.md):
   `lingbot-va`, LIBERO manipulation. Lock-step, driven by an executed-action
@@ -33,6 +33,10 @@ key, and a few minutes. Open the one for your model; there is no reading order.
   predicts every engine tick (~100 ms), and the client filters chunks by
   engine ordering. `(40, 17)` split across three named fields; real FR3 rig
   frames.
+- [`dreamzero_yam_bridge.md`](./notebooks/dreamzero_yam_bridge.md):
+  `dreamzero-yam-molmoact2`, a live bridge for the bimanual YAM embodiment.
+  Replace three methods to connect cameras, robot state, and a controller;
+  the model returns `(24, 14)` action chunks.
 - [`dreamzero_quickstart.md`](./notebooks/dreamzero_quickstart.md):
   `dreamzero`, a 14B world-action model on the DROID/Franka embodiment.
   Free-running: it broadcasts `(24, 8)` chunks and the client uses `obs_seq`
@@ -43,11 +47,11 @@ key, and a few minutes. Open the one for your model; there is no reading order.
   packed chunks of which the first 12 columns are live. Its paper's
   benchmark is [`robocasa365/`](./robocasa365) below.
 
-[`notebooks/README.md`](./notebooks#choose-a-model) has a model matrix covering
-the wire protocol, action chunk, and available closed-loop harness.
+[`notebooks/README.md`](./notebooks#choose-a-model) covers the replay models and
+the live bridge.
 
-The client package the scripts import (`notebooks/reactor_robotics/`) is
-the same client an eval harness or a controller for a physical robot uses; see
+The replay scripts share `notebooks/reactor_robotics/`; the live bridge uses
+the SDK directly. See
 [robot-policy-client-contract.md](./notebooks/robot-policy-client-contract.md).
 
 ## The sim packages

--- a/robotics/sim/notebooks/README.md
+++ b/robotics/sim/notebooks/README.md
@@ -1,8 +1,8 @@
 # Quickstart scripts and guides
 
-Six runnable scripts, each with a guide, that drive a hosted Reactor robotics
-policy from Python, replaying recorded observations. They need no simulator,
-no GPU and no model weights: `uv sync`, an API key, and a few minutes.
+Six replay quickstarts and one live robot bridge for hosted Reactor robotics
+policies. They need no simulator, GPU, or model weights: `uv sync`, an API key,
+and a few minutes.
 
 Open the guide for the model you care about and run its script; there is no
 reading order. `xwam` is the reference implementation of
@@ -11,9 +11,10 @@ so it is the one to read if you want the contract itself rather than a model.
 
 ## Choose a model
 
-Every guide starts with the same lightweight recorded-observation replay. Its
-last two sections cover the optional closed-loop simulator and the remaining
-work for physical deployment. Published figures link to upstream sources;
+Every replay guide starts with the same lightweight recorded-observation
+workflow. Its last two sections cover the optional closed-loop simulator and
+the remaining work for physical deployment. Published figures link to
+upstream sources;
 figures labeled Reactor-measured come from the committed harness or fixture
 provenance.
 
@@ -30,6 +31,14 @@ provenance.
 depart from it (different state fields, no `chunk_id` echo, free-running
 instead of request/reply) and each guide states how for its own model. A
 client written against the generic contract will not drive them unchanged.
+
+## Live robot bridge
+
+[`dreamzero_yam_bridge.md`](./dreamzero_yam_bridge.md) and
+[`dreamzero_yam_bridge.py`](./dreamzero_yam_bridge.py) connect
+`dreamzero-yam-molmoact2` to a bimanual YAM robot. Run the example with
+placeholder cameras and state, then replace three methods to connect your
+hardware. The model returns free-running `(24, 14)` action chunks.
 
 ## Setup
 
@@ -58,7 +67,7 @@ At session close the SDK may log `WARNING Control channel not open; dropping
 'unpublish_track' notification` a few times. That is benign teardown noise —
 the session is already closing — not a failure.
 
-`REACTOR_API_URL` defaults to `https://api.reactor.inc` (PROD, where all six
+`REACTOR_API_URL` defaults to `https://api.reactor.inc` (PROD, where all seven
 models are served). It exists as an escape hatch for pointing at another
 deployment.
 
@@ -67,6 +76,8 @@ deployment.
 ```
 <model>_quickstart.py            the runnable script, one per model
 <model>_quickstart.md            its guide
+dreamzero_yam_bridge.py          live bimanual YAM bridge
+dreamzero_yam_bridge.md          integration guide and safety boundary
 reactor_robotics/
   session.py       connect + READY + tracks + keepalive; the shared plumbing
   track.py         a video track that repeats one frame until you replace it

--- a/robotics/sim/notebooks/dreamzero_yam_bridge.md
+++ b/robotics/sim/notebooks/dreamzero_yam_bridge.md
@@ -1,0 +1,69 @@
+# DreamZero-YAM robot bridge
+
+Use this example to connect `dreamzero-yam-molmoact2` to a bimanual YAM
+robot. It streams three camera views and the measured state of both arms, then
+receives `(24, 14)` action chunks.
+
+The script runs with placeholder cameras and state, so try it before adding
+robot hardware. To integrate your robot, replace three methods:
+
+- `CameraTrack.read_frame`
+- `RobotInterface.get_state`
+- `RobotInterface.execute_chunk`
+
+## Run it
+
+```sh
+cd notebooks
+uv sync --python 3.12
+
+export REACTOR_API_KEY='<your key>'
+uv run python dreamzero_yam_bridge.py
+```
+
+You should see `CONNECTING → WAITING → READY`, followed by
+`prompt_accepted`, `episode_started`, and a stream of chunk messages. Press
+Ctrl-C to stop. HTTP 429 `no available capacity` means no capacity is free;
+wait and retry.
+
+## Connect your robot
+
+- `read_frame` returns the latest `uint8` RGB frame for each view. Keep the
+  `top`, `left`, and `right` camera roles consistent.
+- `get_state` returns six joint positions and one gripper position for each
+  arm. Joint positions are radians; grippers use 0 for open and 1 for closed.
+- `execute_chunk` replaces the pending action buffer with the newest chunk
+  and sends it to your controller at its control rate.
+
+Do not send the raw quickstart output directly to hardware. Add joint limits,
+per-step motion limits, stale-chunk rejection, and a watchdog/e-stop first.
+
+## Wire contract
+
+The model is free-running and closed-loop. It uses:
+
+- video tracks named `top`, `left`, and `right`;
+- `set_prompt` once per episode;
+- `set_left_joint_pos`, `set_left_gripper_pos`,
+  `set_right_joint_pos`, and `set_right_gripper_pos` continuously;
+- `action_chunk` replies containing `chunk_index`, `obs_seq`,
+  `inference_seconds`, and `actions`.
+
+Each action row has 14 values:
+
+```text
+[left joints × 6, left gripper, right joints × 6, right gripper]
+```
+
+## Control-loop rules
+
+1. **Keep state flowing.** The example sends state at 10 Hz. If updates stop,
+   the model eventually waits for fresh state.
+2. **Send both arms.** An arm whose state is never streamed gets relative
+   deltas from a zero default. Do not execute them as absolute targets.
+3. **Replace, do not append.** A new chunk supersedes the pending chunk.
+   Blend or rate-limit the seam before sending it to a stiff controller.
+
+Always close the session when finished; the example does this in `finally`.
+For the shared session lifecycle, see the
+[robot policy client contract](./robot-policy-client-contract.md).

--- a/robotics/sim/notebooks/dreamzero_yam_bridge.py
+++ b/robotics/sim/notebooks/dreamzero_yam_bridge.py
@@ -1,0 +1,118 @@
+"""Minimal robot bridge for ``reactor/dreamzero-yam-molmoact2``.
+
+Streams three camera views and both arms' measured state. Replace
+``CameraTrack.read_frame``, ``RobotInterface.get_state``, and
+``RobotInterface.execute_chunk`` to connect real hardware. See
+``dreamzero_yam_bridge.md`` for the wire contract and safety boundary.
+"""
+
+import asyncio
+import os
+
+import numpy as np
+from aiortc import VideoStreamTrack
+from av import VideoFrame
+from reactor_sdk import Reactor, ReactorStatus
+
+MODEL = "reactor/dreamzero-yam-molmoact2"
+API_URL = os.environ.get("REACTOR_API_URL", "https://api.reactor.inc")
+CAMERAS = ["top", "left", "right"]  # model expects exactly these three views
+STATE_HZ = 10.0
+
+
+class CameraTrack(VideoStreamTrack):
+    """Publishes one camera as a WebRTC video track.
+
+    Replace `read_frame` with your camera driver. The model was trained on
+    176x320 RGB; sending at/near that resolution avoids wasting bandwidth.
+    """
+
+    def __init__(self, camera_name: str):
+        super().__init__()
+        self.camera_name = camera_name
+
+    def read_frame(self) -> np.ndarray:
+        # TODO: return the latest RGB frame from your camera as HxWx3 uint8.
+        return np.zeros((176, 320, 3), dtype=np.uint8)
+
+    async def recv(self) -> VideoFrame:
+        pts, time_base = await self.next_timestamp()
+        frame = VideoFrame.from_ndarray(self.read_frame(), format="rgb24")
+        frame.pts, frame.time_base = pts, time_base
+        return frame
+
+
+class RobotInterface:
+    """Replace with your robot driver."""
+
+    def get_state(self) -> dict:
+        # TODO: return measured joint positions (rad) and grippers (0..1).
+        return {
+            "left_joint_pos": [0.0] * 6,
+            "left_gripper_pos": 0.0,
+            "right_joint_pos": [0.0] * 6,
+            "right_gripper_pos": 0.0,
+        }
+
+    def execute_chunk(self, actions: np.ndarray) -> None:
+        # TODO: replace the pending action buffer with `actions` (24x14) and
+        # feed it to your controller. Columns: 0-5 left joints (absolute rad
+        # targets when you stream state), 6 left gripper, 7-12 right joints,
+        # 13 right gripper. Blend / rate-limit at the seam with the chunk
+        # you were executing.
+        pass
+
+
+async def main() -> None:
+    robot = RobotInterface()
+    ready = asyncio.Event()
+
+    reactor = Reactor(MODEL, api_key=os.environ["REACTOR_API_KEY"], api_url=API_URL)
+
+    @reactor.on_status
+    def on_status(status):
+        print(f"status: {status}")
+        if status == ReactorStatus.READY:
+            ready.set()
+
+    @reactor.on_message
+    def on_message(message):
+        data = message.get("data", {}) if isinstance(message, dict) else {}
+        if message.get("type") == "action_chunk":
+            actions = np.asarray(data["actions"], dtype=np.float64)  # (24, 14)
+            robot.execute_chunk(actions)
+            print(
+                f"chunk {data['chunk_index']}: inference {data['inference_seconds']:.3f}s"
+            )
+        else:
+            print(f"message: {message}")
+
+    await reactor.connect()
+    await asyncio.wait_for(ready.wait(), timeout=120)
+
+    # Publish the three camera views.
+    for name in CAMERAS:
+        await reactor.publish_track(name, CameraTrack(name))
+
+    # Set the task once; the episode starts when prompt + state are in.
+    await reactor.send_command("set_prompt", {"prompt": "fold the towel neatly with both arms"})
+
+    # Closed loop: stream measured state continuously. This is what paces
+    # the model — every chunk is conditioned on the latest state.
+    try:
+        while True:
+            state = robot.get_state()
+            await reactor.send_command("set_left_joint_pos", {"left_joint_pos": state["left_joint_pos"]})
+            await reactor.send_command("set_left_gripper_pos", {"left_gripper_pos": state["left_gripper_pos"]})
+            await reactor.send_command("set_right_joint_pos", {"right_joint_pos": state["right_joint_pos"]})
+            await reactor.send_command("set_right_gripper_pos", {"right_gripper_pos": state["right_gripper_pos"]})
+            await asyncio.sleep(1.0 / STATE_HZ)
+    finally:
+        await reactor.disconnect()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/robotics/sim/notebooks/tests/test_docs.py
+++ b/robotics/sim/notebooks/tests/test_docs.py
@@ -26,6 +26,10 @@ MODELS = {
         "xr1_robocasa365_quickstart.md",
         "xr1_robocasa365_quickstart.py",
     ),
+    "dreamzero-yam-molmoact2": (
+        "dreamzero_yam_bridge.md",
+        "dreamzero_yam_bridge.py",
+    ),
 }
 
 FIXTURE_ACTIONS = {


### PR DESCRIPTION
## Summary

- add the DreamZero-YAM bridge guide and script
- link the example from the robotics indexes
- add it to the documentation consistency check

## Validation

- `uv run python -m unittest discover -s tests`
- `uv run python -m py_compile dreamzero_yam_bridge.py`