### PR TITLE
Declare model.resources in every recipe manifest

### DIFF
--- a/models/alayaworld/reactor.yaml
+++ b/models/alayaworld/reactor.yaml
@@ -1,24 +1,92 @@
-apiVersion: v1beta
-kind: VideoModel
+# Reactor model spec for the AlayaWorld recipe.
+#
+# `$schema` pins the schema this file is written against — reactor/v1 is the
+# current one. Keep it as the first line.
+$schema: reactor/v1
 
+# The `model:` block is read by `reactor model register/publish/deploy` and
+# describes the model to the platform. The `runtime:` block is read by the
+# runtime and names the class to serve. To deploy this recipe under your own
+# account, edit `model.name` and the resources below, then:
+#
+#   reactor run --gpus device=0 -e HF_TOKEN   # serve locally
+#   reactor model publish                     # build the image, prepare a release
+#   reactor model deploy                      # activate that release for traffic
 model:
+  # Model name used in CLI args and API responses. Change it to something
+  # unique to your account before publishing — a name already registered by
+  # someone else is rejected. Segments must be lowercase [a-z0-9] runs
+  # separated by '.', '_' or '-'.
   name: alaya-world
+
+  # The release tag `reactor model publish` / `reactor model deploy` use when
+  # no `<model>:<release>` is passed on the command line. Releases are
+  # immutable, so bump this after every successful publish.
   version: v0.0.1
+
   description: |
     Play the distilled AlayaWorld model with live prompt and six-axis camera controls.
+
+  # A new model registers private. Leave this key out and `reactor model
+  # update` will not touch the setting. Write it to make this file
+  # authoritative: true makes the model discoverable by every Reactor account.
+  # public: false
+
+  # Scheduler resources for a deployed instance. Declare all three keys:
+  # `reactor model update` replaces the model's mutable fields with what is in
+  # this file, so a key left out is cleared server-side rather than kept.
+  #
+  # The `gpu:` key is what marks a model as needing an accelerator. Without it
+  # the model registers as CPU-only, and a CUDA model scheduled onto a CPU node
+  # fails at startup — so this block is not optional for this recipe.
   resources:
+    # `reactor gpu ls` lists every accelerator type the platform accepts.
+    # AlayaWorld runs on FlashAttention-4 (`attention_backend` in
+    # alayaworld.yaml), which needs a Hopper or Blackwell card — an older
+    # accelerator will not serve this model at all. Weights, text encoder,
+    # spatial memory, and VAE all stay resident across chunks, so it holds one
+    # whole GPU for the life of the session.
     gpu:
       type: NVIDIA_B200
       count: 1
+    # Host CPU, as Kubernetes quantities. Generation runs on the GPU; these
+    # cores carry the chunk loop, frame encoding, and WebRTC. The request
+    # guarantees the cores, and the higher limit leaves headroom above the
+    # runtime and encoder threads so the container is not CFS-throttled.
+    cpu:
+      request: "4"
+      limit: "8"
+    # Host memory. This recipe loads a large bundle — the AlayaWorld
+    # checkpoint, Gemma-3-12B as the text encoder, Depth-Anything-3, and the
+    # TAEHV decoder — and each one is staged through host RAM on the way to the
+    # device. The platform's 4Gi default request will not load it. Sized with
+    # margin for the load peak; narrow the limit once you have measured yours.
+    memory:
+      request: 8Gi
+      limit: 96Gi
 
 runtime:
   import: alayaworld:AlayaWorld
+
+  # Path to the model hyperparameters file, relative to this reactor.yaml. The
+  # runtime resolves it and hands the path to `load()`; this model reads the
+  # upstream revision, checkpoint set, attention backend, and motion scaling
+  # from it.
   config: alayaworld.yaml
+
+  # Root directory the runtime resolves via `get_weights_path()`. `reactor run`
+  # mounts it into the container so checkpoints survive between runs; a
+  # deployed instance reads the release's uploaded weights from the same path.
   weights_path: ~/.cache/reactor_registry/alayaworld
 
 build:
+  # The reactor-runtime release this workspace is built against. The install
+  # pin is the `reactor-runtime==<version>` line in requirements.txt; bump it
+  # there and here together to upgrade.
   runtime_version: "3.1.2"
 
+# Session recording. The runtime records the named video track in chunks and
+# serves clips up to `clip_max_seconds`. AlayaWorld emits no audio.
 recording:
   enabled: true
   chunk_seconds: 4

--- a/models/diamond-csgo-world-model/reactor.yaml
+++ b/models/diamond-csgo-world-model/reactor.yaml
@@ -1,19 +1,84 @@
-apiVersion: v1beta
-kind: VideoModel
+# Reactor model spec for the DIAMOND CSGO recipe.
+#
+# `$schema` pins the schema this file is written against — reactor/v1 is the
+# current one. Keep it as the first line.
+$schema: reactor/v1
 
+# The `model:` block is read by `reactor model register/publish/deploy` and
+# describes the model to the platform. The `runtime:` block is read by the
+# runtime and names the class to serve. To deploy this recipe under your own
+# account, edit `model.name` and the resources below, then:
+#
+#   reactor run --gpus all   # serve locally
+#   reactor model publish    # build the image and prepare a release
+#   reactor model deploy     # activate that release for traffic
 model:
+  # Model name used in CLI args and API responses. Change it to something
+  # unique to your account before publishing — a name already registered by
+  # someone else is rejected. Segments must be lowercase [a-z0-9] runs
+  # separated by '.', '_' or '-'.
   name: diamond-csgo-world-model
+
+  # The release tag `reactor model publish` / `reactor model deploy` use when
+  # no `<model>:<release>` is passed on the command line. Releases are
+  # immutable, so bump this after every successful publish.
   version: v0.0.1
+
   description: |
     Play DIAMOND's Counter-Strike world model with native keyboard and mouse input.
 
+  # A new model registers private. Leave this key out and `reactor model
+  # update` will not touch the setting. Write it to make this file
+  # authoritative: true makes the model discoverable by every Reactor account.
+  # public: false
+
+  # Scheduler resources for a deployed instance. Declare all three keys:
+  # `reactor model update` replaces the model's mutable fields with what is in
+  # this file, so a key left out is cleared server-side rather than kept.
+  #
+  # The `gpu:` key is what marks a model as needing an accelerator. DIAMOND
+  # will run on CPU, but far below its native 15 FPS — slow enough that the
+  # stream is no longer interactive. A deployed instance is expected to serve
+  # real-time play, so it asks for a GPU here. Drop the `gpu:` key to schedule
+  # this as a CPU-only model and accept the frame rate.
+  resources:
+    # `reactor gpu ls` lists every accelerator type the platform accepts.
+    # DIAMOND is a small diffusion model — the checkpoint is about 1.4 GB — so
+    # it does not need a large card. This asks for the same accelerator the
+    # sibling recipes use; a smaller type from `reactor gpu ls` also serves it,
+    # subject to what your account has available.
+    gpu:
+      type: NVIDIA_B200
+      count: 1
+    # Host CPU, as Kubernetes quantities. Denoising runs on the GPU; these
+    # cores carry the action loop, frame encoding, and WebRTC.
+    cpu:
+      request: "2"
+      limit: "6"
+    # Host memory. The checkpoint and spawn bundle come to about 1.4 GB, so
+    # this model is comfortable well under the platform's default ceiling.
+    # Sized as a starting point — confirm against your own traffic.
+    memory:
+      request: 4Gi
+      limit: 16Gi
+
 runtime:
   import: diamond:Diamond
+
+  # Path to the model hyperparameters file, relative to this reactor.yaml. The
+  # runtime resolves it and hands the path to `load()`; this model reads the
+  # upstream checkpoint revision, device, and denoising profile from it. Set
+  # `profile: higher_quality` there for cleaner frames at lower throughput.
   config: diamond.yaml
 
 build:
+  # The reactor-runtime release this workspace is built against. The install
+  # pin is the `reactor-runtime==<version>` line in requirements.txt; bump it
+  # there and here together to upgrade.
   runtime_version: "3.1.2"
 
+# Session recording. The runtime records the named video track in chunks and
+# serves clips up to `clip_max_seconds`. DIAMOND emits no audio.
 recording:
   enabled: true
   chunk_seconds: 4

--- a/models/matrix-game-3-5/reactor.yaml
+++ b/models/matrix-game-3-5/reactor.yaml
@@ -1,24 +1,91 @@
-apiVersion: v1beta
-kind: VideoModel
+# Reactor model spec for the Matrix-Game-3.5 recipe.
+#
+# `$schema` pins the schema this file is written against — reactor/v1 is the
+# current one. Keep it as the first line.
+$schema: reactor/v1
 
+# The `model:` block is read by `reactor model register/publish/deploy` and
+# describes the model to the platform. The `runtime:` block is read by the
+# runtime and names the class to serve. To deploy this recipe under your own
+# account, edit `model.name` and the resources below, then:
+#
+#   reactor run --gpus device=0   # serve locally
+#   reactor model publish         # build the image and prepare a release
+#   reactor model deploy          # activate that release for traffic
 model:
+  # Model name used in CLI args and API responses. Change it to something
+  # unique to your account before publishing — a name already registered by
+  # someone else is rejected. Segments must be lowercase [a-z0-9] runs
+  # separated by '.', '_' or '-'.
   name: matrix-game-3-5-distilled-first-person
+
+  # The release tag `reactor model publish` / `reactor model deploy` use when
+  # no `<model>:<release>` is passed on the command line. Releases are
+  # immutable, so bump this after every successful publish.
   version: v0.0.1
+
   description: |
     Explore an autoregressive world from an image, a prompt, and six-axis camera motion.
+
+  # A new model registers private. Leave this key out and `reactor model
+  # update` will not touch the setting. Write it to make this file
+  # authoritative: true makes the model discoverable by every Reactor account.
+  # public: false
+
+  # Scheduler resources for a deployed instance. Declare all three keys:
+  # `reactor model update` replaces the model's mutable fields with what is in
+  # this file, so a key left out is cleared server-side rather than kept.
+  #
+  # The `gpu:` key is what marks a model as needing an accelerator. Without it
+  # the model registers as CPU-only, and a CUDA model scheduled onto a CPU node
+  # fails at startup — so this block is not optional for this recipe.
   resources:
+    # `reactor gpu ls` lists every accelerator type the platform accepts.
+    # Matrix needs roughly 40 GB of VRAM at 704x1280, and the 5B model stays
+    # loaded in a persistent worker for the life of the session along with its
+    # rolling KV cache and Patch Memory. Pick a type with the headroom to hold
+    # all of it; a card under 40 GB will not serve this recipe.
     gpu:
       type: NVIDIA_B200
       count: 1
+    # Host CPU, as Kubernetes quantities. Generation runs on the GPU; these
+    # cores carry the worker process, the chunk loop, frame encoding, and
+    # WebRTC. The request guarantees the cores, and the higher limit leaves
+    # headroom so the container is not CFS-throttled.
+    cpu:
+      request: "4"
+      limit: "8"
+    # Host memory. Three checkpoints load here — the distilled Matrix model,
+    # the Wan2.2 TI2V-5B base, and Depth-Anything-3 — each staged through host
+    # RAM on the way to the device, and the worker runs as a second process.
+    # The platform's 4Gi default request will not load it. Sized with margin
+    # for the load peak; narrow the limit once you have measured yours.
+    memory:
+      request: 8Gi
+      limit: 64Gi
 
 runtime:
   import: matrix_game_3_5:MatrixGame35
+
+  # Path to the model hyperparameters file, relative to this reactor.yaml. The
+  # runtime resolves it and hands the path to `load()`; this model reads the
+  # upstream revision, checkpoint set, rollout bound, and motion scaling from
+  # it.
   config: matrix_game_3_5.yaml
+
+  # Root directory the runtime resolves via `get_weights_path()`. `reactor run`
+  # mounts it into the container so checkpoints survive between runs; a
+  # deployed instance reads the release's uploaded weights from the same path.
   weights_path: ~/.cache/reactor_registry/matrix-game-3-5
 
 build:
+  # The reactor-runtime release this workspace is built against. The install
+  # pin is the `reactor-runtime==<version>` line in requirements.txt; bump it
+  # there and here together to upgrade.
   runtime_version: "3.1.2"
 
+# Session recording. The runtime records the named video track in chunks and
+# serves clips up to `clip_max_seconds`. Matrix emits no audio.
 recording:
   enabled: true
   chunk_seconds: 4

--- a/models/open-dreamer/reactor.yaml
+++ b/models/open-dreamer/reactor.yaml
@@ -1,21 +1,83 @@
-apiVersion: v1beta
-kind: VideoModel
+# Reactor model spec for the OpenDreamer recipe.
+#
+# `$schema` pins the schema this file is written against — reactor/v1 is the
+# current one. Keep it as the first line.
+$schema: reactor/v1
 
+# The `model:` block is read by `reactor model register/publish/deploy` and
+# describes the model to the platform. The `runtime:` block is read by the
+# runtime and names the class to serve. To deploy this recipe under your own
+# account, edit `model.name` and the resources below, then:
+#
+#   reactor run --gpus device=0   # serve locally
+#   reactor model publish         # build the image and prepare a release
+#   reactor model deploy          # activate that release for traffic
 model:
+  # Model name used in CLI args and API responses. Change it to something
+  # unique to your account before publishing — a name already registered by
+  # someone else is rejected. Segments must be lowercase [a-z0-9] runs
+  # separated by '.', '_' or '-'.
   name: open-dreamer
+
+  # The release tag `reactor model publish` / `reactor model deploy` use when
+  # no `<model>:<release>` is passed on the command line. Releases are
+  # immutable, so bump this after every successful publish.
   version: v0.0.1
+
   description: |
     Stream an interactive Minecraft rollout initialized from a configured
     dataset demo or an uploaded screenshot and controlled with keyboard and
     mouse commands.
 
+  # A new model registers private. Leave this key out and `reactor model
+  # update` will not touch the setting. Write it to make this file
+  # authoritative: true makes the model discoverable by every Reactor account.
+  # public: false
+
+  # Scheduler resources for a deployed instance. Declare all three keys:
+  # `reactor model update` replaces the model's mutable fields with what is in
+  # this file, so a key left out is cleared server-side rather than kept.
+  #
+  # The `gpu:` key is what marks a model as needing an accelerator. Without it
+  # the model registers as CPU-only, and a CUDA model scheduled onto a CPU node
+  # fails at startup — so this block is not optional for this recipe.
+  resources:
+    # `reactor gpu ls` lists every accelerator type the platform accepts.
+    # OpenDreamer runs on JAX with the CUDA 12 wheels and reserves 90% of
+    # device memory at load (`memory_fraction` in opendreamer.yaml), so it
+    # wants one whole GPU to itself.
+    gpu:
+      type: NVIDIA_B200
+      count: 1
+    # Host CPU, as Kubernetes quantities. The rollout runs on the GPU; these
+    # cores carry the JAX dispatch loop, frame encoding, and WebRTC.
+    cpu:
+      request: "2"
+      limit: "6"
+    # Host memory. The checkpoint is about 8 GB and is staged through host RAM
+    # on the way to the device, so the platform's 4Gi default request is too
+    # small to load cleanly. Sized as a starting point — narrow the limit once
+    # you have seen the real peak for your traffic.
+    memory:
+      request: 8Gi
+      limit: 32Gi
+
 runtime:
   import: opendreamer:OpenDreamer
+
+  # Path to the model hyperparameters file, relative to this reactor.yaml. The
+  # runtime resolves it and hands the path to `load()`; this model reads the
+  # upstream revision, checkpoint, sampling schedule, and demo offsets from it.
   config: opendreamer.yaml
 
 build:
+  # The reactor-runtime release this workspace is built against. The install
+  # pin is the `reactor-runtime==<version>` line in requirements.txt; bump it
+  # there and here together to upgrade.
   runtime_version: "3.1.2"
 
+# Session recording. The runtime records the named video track in chunks and
+# serves clips up to `clip_max_seconds`. OpenDreamer emits no audio.
 recording:
   enabled: true
   chunk_seconds: 4


### PR DESCRIPTION
## Why

A recipe you can run locally is not yet a recipe you can deploy, and the gap
between the two was a single absent key. `model.resources.gpu` is the only
thing that marks a model as needing an accelerator: without it a model
registers as CPU-only, so the deployment requests no GPU resource, carries no
toleration for the accelerator taint, and gets no GPU node label. The pod is
then confined to exactly the nodes its CUDA image cannot start on. Two of these
four recipes — `open-dreamer` and `diamond-csgo-world-model` — are CUDA-only
and declared nothing at all.

The other two, `alayaworld` and `matrix-game-3-5`, named a GPU but stopped
there. That is its own trap, because `reactor model update` replaces a model's
mutable fields with what the file says rather than merging into what the server
already holds: a half-filled `resources` block reads as an instruction to clear
CPU and memory, which then fall back to platform defaults that are too small to
load these checkpoints.

This surfaced when a partner deployed two of these recipes from a fresh
checkout and found the manifests silent on hardware, with nothing in the file
to suggest anything was missing. The manifests were also thinner than the one
`reactor init` writes, so a reader arriving from the scaffolded workspace lost
the commentary that had been explaining every key up to that point.

## What Changed

All four manifests declare `gpu`, `cpu`, and `memory` together. The values come
from what each recipe already documents about itself rather than from a blanket
default: AlayaWorld's config selects FlashAttention-4, which needs Hopper or
newer, and it loads Gemma-3-12B beside its own checkpoint; Matrix states ~40 GB
of VRAM at 704x1280 and runs its 5B model in a second process; OpenDreamer
reserves 90% of device memory through JAX and stages an 8 GB checkpoint through
host RAM; DIAMOND is small at 1.4 GB but needs a GPU to hold its native 15 FPS.
Where a number is a starting point rather than a measured peak, the comment
says so and tells the reader to narrow it against their own traffic.

DIAMOND is the one judgement call. Its README notes the model will run on CPU,
just far below interactive speed, so the manifest asks for a GPU on the grounds
that a deployed instance is expected to serve real-time play — and the comment
states plainly that dropping the `gpu:` key is a legitimate choice if you will
accept the frame rate.

Around the resources, each file now carries the commentary the scaffolded
workspace has: what `model:` and `runtime:` are each read by, which keys must
change before publishing under a different account, and that `reactor gpu ls`
is where the accelerator vocabulary lives, so the list cannot drift out of date
here. The deprecated `apiVersion`/`kind` header gives way to `$schema:
reactor/v1`, the marker the CLI scaffolds today; the runtime reads the manifest
as a plain mapping and ignores keys it does not own, so serving behaviour is
unchanged.

## Verification

`reactor validate` passes on all four workspaces, with no deprecation warning.

To confirm the block reaches the wire rather than just parsing, each workspace
was registered against a local mock coordinator and the `POST /models` payload
captured. On `main`, both CUDA recipes send:

```json
{ "is_gpu": false, "gpu_type": null, "gpu_count": null,
  "cpu_request": null, "memory_limit": null }
```

On this branch all four send `is_gpu: true` with their declared type, count,
and CPU/memory quantities.

Made with [Cursor](https://cursor.com)