### PR TITLE
Add PersonaPlex speech-to-speech recipe

### DIFF
--- a/models/personaplex/.dockerignore
+++ b/models/personaplex/.dockerignore
@@ -1,0 +1,24 @@
+# Python build and cache artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Local environments; model assets live in the mounted weights cache.
+.venv/
+venv/
+
+# Editor and operating-system state
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Source-control and Docker configuration
+.git/
+.gitignore
+Dockerfile
+.dockerignore

--- a/models/personaplex/Dockerfile
+++ b/models/personaplex/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+# Reactor PersonaPlex image. `reactor build` and `reactor run` invoke Docker for
+# this workspace; reactor-runtime ships its own WebRTC media stack as a wheel,
+# so a plain Python base needs no system media libraries.
+
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# PersonaPlex is published as a subdirectory of its Git repository rather than
+# to PyPI, so pip drives the `git` binary to fetch the pinned commit.
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Keep the expensive dependency layer reusable across adapter-only edits.
+COPY requirements.txt requirements-personaplex.txt /app/
+# Two passes because PersonaPlex's declared `torch < 2.5` and the CUDA 12.8
+# PyTorch a B200 needs cannot be resolved together. The runtime, PyTorch, and
+# every dependency PersonaPlex declares are resolved as one set first; the model
+# code then lands --no-deps on top of it. requirements-personaplex.txt has the
+# detail.
+RUN python -m pip install --no-cache-dir -r /app/requirements.txt \
+    && python -m pip install --no-cache-dir --no-deps -r /app/requirements-personaplex.txt
+
+COPY . /app/
+
+ENV PYTHONUNBUFFERED=1 \
+    HOST=0.0.0.0 \
+    PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["python", "-m", "reactor_runtime.serve"]

--- a/models/personaplex/README.md
+++ b/models/personaplex/README.md
@@ -1,0 +1,275 @@
+# PersonaPlex example
+
+Hold a real-time spoken conversation with
+[NVIDIA PersonaPlex](https://huggingface.co/nvidia/personaplex-7b-v1) — a 7B
+Moshi-architecture speech-to-speech model — served through Reactor Runtime. A
+client sends its microphone and receives the agent's voice, plus the agent's own
+words as text. The persona is a sentence you write ("You work for CitySan
+Services and your name is Ayelen Lucero"), and the voice is one of the model's
+packaged voice prompts.
+
+Reach for this when you want a spoken agent that behaves like a person on a
+call rather than a walkie-talkie: it can be interrupted mid-sentence, it talks
+over you, and it takes a turn back quickly. That is the model's doing, not the
+adapter's, and the next section explains why it comes for free.
+
+## Runtime boundary
+
+PersonaPlex encodes incoming speech and generates its own on the same 12.5 Hz
+token clock — one step consumes 80 ms of what it hears and produces 80 ms of
+what it says. Because the agent is speaking while it is still listening, there is
+no turn to detect and no barge-in to implement: interruptions, overlaps, and
+rapid turn-taking fall out of the model. The adapter never inspects the audio
+and never decides whose turn it is.
+
+What the adapter does own is clocks and rates:
+
+- **Rate conversion.** Reactor's WebRTC transport carries mono 16-bit PCM at
+  48 kHz in both directions; Mimi works at 24 kHz float32. The ratio is exactly
+  two, so `personaplex_audio.py` decimates on the way in and interpolates on the
+  way out, through one linear-phase FIR applied with retained history so the
+  filter stays continuous across frame boundaries. Restarting it every frame
+  would stamp a discontinuity into the audio 12.5 times a second. Fixed cost:
+  0.65 ms of group delay per leg, which does not accumulate.
+- **Pacing.** The microphone read is the clock. It cannot return faster than
+  real time, so the loop needs no rate limiter and the agent's speech leaves at
+  exactly the rate the participant's arrives. `fps` is pinned to Mimi's 12.5 Hz
+  rather than left adaptive: an 80 ms frame is 80 ms of speech however long it
+  took to compute, and pacing it to the measured step time would resample the
+  agent's voice into a pitch shift.
+- **Framing.** Inbound blocks are whatever the transport decoded — 10 ms each in
+  practice — and never line up with an 80 ms frame. The remainder is carried
+  between turns so no sample is dropped or duplicated at a block boundary.
+
+The playout queue is bounded at four frames, or 320 ms. The loop is mic-paced so
+it rarely fills; what the bound buys is room to absorb a step that overruns its
+80 ms budget without the client hearing a gap. Deeper would only add latency to
+a conversation, which is the one thing that has to stay low.
+
+If the model cannot keep up with real time, the inbound buffer drops its oldest
+blocks rather than growing a queue — right for a conversation, but silent, so the
+adapter logs `inbound audio is backing up` when it happens. A session that
+reports it is a session where the agent is missing parts of what was said.
+
+### Conditioning is a separate phase
+
+A voice prompt and a role prompt are stepped through the language model before
+it can generate anything, which takes seconds rather than milliseconds. So it is
+not part of the per-frame loop: the adapter enters a conditioning phase on the
+first step of a session, and again whenever a client sends `set_persona`,
+`set_voice`, or `restart`.
+
+While it runs, no agent speech is produced. `StateUpdate.conversation_pending`
+is true throughout and `ConversationStarted` is broadcast at the end, so a
+client can show the agent as preparing rather than as broken. On the way out,
+queued playout is flushed and the microphone backlog is dropped: the agent
+starts listening from that moment instead of answering speech from before the
+persona changed.
+
+`StateUpdate.conversation_index` increments per conversation, and `AgentText`
+carries the index it came from, so a client can discard transcript belonging to
+a persona the user has already replaced.
+
+### One conversation per session
+
+The model streams with a batch size of one, so a session holds exactly one
+conversation. Reactor routes inbound media from every connection into the same
+track, so two clients both sending microphone audio would interleave into one
+corrupted stream. Additional clients are fine as **listeners** — outbound audio
+and text reach all of them — but only one participant should publish a
+microphone.
+
+## Run with the Reactor CLI
+
+This directory is a `reactor` workspace, described in
+[Build your own model](https://docs.reactor.inc/deploy/overview). The host needs
+the [`reactor` CLI](https://docs.reactor.inc/deploy/platform/installation),
+Docker, the NVIDIA Container Toolkit, and a Blackwell NVIDIA GPU — the pinned
+PyTorch is a CUDA 12.8 build, for the reason the next section gives. The 7B
+checkpoint runs in bfloat16 and wants roughly 20 GB of VRAM.
+
+The model repository is **gated**: accept its licence on Hugging Face and
+forward a read token without putting its value on the Docker command line.
+
+```sh
+cd models/personaplex
+export HF_TOKEN=hf_your_read_token
+reactor build
+reactor run --gpus device=0 -e HF_TOKEN
+```
+
+`--gpus device=3` selects host GPU 3 and presents it as device 0 inside the
+container; `--gpus all` exposes every GPU. `reactor run` reuses the built image
+and serves on `http://localhost:8080`. Rebuild after changing code or
+dependencies. To use a different port:
+
+```sh
+reactor build && reactor run --gpus device=0 -e HF_TOKEN --port 18011
+```
+
+The first start downloads roughly 20 GB and captures CUDA graphs, so it takes a
+while; later starts reuse both. Once it is ready:
+
+```sh
+curl -s localhost:8080/health
+curl -s localhost:8080/schema
+curl -s -X POST localhost:8080/start_session \
+  -H 'content-type: application/json' -d '{}'
+```
+
+A WebRTC client publishes a microphone on `mic` and subscribes to `voice`.
+Connect using a client built with the
+[Reactor SDK](https://docs.reactor.inc/sdk-reference/using-the-sdk).
+
+### Why the PyTorch pin is overridden
+
+The manifest requests one `NVIDIA_B200`. A B200 is `sm_100`, and the first
+PyTorch with Blackwell support is
+[2.7, with CUDA 12.8 wheels](https://pytorch.org/blog/pytorch-2-7/) — while
+PersonaPlex declares `torch >= 2.2, < 2.5`. The two are mutually exclusive, and
+not softly: a cu124 build carries no `sm_100` kernel image, so it does not run
+slowly on a B200, it fails at the first CUDA op.
+
+So the pin is overridden. `requirements.txt` installs `torch==2.9.1+cu128` —
+2.9 rather than 2.7 because Blackwell support had a few releases to settle, and
+because `alayaworld` in this repository already serves B200 on that line.
+
+The declared ceiling looks conservative rather than load-bearing. PersonaPlex
+touches only mainstream PyTorch, and its whole inference path — Mimi streaming
+encode/decode, `LMGen.step`, the `.wav` voice-prompt path, and
+`step_system_prompts` — runs unmodified on torch 2.9.1, and on 2.13 with numpy
+2.5 besides. The one relevant default that changed since upstream's pin is
+`torch.load`'s `weights_only`, flipped to `True` in torch 2.6; the voice `.pt`
+files are a dict of tensors, which the strict loader accepts.
+
+What blocks the override is packaging, not the code: pip reads the declared
+metadata and refuses the install outright with `ResolutionImpossible`. Hence the
+two passes in the `Dockerfile` — the runtime, PyTorch, and everything
+PersonaPlex declares resolve as one set, then the model code lands `--no-deps`
+on top. `requirements-personaplex.txt` carries that reasoning next to the pin.
+
+Two consequences worth knowing. The build loses its single-pass guarantee: a
+future conflict between the runtime and PersonaPlex will surface at model load
+rather than during the build, so `pip check` inside the image is the thing to
+read — it should report the deliberate `torch<2.5` complaint and nothing else.
+And the weights run against a PyTorch upstream has not tested them on.
+
+**Running on an H100 instead** is the conservative alternative: set
+`gpu.type: NVIDIA_H100`, change the index to `.../whl/cu124` and the pin to
+`torch==2.4.1+cu124`, and the two passes collapse back into one with
+`moshi-personaplex` moved into `requirements.txt`. That configuration honours
+every declared bound. It is not the default only because the hardware here is
+Blackwell.
+
+Either way the model is latency-bound rather than throughput-bound — a 7B model
+stepping at 12.5 Hz — and one conversation uses about 20 GB. The GPU choice
+buys session density, not a faster conversation.
+
+## Model assets
+
+The CLI bind-mounts `runtime.weights_path` from `reactor.yaml` and exports it as
+`REACTOR_WEIGHTS_PATH`. The checked-in default keeps everything under
+`~/.cache/reactor_registry/personaplex`, outside both the image and this Git
+checkout, so rebuilds retain it. Nothing large is baked into a layer.
+
+On first load the adapter downloads four files at the pinned revision — the 7B
+language model, the Mimi codec checkpoint, the SentencePiece tokenizer, and the
+voice archive — then unpacks the voices once, guarded by a marker recording the
+revision they came from. An interrupted download resumes on the next start; a
+revision bump re-unpacks rather than silently mixing two sets of voices.
+
+`assets.revision` in `personaplex.yaml` is an immutable commit rather than
+`main`, so every build installs the same weights. To relocate everything, change
+only `runtime.weights_path`.
+
+## Controls
+
+Every command returns `StateUpdate`, a complete snapshot of the conversation's
+settings, and a joining client receives the same message — so clients render
+their controls from one payload instead of reconstructing state from partial
+updates.
+
+Two settings are applied live, on the next step:
+
+- `set_audio_temperature` — sampling temperature for the agent's speech, 0 to 2.
+- `set_text_temperature` — sampling temperature for the agent's text, 0 to 2.
+
+Two condition the model, so they start a fresh conversation:
+
+- `set_persona` — the role prompt: who the agent is, its background, and the
+  scenario. The adapter wraps it in the `<system>` tags the model was trained to
+  read. An empty persona leaves the agent unconditioned by any role.
+- `set_voice` — the voice prompt name. Names are read off the unpacked archive
+  rather than hard-coded, so `StateUpdate.voices` is the list this deployment
+  actually carries and an unknown name is rejected with `unknown_voice` naming
+  the valid ones. Upstream ships natural (`NATF*`, `NATM*`) and varied
+  (`VARF*`, `VARM*`) sets.
+
+And one restarts without changing anything:
+
+- `restart` — a fresh conversation under the current persona and voice,
+  discarding everything said so far.
+
+The model sends back:
+
+- `AgentText` — one fragment of the agent's own speech as text, alongside every
+  frame it generates. Fragments carry their leading spaces, so concatenating
+  them in arrival order reproduces the transcript with no separator. Text
+  arrives slightly ahead of the audio that renders it.
+- `ConversationStarted` — conditioning is done and the floor is open.
+- `StateUpdate` — the snapshot described above.
+
+Client-settable defaults live on `PersonaPlexState` in `personaplex_types.py`,
+not in `personaplex.yaml`, so the published schema and the running model cannot
+disagree about them. `personaplex.yaml` holds only what a client cannot choose:
+where the assets live, the device, the top-k cutoffs, and the seed.
+
+## Notes on the code
+
+- **No recording.** Runtime's recorder muxes around a video track and disables
+  itself for a model that emits none, so `reactor.yaml` carries no `recording:`
+  block. Enabling it on this audio-only model would log a warning and record
+  nothing.
+- **The persona field is moderated; the voice name is not.** A persona is
+  free text a client authored, so it carries Runtime's default moderation
+  eligibility. A voice name is an identifier chosen from a published list, so it
+  opts out — moderating `NATF0` would spend a check on nothing.
+- **PersonaPlex's dependency list is restated by hand, plus two it omits.**
+  Installing it `--no-deps` means pip never reads its metadata, so
+  `requirements.txt` carries that list at the bounds upstream declares. Two more
+  are there that upstream does not declare at all: `pyloudnorm`, imported inside
+  `normalize_audio` on the `.wav` voice-prompt path, and `accelerate`, inside
+  the `cpu_offload` branch of `get_moshi_lm`. Both sit behind a specific path,
+  so without them the failure is a `ModuleNotFoundError` mid-session rather than
+  at build. They are what make a reference-audio `.wav` and the
+  `cpu_offload: true` knob actually work.
+- **Eight codebooks are decoded, not sixteen.** `get_moshi_lm` builds the
+  language model with `dep_q = 16`: eight codebooks for the agent's own speech
+  and eight more for its prediction of the participant's stream. Only the
+  agent's half is audio to send, and its width is exactly the number of
+  codebooks `get_mimi` configures, so the adapter reads it from Mimi rather than
+  halving `dep_q` or hard-coding `1:9` the way upstream does.
+- **One Mimi, not two.** Upstream's `server.py` and `offline.py` both construct
+  a second `MimiModel` and run `encode`/`decode` on it in lockstep with the
+  first, discarding every result; it never reaches the language model or the
+  output. This adapter omits it, which halves Mimi's cost per step on the path
+  that has to stay under 80 ms.
+- **`BOS` and `EOS` are kept out of the transcript.** Upstream filters only
+  `EPAD` and `PAD`, so its client also receives raw `<s>` and `</s>` pieces.
+  Those are structural markers rather than speech, so they are dropped here.
+  This affects the transcript only, never the audio.
+- **`<system>` closes with `<system>`.** Not a typo carried over by accident:
+  upstream wraps the role prompt in `<system> … <system>`, and the tokenizer was
+  trained that way, so a well-formed closing tag would not match what the model
+  expects.
+- **Once-per-session work runs in `@session_started`, not `@connected`.** A
+  session closed server-side is torn down without a per-client disconnect, so
+  anything counted across connections would not return to its starting value for
+  the next session.
+
+## Licences
+
+The adapter follows this repository's Apache-2.0 licence. PersonaPlex's code is
+MIT; its weights are governed by the
+[NVIDIA Open Model License Agreement](https://huggingface.co/nvidia/personaplex-7b-v1),
+which you accept on Hugging Face before the first download.

--- a/models/personaplex/personaplex.py
+++ b/models/personaplex/personaplex.py
@@ -1,0 +1,632 @@
+"""Serve NVIDIA PersonaPlex as a full-duplex speech-to-speech Reactor model.
+
+PersonaPlex is a Moshi-architecture model that encodes the participant's speech
+and generates its own at the same time, on one 12.5 Hz token clock. That is what
+makes it conversational rather than turn-based: because the agent is producing
+audio while it is still hearing, interruptions, overlaps, and fast turn-taking
+come out of the model itself. Nothing in this adapter arranges them.
+
+The adapter's job is therefore small and mostly about clocks. Reactor's wire
+carries 48 kHz int16 mono; Mimi works at 24 kHz float32. Every 80 ms the adapter
+takes one wire frame, converts it down, runs one step of Mimi and the language
+model, converts the generated frame back up, and emits it. The mic read is what
+paces the loop — it cannot return faster than real time — so no rate limiter is
+needed and the agent's speech leaves at exactly the rate the participant's
+arrives.
+
+Conditioning is separate from that loop. A voice prompt and a role prompt are
+stepped through the language model before a conversation can start, which takes
+seconds rather than milliseconds, so it is a distinct phase the adapter enters
+on the first step of a session and again whenever a client changes the persona
+or the voice.
+
+Upstream's ``server.py`` and ``offline.py`` are the reference for the inference
+sequence; where this file departs from them it says so.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import time
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import numpy.typing as npt
+import sentencepiece
+import torch
+from moshi.models import LMGen, loaders
+
+from reactor_runtime import (
+    ClientInfo,
+    CommandError,
+    Idle,
+    InputField,
+    ReactorPipeline,
+    ReadMode,
+    connected,
+    event,
+    session_ended,
+    session_started,
+)
+from reactor_runtime.interface.pipeline.idle import _IdleType
+from reactor_runtime.log import get_logger
+
+from personaplex_assets import PersonaPlexAssets, prepare_assets, read_config
+from personaplex_audio import (
+    MODEL_SAMPLE_RATE,
+    WIRE_SAMPLE_RATE,
+    ModelToWire,
+    WireFrameAssembler,
+    WireToModel,
+)
+from personaplex_types import (
+    AgentText,
+    ConversationStarted,
+    PersonaPlexConfig,
+    PersonaPlexInput,
+    PersonaPlexOutput,
+    PersonaPlexState,
+    StateUpdate,
+)
+
+logger = get_logger(__name__)
+
+FRAME_RATE = 12.5
+"""Mimi's token rate in Hz — one 80 ms frame per step, in and out."""
+
+_PLAYOUT_FRAMES = 4
+"""Frames of agent speech that may queue ahead of the wire, i.e. 320 ms.
+
+The loop is paced by the mic, so it cannot outrun playout for long and this
+bound rarely binds; what it buys is room to absorb a step that takes longer
+than its 80 ms budget without the client hearing a gap. A deeper queue would
+only add latency to a conversation, which is the one thing that must stay low.
+"""
+
+_WARMUP_STEPS = 4
+"""Zero-input steps taken at load, to build the CUDA graphs before a client waits."""
+
+_TEXT_CONTROL_TOKENS = frozenset({0, 1, 2, 3})
+"""Text ids carrying no transcript: EPAD, BOS, EOS, and PAD.
+
+Upstream filters only EPAD and PAD, so its client also receives the raw ``<s>``
+and ``</s>`` pieces for BOS and EOS. Those are structural markers rather than
+speech, so they are dropped here; this affects the transcript only, never audio.
+"""
+
+_SYSTEM_TAG = "<system>"
+
+_BACKLOG_FRAMES = 25
+"""Inbound blocks waiting before the model is reported as falling behind.
+
+Counted in transport blocks, whose size the transport chooses — 10 ms each in
+practice, so this is roughly a quarter second of speech. Deliberately well above
+ordinary network jitter: the point is to name a model that cannot keep up with
+real time, not to narrate a queue that drains on the next step.
+"""
+
+_BACKLOG_QUIET = 5.0
+"""Seconds between repeats of the backlog warning, so a bad session logs once."""
+
+
+class PersonaPlex(ReactorPipeline):
+    """Hold a spoken conversation with a persona a client describes in text."""
+
+    state: PersonaPlexState
+    input: PersonaPlexInput
+
+    # Pinning `fps` tells the runtime every chunk plays out at Mimi's own token
+    # rate. Leaving it unpinned would tag each chunk with the measured step time
+    # instead, which for audio is meaningless — the frame is 80 ms of speech
+    # however long it took to compute, and pacing it any faster or slower would
+    # resample the agent's voice.
+    fps = FRAME_RATE
+    buffer_size = _PLAYOUT_FRAMES
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config: PersonaPlexConfig | None = None
+        self._assets: PersonaPlexAssets | None = None
+        self._device = torch.device("cpu")
+        self._mimi: Any = None
+        self._lm_gen: Any = None
+        self._tokenizer: Any = None
+        self._agent_codebooks = 0
+        self._model_frame_samples = 0
+        self._assembler: WireFrameAssembler | None = None
+        self._to_model = WireToModel()
+        self._to_wire = ModelToWire()
+        self._lagging_since: float | None = None
+
+    # -- load ------------------------------------------------------------------
+
+    def load(self, config_path: Path | None) -> None:
+        """Fetch the assets, place the model, and warm its CUDA graphs.
+
+        Runs once before any client can connect, so the first conversation pays
+        for downloads and graph capture only if this process has never served.
+
+        Args:
+            config_path: Path the runtime resolved from ``runtime.config``.
+
+        Raises:
+            RuntimeError: If Mimi's own frame rate disagrees with the rate this
+                adapter pins its playout to. Every clock here derives from that
+                one number, so a mismatch would emit correctly-sized frames at
+                the wrong speed — audible as a pitch shift rather than an error.
+        """
+        config = read_config(config_path)
+        assets = prepare_assets(config)
+        device = _select_device(config.device)
+        logger.info("loading PersonaPlex", device=str(device))
+
+        mimi = loaders.get_mimi(str(assets.mimi_weights), device)
+        tokenizer = sentencepiece.SentencePieceProcessor(str(assets.tokenizer))
+        lm = loaders.get_moshi_lm(
+            str(assets.lm_weights), device=device, cpu_offload=config.cpu_offload
+        )
+        lm.eval()
+
+        if int(mimi.sample_rate) != MODEL_SAMPLE_RATE or not math.isclose(
+            float(mimi.frame_rate), FRAME_RATE
+        ):
+            raise RuntimeError(
+                f"Mimi reports {mimi.sample_rate} Hz at {mimi.frame_rate} fps; this "
+                f"adapter is built for {MODEL_SAMPLE_RATE} Hz at {FRAME_RATE} fps"
+            )
+
+        lm_gen = LMGen(
+            lm,
+            device=device,
+            sample_rate=int(mimi.sample_rate),
+            frame_rate=mimi.frame_rate,
+            audio_silence_frame_cnt=int(
+                config.prompt_silence_seconds * mimi.frame_rate
+            ),
+            top_k=config.audio_top_k,
+            top_k_text=config.text_top_k,
+            save_voice_prompt_embeddings=False,
+        )
+
+        # Both modules stay in streaming mode for the life of the process;
+        # `reset_streaming` is what starts a fresh conversation within it.
+        mimi.streaming_forever(1)
+        lm_gen.streaming_forever(1)
+
+        self._config = config
+        self._assets = assets
+        self._device = device
+        self._mimi = mimi
+        self._lm_gen = lm_gen
+        self._tokenizer = tokenizer
+        # The language model runs two audio streams — the agent's own speech and
+        # its prediction of the participant's — so `lm.dep_q` counts both. Only
+        # the agent's half is decoded, and its width is exactly the number of
+        # codebooks Mimi was configured for, so read it from Mimi rather than
+        # halving dep_q or hard-coding 8.
+        agent_codebooks = int(mimi.num_codebooks)
+        if int(lm.dep_q) < agent_codebooks:
+            raise RuntimeError(
+                f"the language model carries {lm.dep_q} audio codebooks, fewer than "
+                f"the {agent_codebooks} Mimi decodes"
+            )
+        self._agent_codebooks = agent_codebooks
+        self._model_frame_samples = int(mimi.sample_rate / mimi.frame_rate)
+        self._assembler = WireFrameAssembler(
+            self._model_frame_samples * (WIRE_SAMPLE_RATE // MODEL_SAMPLE_RATE)
+        )
+
+        self._warm_up()
+        logger.info(
+            "PersonaPlex loaded",
+            voices=len(assets.voices),
+            frame_samples=self._model_frame_samples,
+        )
+
+    def _warm_up(self) -> None:
+        """Run silent steps so CUDA graph capture happens before a client connects.
+
+        Mirrors upstream's warmup: encode silence, step the language model, and
+        decode what it produces, enough times for every graph on the path to be
+        captured. The streaming state this leaves behind is discarded by the
+        `reset_streaming` that starts the first conversation.
+        """
+        silence = torch.zeros(
+            1, 1, self._model_frame_samples, dtype=torch.float32, device=self._device
+        )
+        for _ in range(_WARMUP_STEPS):
+            codes = self._mimi.encode(silence)
+            for index in range(codes.shape[-1]):
+                tokens = self._lm_gen.step(codes[:, :, index : index + 1])
+                if tokens is not None:
+                    self._mimi.decode(tokens[:, 1 : 1 + self._agent_codebooks])
+        if self._device.type == "cuda":
+            torch.cuda.synchronize()
+
+    # -- lifecycle -------------------------------------------------------------
+
+    @session_started
+    def on_session_started(self) -> None:
+        """Arm the first conversation before the session's first client connects.
+
+        Once-per-session work belongs here rather than in ``@connected``: a
+        session that ends server-side is torn down without a per-client
+        disconnect, so anything counted across connections would not return to
+        its starting value for the next session.
+        """
+        self.state._conversation_pending = True
+        self.state._conversation_index = 0
+
+    @connected
+    async def on_connected(self, client: ClientInfo) -> None:
+        """Hand a joining client the current snapshot, including the voice list."""
+        await client.send(self._snapshot())
+
+    @session_ended
+    def on_session_ended(self) -> None:
+        """Drop the conversation's streaming state, keeping the weights resident.
+
+        Fires on a server-side close as well as a natural end, so it is the only
+        place that reliably sees every session out.
+        """
+        if self._lm_gen is not None:
+            self._mimi.reset_streaming()
+            self._lm_gen.reset_streaming()
+        self._reset_stream_buffers()
+        self._lagging_since = None
+
+    # -- commands --------------------------------------------------------------
+
+    @event(
+        name="set_persona",
+        description=(
+            "Describe who the agent is, then start a conversation under that "
+            "role. The model is conditioned on the text before it generates, so "
+            "this restarts the conversation rather than steering the current one."
+        ),
+    )
+    async def set_persona(
+        self,
+        persona: str = InputField(
+            max_length=2000,
+            description=(
+                "Role prompt: who the agent is, its background, and the "
+                "scenario. Pass an empty string to leave the agent "
+                "unconditioned by any role."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Store the role prompt and arm a conversation that runs under it."""
+        if self.state is None:
+            raise CommandError("no_session", "No session is running.")
+        self.state.persona = persona
+        self._arm_conversation()
+        return self._snapshot()
+
+    @event(
+        name="set_voice",
+        description=(
+            "Select the voice the agent speaks in, then start a conversation "
+            "using it. StateUpdate.voices lists the names available."
+        ),
+    )
+    async def set_voice(
+        self,
+        voice: str = InputField(
+            description=(
+                "Voice prompt name, as published in StateUpdate.voices "
+                "(for example NATF0 or VARM2)."
+            ),
+            min_length=1,
+            max_length=64,
+            # An identifier chosen from a published list, not authored prose.
+            moderate=False,
+        ),
+    ) -> StateUpdate:
+        """Store the voice and arm a conversation that speaks in it.
+
+        The names are validated against what the model repository actually
+        shipped rather than a list baked into this adapter, so the error tells a
+        client what it may choose from instead of what a past release carried.
+        """
+        if self.state is None:
+            raise CommandError("no_session", "No session is running.")
+        assets = self._require_assets()
+        if voice not in assets.voices:
+            raise CommandError(
+                "unknown_voice",
+                f"Unknown voice {voice!r}. Available: {', '.join(assets.voice_names)}.",
+            )
+        self.state.voice = voice
+        self._arm_conversation()
+        return self._snapshot()
+
+    @event(
+        name="restart",
+        description=(
+            "Start a fresh conversation under the current persona and voice, "
+            "discarding everything said so far. Queued agent speech is dropped "
+            "so nothing from the old conversation plays after the cut."
+        ),
+    )
+    async def restart(self) -> StateUpdate:
+        """Arm a fresh conversation without changing any setting."""
+        if self.state is None:
+            raise CommandError("no_session", "No session is running.")
+        self._arm_conversation()
+        return self._snapshot()
+
+    # -- inference -------------------------------------------------------------
+
+    async def inference(self) -> AsyncIterator[PersonaPlexOutput | _IdleType]:
+        """Step the conversation once per inbound 80 ms frame.
+
+        Each turn reads one frame of the participant's speech, feeds it to the
+        model, and yields the frame the model spoke in return. The read is the
+        clock: it cannot complete faster than the mic delivers, so the loop runs
+        at real time without measuring anything.
+
+        A conversation that is armed is built first. That is the several-second
+        conditioning phase, and it runs inside this turn on purpose — the
+        pipeline holds its generator lock across a turn, so no command can
+        change the persona halfway through the prompt it is being applied from.
+        """
+        while True:
+            if self.state._conversation_pending:
+                await self._begin_conversation()
+
+            frame = await self._read_model_frame()
+            speech, text = self._step_conversation(frame)
+
+            if text:
+                await self.send(
+                    AgentText(
+                        text=text, conversation_index=self.state._conversation_index
+                    )
+                )
+            if speech is None:
+                # The language model is still inside its own token delay and has
+                # not produced a frame yet. Skipping the turn lets the transport
+                # fill the gap with real-time silence, which keeps the audio
+                # clock advancing; emitting an invented frame would not.
+                yield Idle
+                continue
+
+            yield PersonaPlexOutput(voice=speech)
+
+    async def _begin_conversation(self) -> None:
+        """Condition the model on the current voice and persona, then open the floor.
+
+        Follows upstream's order exactly: load the voice prompt, encode the role
+        prompt, reset both streaming states, step the prompts through the
+        language model, and reset Mimi again — the voice prompt is encoded with
+        the same Mimi instance the conversation then uses, so its encoder state
+        has to be cleared before the participant's first frame reaches it.
+        """
+        state = self.state
+        assets = self._require_assets()
+        config = self._require_config()
+
+        voice_path = assets.voices.get(state.voice)
+        if voice_path is None:
+            # A voice can only be missing if it was valid when set and the
+            # assets changed underneath, so fall back rather than end the
+            # session: a conversation in the wrong voice beats no conversation.
+            fallback = assets.voice_names[0]
+            logger.warning(
+                "voice is no longer available; falling back",
+                requested=state.voice,
+                fallback=fallback,
+            )
+            state.voice = fallback
+            voice_path = assets.voices[fallback]
+
+        state._conversation_index += 1
+        logger.info(
+            "conditioning conversation",
+            index=state._conversation_index,
+            voice=state.voice,
+            persona_chars=len(state.persona),
+        )
+
+        if config.seed is not None:
+            _seed_all(config.seed)
+
+        lm_gen = self._lm_gen
+        if lm_gen.voice_prompt != str(voice_path):
+            if voice_path.suffix == ".pt":
+                lm_gen.load_voice_prompt_embeddings(str(voice_path))
+            else:
+                lm_gen.load_voice_prompt(str(voice_path))
+        lm_gen.text_prompt_tokens = (
+            self._tokenizer.encode(_wrap_with_system_tags(state.persona))
+            if state.persona.strip()
+            else None
+        )
+
+        started = time.perf_counter()
+        self._mimi.reset_streaming()
+        lm_gen.reset_streaming()
+        lm_gen.step_system_prompts(self._mimi)
+        self._mimi.reset_streaming()
+
+        # Everything that arrived or was queued while conditioning ran belongs
+        # to no conversation: drop the participant's backlog so the agent does
+        # not answer speech from seconds ago, and cut queued playout so the old
+        # conversation cannot be heard after the new one starts.
+        self.output.flush()
+        self._reset_stream_buffers()
+        self.input.mic.clear()
+
+        state._conversation_pending = False
+        self._lagging_since = None
+        logger.info(
+            "conversation ready",
+            index=state._conversation_index,
+            seconds=round(time.perf_counter() - started, 2),
+        )
+        await self.send(
+            ConversationStarted(
+                persona=state.persona,
+                voice=state.voice,
+                conversation_index=state._conversation_index,
+            )
+        )
+        await self.send(self._snapshot())
+
+    async def _read_model_frame(self) -> npt.NDArray[np.float32]:
+        """Return the next 80 ms of participant speech at the model's rate.
+
+        Inbound blocks are whatever the transport decoded — 10 ms each in
+        practice — so they are accumulated until one whole frame is held. The
+        read blocks, which is what paces this model, and raises ``BufferClosed``
+        on teardown, which the pipeline driver treats as the end of the session.
+        """
+        assembler = self._require_assembler()
+        while True:
+            frame = assembler.take()
+            if frame is not None:
+                return self._to_model.process(frame)
+            blocks = await self.input.mic.read(1, mode=ReadMode.FIFO)
+            assembler.push(blocks[0].data)
+            self._note_backlog()
+
+    def _step_conversation(
+        self, frame: npt.NDArray[np.float32]
+    ) -> tuple[npt.NDArray[np.int16] | None, str]:
+        """Run one model step over one frame, returning its speech and its text.
+
+        Args:
+            frame: One frame of participant speech, mono float32 at the model's
+                sample rate.
+
+        Returns:
+            The agent's speech for this step as wire-rate int16 samples, or
+            ``None`` when the model produced no frame, together with whatever
+            text it produced (empty when it produced none).
+        """
+        state = self.state
+        lm_gen = self._lm_gen
+        # Read live each step: the temperatures are the two settings a client can
+        # change without restarting, so they are applied here rather than cached.
+        lm_gen.temp = float(state.audio_temperature)
+        lm_gen.temp_text = float(state.text_temperature)
+
+        chunk = torch.from_numpy(frame).to(self._device).reshape(1, 1, -1)
+        codes = self._mimi.encode(chunk)
+
+        speech: list[npt.NDArray[np.float32]] = []
+        pieces: list[str] = []
+        for index in range(codes.shape[-1]):
+            tokens = lm_gen.step(codes[:, :, index : index + 1])
+            if tokens is None:
+                continue
+            # Channel 0 carries the text token; 1..agent_codebooks carry the
+            # agent's speech. The channels above those are the model's prediction
+            # of the participant's own stream, which nothing here decodes.
+            decoded = self._mimi.decode(tokens[:, 1 : 1 + self._agent_codebooks])
+            speech.append(decoded[0, 0].float().cpu().numpy())
+            piece = self._text_piece(int(tokens[0, 0, 0].item()))
+            if piece:
+                pieces.append(piece)
+
+        if not speech:
+            return None, "".join(pieces)
+        generated = speech[0] if len(speech) == 1 else np.concatenate(speech)
+        # Shaped (1, M) — the runtime's documented form for a mono audio track.
+        wire = self._to_wire.process(generated).reshape(1, -1)
+        return wire, "".join(pieces)
+
+    def _text_piece(self, token: int) -> str:
+        """Render one text token as transcript text, or ``""`` for a control token."""
+        if token in _TEXT_CONTROL_TOKENS:
+            return ""
+        return str(self._tokenizer.id_to_piece(token)).replace("▁", " ")
+
+    # -- internals -------------------------------------------------------------
+
+    def _arm_conversation(self) -> None:
+        """Mark the conversation for rebuilding on the next inference turn."""
+        self.state._conversation_pending = True
+
+    def _snapshot(self) -> StateUpdate:
+        """Build the complete client-facing snapshot of the conversation."""
+        return StateUpdate.from_state(self.state, self._require_assets().voice_names)
+
+    def _reset_stream_buffers(self) -> None:
+        """Clear the resampler history and the partial inbound frame."""
+        self._to_model.reset()
+        self._to_wire.reset()
+        if self._assembler is not None:
+            self._assembler.reset()
+
+    def _note_backlog(self) -> None:
+        """Log once while the model is falling behind the participant's speech.
+
+        The inbound buffer drops its oldest frames when it fills, so a model
+        that cannot keep up with real time loses audio rather than growing a
+        queue. That is the right behaviour for a conversation, but it is silent,
+        so it is worth saying out loud — a session that reports this is a
+        session where the agent is missing parts of what was said.
+        """
+        available = self.input.mic.available
+        if available < _BACKLOG_FRAMES:
+            self._lagging_since = None
+            return
+        now = time.monotonic()
+        if self._lagging_since is None or now - self._lagging_since > _BACKLOG_QUIET:
+            self._lagging_since = now
+            logger.warning(
+                "inbound audio is backing up; the agent is missing speech",
+                blocks_waiting=available,
+            )
+
+    def _require_config(self) -> PersonaPlexConfig:
+        """Return the loaded config, or fail clearly if ``load`` never ran."""
+        if self._config is None:
+            raise RuntimeError("PersonaPlex was not loaded")
+        return self._config
+
+    def _require_assets(self) -> PersonaPlexAssets:
+        """Return the resolved assets, or fail clearly if ``load`` never ran."""
+        if self._assets is None:
+            raise RuntimeError("PersonaPlex was not loaded")
+        return self._assets
+
+    def _require_assembler(self) -> WireFrameAssembler:
+        """Return the inbound frame assembler, or fail clearly if ``load`` never ran."""
+        if self._assembler is None:
+            raise RuntimeError("PersonaPlex was not loaded")
+        return self._assembler
+
+
+def _wrap_with_system_tags(persona: str) -> str:
+    """Wrap a role prompt in the system tags the model was trained to read.
+
+    Kept byte-identical to upstream's helper, including the closing tag being
+    ``<system>`` rather than ``</system>``: the tokenizer was trained that way,
+    and a well-formed closing tag would not match what the model expects.
+    """
+    cleaned = persona.strip()
+    if cleaned.startswith(_SYSTEM_TAG) and cleaned.endswith(_SYSTEM_TAG):
+        return cleaned
+    return f"{_SYSTEM_TAG} {cleaned} {_SYSTEM_TAG}"
+
+
+def _select_device(requested: str) -> torch.device:
+    """Resolve the configured device, preferring CUDA when asked for ``auto``."""
+    if requested and requested != "auto":
+        return torch.device(requested)
+    return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def _seed_all(seed: int) -> None:
+    """Seed torch, NumPy, and Python so a conversation is reproducible."""
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    random.seed(seed)
+    np.random.seed(seed)

--- a/models/personaplex/personaplex.yaml
+++ b/models/personaplex/personaplex.yaml
@@ -1,0 +1,42 @@
+# PersonaPlex deployment settings.
+#
+# Only what a client cannot choose lives here. The persona, voice, and the two
+# sampling temperatures are client-settable, so their defaults are declared on
+# PersonaPlexState in personaplex_types.py — that way the published schema and
+# the running model cannot disagree about them.
+
+assets:
+  # The model repository is gated: accept its licence on Hugging Face and pass
+  # a read token to the container as HF_TOKEN before the first start.
+  repo_id: nvidia/personaplex-7b-v1
+
+  # Immutable commit rather than `main`, so a rebuild downloads the same
+  # checkpoint, codec, tokenizer, and voice set as every start before it.
+  revision: fdaf4090a61cb315c138a1faee287ffd6c716309
+
+  # Where the downloaded assets land, relative to the CLI's weights mount
+  # (`runtime.weights_path` in reactor.yaml, exported as REACTOR_WEIGHTS_PATH).
+  # Roughly 20 GB once the checkpoint and voices are on disk.
+  path: assets
+
+# Torch device for the language model and the codec. `auto` prefers CUDA.
+device: auto
+
+# Move language-model layers to host memory when GPU memory is short. Costs
+# latency on every step, so leave it off unless a start fails for memory.
+cpu_offload: false
+
+sampling:
+  # Top-k cutoffs, fixed per deployment; the temperatures beside them are the
+  # client-settable half of the same sampling controls.
+  audio_top_k: 250
+  text_top_k: 25
+
+# Silence held between the voice prompt, the role prompt, and the conversation,
+# matching upstream's spacer. Shortening it makes conditioning faster and the
+# transition into speech more abrupt.
+prompt_silence_seconds: 0.5
+
+# Seed applied before each conversation. -1 leaves generation unseeded, which is
+# what a conversation normally wants; a fixed value makes a rollout repeatable.
+seed: -1

--- a/models/personaplex/personaplex_assets.py
+++ b/models/personaplex/personaplex_assets.py
@@ -1,0 +1,229 @@
+"""Resolving the PersonaPlex config and fetching its published assets.
+
+The adapter needs four files from the model repository — the language model, the
+Mimi codec checkpoint, the text tokenizer, and the archive of voice prompts —
+plus the voices unpacked to disk. All of it is downloaded once into the
+directory the Reactor CLI mounts as the weights root, so a rebuilt image
+reuses what is already there and nothing large is baked into a layer.
+
+The repository is gated: accept its licence on Hugging Face and pass a read
+token in as ``HF_TOKEN``. Without one the first download fails with an
+authorisation error rather than anything about the model.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from reactor_runtime import get_weights_path
+from reactor_runtime.log import get_logger
+
+from personaplex_types import PersonaPlexConfig
+
+logger = get_logger(__name__)
+
+_VOICES_ARCHIVE = "voices.tgz"
+_VOICES_DIR = "voices"
+_VOICE_SUFFIXES = (".pt", ".wav")
+_UNPACK_MARKER = ".reactor-voices.json"
+
+
+@dataclass(frozen=True)
+class PersonaPlexAssets:
+    """Where each downloaded asset landed on disk.
+
+    Attributes:
+        lm_weights: The 7B language-model checkpoint.
+        mimi_weights: The Mimi encoder/decoder checkpoint.
+        tokenizer: The SentencePiece text tokenizer.
+        voices: Voice prompt name to the file conditioning on it.
+    """
+
+    lm_weights: Path
+    mimi_weights: Path
+    tokenizer: Path
+    voices: dict[str, Path]
+
+    @property
+    def voice_names(self) -> list[str]:
+        """Every voice prompt name available, sorted."""
+        return sorted(self.voices)
+
+
+def read_config(config_path: Path | None) -> PersonaPlexConfig:
+    """Read the adapter's config file into a :class:`PersonaPlexConfig`.
+
+    The runtime resolves ``runtime.config`` from ``reactor.yaml`` to a path and
+    hands it over unparsed, so the format is this adapter's own. Every key has a
+    default, and ``assets.path`` is resolved under the runtime's weights root so
+    relocating the assets is a one-line change in ``reactor.yaml``.
+
+    Args:
+        config_path: Path the runtime resolved, or ``None`` when the manifest
+            names no config file.
+
+    Returns:
+        The parsed configuration.
+
+    Raises:
+        ValueError: If ``assets.path`` is absolute, or a numeric field is out of
+            range — either would only surface later as a confusing failure.
+    """
+    document: dict[str, Any] = {}
+    if config_path is not None:
+        loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            document = loaded
+
+    assets = document.get("assets") if isinstance(document.get("assets"), dict) else {}
+    sampling = (
+        document.get("sampling") if isinstance(document.get("sampling"), dict) else {}
+    )
+
+    relative = str(assets.get("path", "personaplex"))
+    if Path(relative).is_absolute():
+        raise ValueError(
+            f"assets.path must be relative to the weights root, got {relative!r}"
+        )
+
+    audio_top_k = int(sampling.get("audio_top_k", 250))
+    text_top_k = int(sampling.get("text_top_k", 25))
+    if audio_top_k < 1 or text_top_k < 1:
+        raise ValueError("sampling.audio_top_k and sampling.text_top_k must be >= 1")
+
+    silence = float(document.get("prompt_silence_seconds", 0.5))
+    if silence < 0:
+        raise ValueError("prompt_silence_seconds must not be negative")
+
+    raw_seed = document.get("seed")
+    seed = None if raw_seed is None or int(raw_seed) < 0 else int(raw_seed)
+
+    return PersonaPlexConfig(
+        repo_id=str(assets.get("repo_id", "nvidia/personaplex-7b-v1")),
+        revision=str(assets.get("revision", "main")),
+        assets_path=get_weights_path() / relative,
+        device=str(document.get("device", "auto")),
+        audio_top_k=audio_top_k,
+        text_top_k=text_top_k,
+        prompt_silence_seconds=silence,
+        seed=seed,
+        cpu_offload=bool(document.get("cpu_offload", False)),
+    )
+
+
+def prepare_assets(config: PersonaPlexConfig) -> PersonaPlexAssets:
+    """Download and unpack everything the adapter loads, reusing what is present.
+
+    Each file is fetched at the pinned revision into ``config.assets_path``.
+    Hugging Face skips a file already complete there and resumes a partial one,
+    so an interrupted first start continues rather than starting over. The voice
+    archive is unpacked once, guarded by a marker recording the revision it came
+    from, so a revision bump re-unpacks instead of silently mixing two sets.
+
+    Args:
+        config: The parsed adapter configuration.
+
+    Returns:
+        The resolved asset paths and the voice prompts found on disk.
+
+    Raises:
+        RuntimeError: If the archive carried no voice prompt files — the model
+            cannot be conditioned without one, and failing here names the cause.
+    """
+    from huggingface_hub import hf_hub_download
+    from moshi.models import loaders
+
+    root = config.assets_path
+    root.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        "preparing PersonaPlex assets",
+        repo_id=config.repo_id,
+        revision=config.revision,
+        path=str(root),
+    )
+
+    def fetch(filename: str) -> Path:
+        return Path(
+            hf_hub_download(
+                repo_id=config.repo_id,
+                filename=filename,
+                revision=config.revision,
+                local_dir=root,
+            )
+        )
+
+    lm_weights = fetch(loaders.MOSHI_NAME)
+    mimi_weights = fetch(loaders.MIMI_NAME)
+    tokenizer = fetch(loaders.TEXT_TOKENIZER_NAME)
+    archive = fetch(_VOICES_ARCHIVE)
+
+    voices_dir = _unpack_voices(archive, root, config.revision)
+    voices = _collect_voices(voices_dir)
+    if not voices:
+        raise RuntimeError(
+            f"{_VOICES_ARCHIVE} unpacked no voice prompts into {voices_dir}; "
+            f"expected files ending in {' or '.join(_VOICE_SUFFIXES)}"
+        )
+
+    logger.info("PersonaPlex assets ready", voices=len(voices))
+    return PersonaPlexAssets(
+        lm_weights=lm_weights,
+        mimi_weights=mimi_weights,
+        tokenizer=tokenizer,
+        voices=voices,
+    )
+
+
+def _unpack_voices(archive: Path, root: Path, revision: str) -> Path:
+    """Extract the voice archive under *root*, once per revision.
+
+    Extraction is filtered to plain data members, so a malformed archive cannot
+    write outside the destination. The marker is written last and replaced
+    atomically, so an interrupted extraction is retried on the next start rather
+    than mistaken for a finished one.
+    """
+    voices_dir = root / _VOICES_DIR
+    marker = root / _UNPACK_MARKER
+    if marker.is_file():
+        try:
+            recorded = json.loads(marker.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            recorded = {}
+        if recorded.get("revision") == revision and voices_dir.is_dir():
+            return voices_dir
+
+    logger.info("unpacking voice prompts", archive=str(archive))
+    with tarfile.open(archive, "r:gz") as tar:
+        tar.extractall(path=root, filter="data")
+    if not voices_dir.is_dir():
+        raise RuntimeError(f"{archive} did not contain a '{_VOICES_DIR}/' directory")
+
+    pending = marker.with_suffix(".tmp")
+    pending.write_text(json.dumps({"revision": revision}), encoding="utf-8")
+    os.replace(pending, marker)
+    return voices_dir
+
+
+def _collect_voices(voices_dir: Path) -> dict[str, Path]:
+    """Map each voice prompt's name to its file, preferring precomputed embeddings.
+
+    Upstream ships both a ``.wav`` of the reference speech and a ``.pt`` of the
+    embeddings already encoded from it. The ``.pt`` skips a few seconds of Mimi
+    encoding at every conversation start, so it wins when both are present.
+
+    The names are read off disk rather than hard-coded: the set of packaged
+    voices belongs to the model repository, and a list baked into the adapter
+    would start rejecting valid voices the moment upstream adds one.
+    """
+    voices: dict[str, Path] = {}
+    for suffix in reversed(_VOICE_SUFFIXES):
+        for path in sorted(voices_dir.rglob(f"*{suffix}")):
+            voices[path.stem] = path
+    return voices

--- a/models/personaplex/personaplex_audio.py
+++ b/models/personaplex/personaplex_audio.py
@@ -1,0 +1,189 @@
+"""Rate conversion between Reactor's wire audio and PersonaPlex's model audio.
+
+Reactor's WebRTC transport carries mono 16-bit PCM at 48 kHz in both
+directions, and PersonaPlex works on mono float32 at 24 kHz — Mimi's native
+rate. The ratio is exactly two, so both directions are a fixed half-band
+resampling: decimate by two on the way in, interpolate by two on the way out.
+
+Both use the same linear-phase FIR, applied with retained history so the
+filter is continuous across frame boundaries. That continuity is the reason
+these are objects rather than functions: a conversation is a long stream cut
+into 80 ms frames, and a filter restarted on every frame would stamp a
+discontinuity into the audio 12.5 times a second.
+
+The constant group delay is ``(taps - 1) / 2`` samples at 48 kHz — 0.65 ms
+with the filter below, on each leg. That is well inside the latency budget of
+a spoken turn and does not accumulate: it is a fixed offset, not a drift.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+WIRE_SAMPLE_RATE = 48_000
+"""Sample rate Reactor's transport delivers and accepts, in Hz."""
+
+MODEL_SAMPLE_RATE = 24_000
+"""Sample rate Mimi encodes and decodes at, in Hz."""
+
+_RATIO = WIRE_SAMPLE_RATE // MODEL_SAMPLE_RATE
+
+_INT16_SCALE = 32768.0
+_INT16_PEAK = 32767
+
+# 63 taps of windowed sinc, cut off at 11 kHz of the 48 kHz stream. The stop
+# band starts below the 12 kHz Nyquist of the 24 kHz side, so decimation
+# folds nothing audible back into the speech band; a Kaiser window at
+# beta 8.6 puts the stop-band ripple near -90 dB, far under the noise floor
+# of a 16-bit wire. Speech carries nothing above 11 kHz worth preserving.
+_NUM_TAPS = 63
+_CUTOFF_HZ = 11_000.0
+_KAISER_BETA = 8.6
+
+
+def _lowpass_taps() -> npt.NDArray[np.float32]:
+    """Return the shared anti-alias / anti-image FIR, normalised to unity DC gain."""
+    positions = np.arange(_NUM_TAPS, dtype=np.float64)
+    centre = (_NUM_TAPS - 1) / 2.0
+    ratio = _CUTOFF_HZ / WIRE_SAMPLE_RATE
+    taps = 2.0 * ratio * np.sinc(2.0 * ratio * (positions - centre))
+    taps *= np.kaiser(_NUM_TAPS, _KAISER_BETA)
+    taps /= taps.sum()
+    return taps.astype(np.float32)
+
+
+_TAPS = _lowpass_taps()
+
+
+class _StreamingFir:
+    """The shared FIR, applied across frames without restarting.
+
+    Holds the ``taps - 1`` trailing samples of the previous call so the next
+    one convolves against real history instead of zeros. Feeding ``n`` samples
+    always returns ``n`` samples.
+    """
+
+    def __init__(self) -> None:
+        self._history = np.zeros(_TAPS.size - 1, dtype=np.float32)
+
+    def reset(self) -> None:
+        """Forget the retained history, for a stream that starts over."""
+        self._history[:] = 0.0
+
+    def process(self, samples: npt.NDArray[np.float32]) -> npt.NDArray[np.float32]:
+        """Filter *samples*, returning as many samples as were given."""
+        if samples.size == 0:
+            return samples
+        padded = np.concatenate([self._history, samples])
+        self._history = padded[padded.size - self._history.size :].copy()
+        return np.convolve(padded, _TAPS, mode="valid").astype(np.float32)
+
+
+class WireToModel:
+    """Turns 48 kHz int16 wire audio into 24 kHz float32 model audio.
+
+    Low-passes at the shared cutoff, then keeps every second sample. Input
+    length must be even, which the caller guarantees by working in whole
+    frames.
+    """
+
+    def __init__(self) -> None:
+        self._fir = _StreamingFir()
+
+    def reset(self) -> None:
+        """Drop the filter history, for a conversation that starts over."""
+        self._fir.reset()
+
+    def process(self, wire: npt.NDArray[np.int16]) -> npt.NDArray[np.float32]:
+        """Convert one block of wire samples into model samples.
+
+        Args:
+            wire: Mono int16 samples at 48 kHz. The length must be even.
+
+        Returns:
+            Mono float32 samples at 24 kHz in ``[-1, 1)``, half as many.
+
+        Raises:
+            ValueError: If the block length is not a multiple of the rate ratio.
+        """
+        if wire.size % _RATIO:
+            raise ValueError(
+                f"expected a multiple of {_RATIO} wire samples, got {wire.size}"
+            )
+        scaled = wire.astype(np.float32) / _INT16_SCALE
+        return self._fir.process(scaled)[::_RATIO]
+
+
+class ModelToWire:
+    """Turns 24 kHz float32 model audio into 48 kHz int16 wire audio.
+
+    Inserts a zero between successive samples and low-passes to remove the
+    images that zero-stuffing creates. Zero-stuffing halves the average
+    amplitude, so the filtered result is scaled back by the ratio.
+    """
+
+    def __init__(self) -> None:
+        self._fir = _StreamingFir()
+
+    def reset(self) -> None:
+        """Drop the filter history, for a conversation that starts over."""
+        self._fir.reset()
+
+    def process(self, model: npt.NDArray[np.float32]) -> npt.NDArray[np.int16]:
+        """Convert one block of model samples into wire samples.
+
+        Args:
+            model: Mono float32 samples at 24 kHz, nominally in ``[-1, 1]``.
+
+        Returns:
+            Mono int16 samples at 48 kHz, twice as many, clipped to the int16
+            range rather than wrapped — a generated frame can overshoot, and a
+            wrap would read as a click.
+        """
+        stuffed = np.zeros(model.size * _RATIO, dtype=np.float32)
+        stuffed[::_RATIO] = model.astype(np.float32) * _RATIO
+        filtered = self._fir.process(stuffed)
+        return np.clip(filtered * _INT16_SCALE, -_INT16_PEAK - 1, _INT16_PEAK).astype(
+            np.int16
+        )
+
+
+class WireFrameAssembler:
+    """Cuts a stream of arbitrary inbound blocks into fixed-size frames.
+
+    Inbound audio arrives in whatever blocks the transport decoded — 10 ms at a
+    time in practice — while the model consumes exactly one 80 ms frame per
+    step. This holds the remainder between reads so no sample is dropped or
+    duplicated at a block boundary.
+
+    Args:
+        frame_samples: How many samples one frame holds.
+    """
+
+    def __init__(self, frame_samples: int) -> None:
+        self._frame_samples = frame_samples
+        self._pending = np.zeros(0, dtype=np.int16)
+
+    def reset(self) -> None:
+        """Discard whatever is held short of a full frame."""
+        self._pending = np.zeros(0, dtype=np.int16)
+
+    @property
+    def buffered(self) -> int:
+        """How many samples are held, short of a full frame."""
+        return int(self._pending.size)
+
+    def push(self, block: npt.NDArray[np.int16]) -> None:
+        """Append one decoded inbound block, flattening its channel dimension."""
+        samples = np.asarray(block, dtype=np.int16).reshape(-1)
+        if samples.size:
+            self._pending = np.concatenate([self._pending, samples])
+
+    def take(self) -> npt.NDArray[np.int16] | None:
+        """Return one whole frame, or ``None`` while fewer samples are held."""
+        if self._pending.size < self._frame_samples:
+            return None
+        frame = self._pending[: self._frame_samples].copy()
+        self._pending = self._pending[self._frame_samples :]
+        return frame

--- a/models/personaplex/personaplex_types.py
+++ b/models/personaplex/personaplex_types.py
@@ -1,0 +1,233 @@
+"""Client-facing contract for the PersonaPlex adapter.
+
+Everything a connected client can see or change lives here: the two audio
+tracks, the session state its commands write, and the messages the model sends
+back. Keeping them in one file makes the published schema readable as a single
+document rather than something reassembled from the adapter's control flow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from reactor_runtime import (
+    Audio,
+    Input,
+    InputField,
+    InputState,
+    MessageField,
+    ModelMessage,
+    Output,
+)
+
+DEFAULT_PERSONA = (
+    "You are a wise and friendly teacher. Answer questions or provide advice "
+    "in a clear and engaging way."
+)
+"""Role prompt used until a client sets its own — upstream's assistant template."""
+
+DEFAULT_VOICE = "NATF0"
+"""Voice prompt used until a client selects another, from upstream's natural set."""
+
+
+# -- Tracks --------------------------------------------------------------------
+
+
+class PersonaPlexInput(Input):
+    """The audio this model listens to.
+
+    ``mic`` is the participant's microphone. PersonaPlex encodes it
+    incrementally while generating its own reply, so speech that overlaps the
+    agent is heard rather than queued — interruptions and barge-ins are part of
+    the model, not something the adapter arranges.
+    """
+
+    mic: Audio
+
+
+class PersonaPlexOutput(Output):
+    """The audio this model speaks.
+
+    ``voice`` carries the agent's own generated speech. Its text is sent
+    separately as :class:`AgentText`, so a client can show a transcript without
+    running speech recognition over the track.
+    """
+
+    voice: Audio
+
+
+# -- Session state -------------------------------------------------------------
+
+
+class PersonaPlexState(InputState):
+    """Conversation settings a client may change mid-session.
+
+    ``persona`` and ``voice`` condition the model before it generates anything,
+    so a change to either takes effect at the next conversation — either the
+    ``restart`` command, or the setter itself, which starts one. The two
+    temperatures are read on every step and take effect immediately.
+    """
+
+    persona: str = InputField(
+        default=DEFAULT_PERSONA,
+        max_length=2000,
+        description=(
+            "Role prompt describing who the agent is: its name, background, "
+            "and the scenario it is in. Applied at the next conversation start."
+        ),
+    )
+    voice: str = InputField(
+        default=DEFAULT_VOICE,
+        min_length=1,
+        max_length=64,
+        # A voice name is an identifier the model repository published, not
+        # prose a client authored, so it is not a moderation candidate.
+        moderate=False,
+        description=(
+            "Name of the packaged voice prompt establishing the agent's vocal "
+            "characteristics. StateUpdate.voices lists the names this "
+            "deployment carries. Applied at the next conversation start."
+        ),
+    )
+    audio_temperature: float = InputField(
+        default=0.8,
+        ge=0.0,
+        le=2.0,
+        description=(
+            "Sampling temperature for the agent's speech tokens. Lower is "
+            "steadier, higher is more varied. Takes effect immediately."
+        ),
+    )
+    text_temperature: float = InputField(
+        default=0.7,
+        ge=0.0,
+        le=2.0,
+        description=(
+            "Sampling temperature for the agent's text tokens. Takes effect "
+            "immediately."
+        ),
+    )
+
+    # Private: the adapter's own bookkeeping, never surfaced as a command.
+    # A conversation is pending until the model has run its voice and role
+    # prompts through the language model, which it does on the first step of a
+    # session and again after any restart.
+    _conversation_pending: bool = True
+    _conversation_index: int = 0
+
+
+# -- Messages ------------------------------------------------------------------
+
+
+class StateUpdate(ModelMessage):
+    """Complete snapshot of the conversation's settings.
+
+    Sent to a client when it joins, and returned by every command, so a client
+    renders its controls from one message instead of reconstructing them from a
+    sequence of partial updates.
+    """
+
+    persona: str = MessageField(description="Role prompt the agent is conditioned on.")
+    voice: str = MessageField(description="Voice prompt selected for the agent.")
+    voices: list[str] = MessageField(
+        description="Every voice prompt name this deployment carries, sorted."
+    )
+    audio_temperature: float = MessageField(
+        description="Sampling temperature now applied to speech tokens."
+    )
+    text_temperature: float = MessageField(
+        description="Sampling temperature now applied to text tokens."
+    )
+    conversation_pending: bool = MessageField(
+        description=(
+            "True while the model is conditioning on the persona and voice. "
+            "No agent speech is produced until it turns false."
+        )
+    )
+    conversation_index: int = MessageField(
+        description=(
+            "How many conversations this session has started. Increments on "
+            "every restart, so a client can discard text from a prior one."
+        )
+    )
+
+    @classmethod
+    def from_state(cls, state: PersonaPlexState, voices: list[str]) -> StateUpdate:
+        """Build a snapshot from the live session state and the loaded voices."""
+        return cls(
+            persona=state.persona,
+            voice=state.voice,
+            voices=voices,
+            audio_temperature=state.audio_temperature,
+            text_temperature=state.text_temperature,
+            conversation_pending=state._conversation_pending,
+            conversation_index=state._conversation_index,
+        )
+
+
+class ConversationStarted(ModelMessage):
+    """The model has finished conditioning and is now listening.
+
+    Broadcast once per conversation, after the voice and role prompts have been
+    stepped through the language model. Agent audio starts flowing from here.
+    """
+
+    persona: str = MessageField(description="Role prompt this conversation runs under.")
+    voice: str = MessageField(description="Voice prompt this conversation runs under.")
+    conversation_index: int = MessageField(
+        description="Index of the conversation that just started."
+    )
+
+
+class AgentText(ModelMessage):
+    """One piece of the agent's own speech, as text.
+
+    PersonaPlex generates a text token alongside every 80 ms audio frame, so
+    this arrives incrementally and slightly ahead of the audio that renders it.
+    Concatenating the pieces in arrival order reproduces the transcript; the
+    pieces already carry their leading spaces, so no separator is needed.
+    """
+
+    text: str = MessageField(description="Text fragment the agent just produced.")
+    conversation_index: int = MessageField(
+        description="Which conversation produced it, matching StateUpdate."
+    )
+
+
+# -- Configuration -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PersonaPlexConfig:
+    """Deployment settings read from the adapter's config file.
+
+    These are the choices a client does not make: where the weights live, what
+    device to place them on, and the sampling bounds the temperatures move
+    within. Client-settable defaults live on :class:`PersonaPlexState` instead,
+    so the published schema and the running model cannot disagree about them.
+
+    Attributes:
+        repo_id: Hugging Face repository holding the checkpoint and voices.
+        revision: Immutable commit of that repository to download.
+        assets_path: Directory the assets are downloaded into, resolved under
+            the runtime's weights root.
+        device: Torch device string, or ``"auto"`` to prefer CUDA.
+        audio_top_k: Top-k cutoff for speech-token sampling.
+        text_top_k: Top-k cutoff for text-token sampling.
+        prompt_silence_seconds: Silence held between the prompt phases, matching
+            upstream's spacer.
+        seed: Seed applied before each conversation, or ``None`` for unseeded.
+        cpu_offload: Offload language-model layers to host memory when GPU
+            memory is short.
+    """
+
+    repo_id: str
+    revision: str
+    assets_path: Path
+    device: str
+    audio_top_k: int
+    text_top_k: int
+    prompt_silence_seconds: float
+    seed: int | None
+    cpu_offload: bool

--- a/models/personaplex/reactor.yaml
+++ b/models/personaplex/reactor.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1beta
+kind: VideoModel
+
+model:
+  name: personaplex-7b
+  version: v0.0.1
+  description: |
+    Hold a real-time spoken conversation with a persona described in text and
+    a voice chosen from the model's packaged set.
+  resources:
+    gpu:
+      type: NVIDIA_B200
+      count: 1
+
+runtime:
+  import: personaplex:PersonaPlex
+  config: personaplex.yaml
+  weights_path: ~/.cache/reactor_registry/personaplex
+
+build:
+  runtime_version: "3.1.2"
+
+# No `recording:` block. The recorder muxes around a video track and disables
+# itself for a model that emits none, so enabling it on this audio-only model
+# would produce a startup warning and no recording.

--- a/models/personaplex/requirements-personaplex.txt
+++ b/models/personaplex/requirements-personaplex.txt
@@ -1,0 +1,17 @@
+# The PersonaPlex model code, from the pinned upstream commit rather than a
+# branch head, so the same build installs the same source every time. Published
+# only as a subdirectory of its repository, never to PyPI.
+#
+# It is installed on its own, with --no-deps, because its metadata declares
+# `torch >= 2.2, < 2.5` and Blackwell support starts at PyTorch 2.7 — no single
+# resolution can satisfy both, and pip refuses the install outright with
+# ResolutionImpossible. Everything it declares is restated in requirements.txt
+# instead, alongside the two dependencies it imports without declaring.
+#
+# The ceiling is conservative rather than load-bearing: PersonaPlex touches only
+# mainstream PyTorch, and its whole inference path — Mimi streaming
+# encode/decode, LMGen.step, the .wav voice-prompt path, and
+# step_system_prompts — runs unmodified on the pinned torch above. What this
+# gives up is the single-pass guarantee: a conflict between the runtime and this
+# package now surfaces at model load instead of during the build.
+moshi-personaplex @ git+https://github.com/NVIDIA/personaplex.git@3428dfd95309a7f3c84fd93259ded0f810d1ff91#subdirectory=moshi

--- a/models/personaplex/requirements.txt
+++ b/models/personaplex/requirements.txt
@@ -1,0 +1,56 @@
+# Python dependencies installed into the model image, so a conflict between the
+# runtime, PyTorch, and PersonaPlex's own stack fails during build rather than
+# at model load.
+#
+# reactor-runtime is the runtime itself; releases are immutable and there is no
+# floating `latest` version. It must match `build.runtime_version` in
+# reactor.yaml.
+reactor-runtime==3.1.2
+
+# PyTorch's CUDA 12.8 wheels, which carry the sm_100 kernels a B200 needs.
+# PyPI stays the primary index for everything else.
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+# B200-compatible replacement for PersonaPlex's upstream `torch >= 2.2, < 2.5`.
+# Blackwell support starts at PyTorch 2.7, so the declared ceiling and this GPU
+# are mutually exclusive; requirements-personaplex.txt explains how that is
+# resolved and what it costs. 2.9.1 rather than 2.7.x because Blackwell support
+# had a few releases to settle and because `alayaworld` in this repository
+# already serves B200 on it.
+torch==2.9.1+cu128
+
+# The one version satisfying both floors: Runtime needs `numpy >= 2.1` and
+# PersonaPlex needs `numpy < 2.2`. Pinned because that overlap is a single minor
+# release, and a resolver picking either side of it would fail the build.
+numpy==2.1.3
+
+# Imported directly by the adapter: the tokenizer for the role prompt, the Hub
+# client for the gated assets, and YAML for the config file. Hub is held below
+# PersonaPlex's `< 0.25` ceiling.
+sentencepiece==0.2.0
+huggingface-hub==0.24.7
+PyYAML==6.0.3
+
+# PersonaPlex's own dependencies, restated. It is installed --no-deps (see
+# requirements-personaplex.txt), so pip does not read its metadata and these
+# would otherwise be missing. Kept at the bounds upstream declares.
+einops==0.7
+safetensors>=0.4.0,<0.5
+sphn>=0.1.4,<0.2
+aiohttp>=3.10.5,<3.11
+sounddevice==0.5
+tqdm
+
+# Two more that PersonaPlex imports but never declares, so they are absent from
+# the metadata restated above. Both sit behind a specific path, which is why
+# they surface as a ModuleNotFoundError mid-session rather than at build:
+#
+#   pyloudnorm  `normalize_audio`, reached by `load_voice_prompt` — the .wav
+#               voice path. Upstream ships its voices as precomputed .pt
+#               embeddings, which skip it, so this is what makes a
+#               reference-audio .wav dropped into the voices directory work.
+#               Brings scipy.
+#   accelerate  the `cpu_offload: true` branch of `get_moshi_lm`. Installed so
+#               that config knob is real rather than a crash.
+pyloudnorm==0.2.0
+accelerate==1.14.0


### PR DESCRIPTION
Serves [NVIDIA PersonaPlex](https://huggingface.co/nvidia/personaplex-7b-v1) — a
7B Moshi-architecture full-duplex speech model — through Reactor Runtime 3.1.2.
A client publishes a microphone and receives the agent's voice plus its own
words as text. The persona is a sentence the client writes; the voice is one of
the model's packaged prompts.

## What the adapter owns

Clocks, not conversation logic. PersonaPlex encodes incoming speech and
generates its own on the same 12.5 Hz clock, so interruptions, overlaps, and
fast turn-taking come from the model — nothing here detects a turn.

- **Rate conversion.** Reactor's WebRTC transport is fixed at 48 kHz int16 mono
  (the inbound sink discards the reported rate; `Audio.sample_rate` is schema
  metadata only), and Mimi works at 24 kHz float32. The adapter resamples 2×
  through one linear-phase FIR applied with retained history, so the filter
  stays continuous across 80 ms frames instead of stamping a discontinuity
  12.5 times a second. Measured: 0.02% round-trip RMS error, −59 dB rejection
  at 20 kHz.
- **Pacing.** The microphone read is the clock — it cannot return faster than
  real time — so there is no rate limiter. `fps` is pinned to 12.5 rather than
  left adaptive, which would tag each chunk with the measured step time and
  resample the agent's voice into a pitch shift.
- **Conditioning** on the voice and role prompts takes seconds, so it is a
  separate phase, entered on session start and on
  `set_persona` / `set_voice` / `restart`.

## Contract

Tracks `mic` (in) and `voice` (out). Commands `set_persona`, `set_voice`,
`restart`, `set_audio_temperature`, `set_text_temperature`. Messages
`StateUpdate`, `ConversationStarted`, `AgentText`.

Client-settable defaults live on `PersonaPlexState`, not in the config file, so
the published schema and the running model cannot disagree. Voice names are read
off the unpacked archive rather than hard-coded, so `StateUpdate.voices` is what
this deployment actually carries.

## Deviations from upstream, and why

Each is covered in the README's "Notes on the code".

- **Decodes 8 codebooks, read from `mimi.num_codebooks`.** `get_moshi_lm` sets
  `dep_q = 16` — the agent's stream plus its prediction of the participant's —
  and only the agent's half is audio to send. Upstream hard-codes `1:9`.
- **Drops upstream's second `MimiModel`,** which encodes and decodes in lockstep
  with the first and discards every result; it reaches neither the LM nor the
  output. Halves Mimi's cost on the path that must stay under 80 ms.
- **Installs `pyloudnorm` and `accelerate`,** which PersonaPlex imports but does
  not declare. `pyloudnorm` is reached by `load_voice_prompt` (the `.wav` path)
  and `accelerate` by the `cpu_offload` branch. Both would surface as a
  `ModuleNotFoundError` mid-session rather than at build.
- **Overrides the declared `torch < 2.5`** for CUDA 12.8 on B200 — Blackwell is
  `sm_100` and a cu124 build has no kernel image for it. pip refuses that in one
  pass, so the model code installs `--no-deps` with its metadata restated in
  `requirements.txt`.
- **Keeps `BOS`/`EOS` out of the transcript.** Upstream filters only `EPAD` and
  `PAD`, so its client also receives raw `<s>`/`</s>`. Transcript only, never
  audio.

## Verified

Run inside a venv reproducing the image's two-pass install (cu128 wheel swapped
for the CPU equivalent, since the dev box is macOS):

- `pip check` reports **only** the deliberate `torch<2.5` override — proof the
  hand-restated dependency list is complete.
- The real moshi inference path on CPU under torch 2.9.1 + numpy 2.1.3: Mimi
  streaming encode/decode, `LMGen.step`, the `.wav` voice-prompt path,
  `step_system_prompts`.
- A stub-driven harness over the adapter: load, warmup, conditioning, odd-block
  reframing, a full step, live temperature, voice validation, restart, session
  end.
- Schema renders (5 commands, 3 messages, both tracks); `ruff format` clean.

## Not verified — why this is a draft

- **`reactor build` has not run** (no Docker daemon on the dev box).
- **Nothing ran on Blackwell silicon.** CUDA graph capture is disabled on CPU,
  so `CUDAGraphed` and `sm_100` codegen are exactly what a CPU run cannot
  check. If it breaks, it surfaces in `load()`'s warmup, before any client
  connects.
- **No live session** against real weights — the repo is gated, so the weights
  were never downloaded here. Numerical parity is untested.

## Notes for review

- Recording is deliberately absent: Runtime's recorder self-disables for a model
  with no video track.
- A session holds one conversation — the model streams batch-1 and Runtime
  merges inbound media from every connection into one track, so extra clients
  are listeners only. Documented in the README.
- Branch and commit follow this repo's conventions (plain sentence titles, no
  Linear ticket IDs), not the internal monorepo's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
