### PR TITLE
Improve World Model Arcade keyboard and mouse controls

### DIFF
--- a/examples/world-model-arcade/README.md
+++ b/examples/world-model-arcade/README.md
@@ -1,9 +1,10 @@
 # World Model Arcade
 
-A complete controller-first interface for switching between seven real-time
-world-model experiences without leaving a shared 3D arcade. The room, cabinet,
-game selector, controller visualization, and HUD run locally; launching a world
-starts a live [`reactor/lingbot-world-2`](https://docs.reactor.inc/model-api-reference/lingbot-world-2/overview)
+A complete keyboard-first, controller-compatible interface for switching
+between seven real-time world-model experiences without leaving a shared 3D
+arcade. The room, cabinet, game selector, input visualization, and HUD run
+locally; launching a world starts a live
+[`reactor/lingbot-world-2`](https://docs.reactor.inc/model-api-reference/lingbot-world-2/overview)
 session using that world's reference frame and prompt contract.
 
 ![World Model Arcade lobby](./docs/preview.png)
@@ -13,7 +14,7 @@ to make a generative experience feel like a product:
 
 - keep the Reactor API key on the server and mint a scoped, short-lived token;
 - condition one model with several visual anchors and world contracts;
-- translate gamepad and keyboard input into persistent movement state;
+- translate keyboard, mouse, and gamepad input into persistent movement state;
 - make held face-button actions survive model chunk boundaries;
 - drive conventional HUD telemetry immediately from the same controls; and
 - audit visual continuity and re-anchor a world when it drifts.
@@ -44,7 +45,8 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000). Walk up to the cabinet,
 press <kbd>A</kbd> or <kbd>Enter</kbd>, choose a world, and launch it. Live
-world generation uses your Reactor account and may incur usage charges.
+world generation uses your Reactor account and may incur usage charges. Click
+the scene to capture mouse look; press <kbd>Escape</kbd> to release it.
 
 ## Give this to a coding agent
 
@@ -64,15 +66,17 @@ receives a scoped session token, never the API key.
 | Input | Arcade | In a world |
 | --- | --- | --- |
 | Left stick / WASD | Walk, move selection | Move or steer |
-| Right stick / arrow keys | Look around | Look; also drives reactive HUD instruments |
+| Right stick / mouse | Look around | Look; also drives reactive HUD instruments |
+| Click scene / Escape | Capture or release mouse look | Capture or release mouse look |
 | A / Enter or 1 | Use cabinet, launch selection | Primary world action |
 | B, X, Y / 2, 3, 4 | Back; X previews a world locally | World-specific quick actions |
 | LB, RB / Q, E | Previous / next world | LB toggles diagnostics |
 | Menu / P | — | Return to the world's first frame |
-| View / Tab or Escape | Step back | Leave the current world |
+| View / Tab | Step back | Leave the current world |
 
-The controller diagram is interactive. Keyboard input updates it too, so the
-demo remains legible while screen recording without a connected gamepad.
+The input overlay defaults to a live keyboard map and switches to the Xbox view
+when a controller is used. A small prompt makes the optional controller path
+discoverable without obscuring the demo.
 
 ## Where to change things
 

--- a/examples/world-model-arcade/app/globals.css
+++ b/examples/world-model-arcade/app/globals.css
@@ -66,6 +66,10 @@ button:focus-visible {
   background: var(--interstellar);
 }
 
+.arcade-app[data-pointer-locked="true"] {
+  cursor: none;
+}
+
 .system-label,
 .world-telemetry,
 .flight-heading,
@@ -421,6 +425,33 @@ button:focus-visible {
 .xbox-y {
   border-color: #c6b56d;
   color: #eadb99;
+}
+
+.keyboard-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  border-radius: 3px;
+  background: #191a18;
+  color: var(--dune-light);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.12),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.42);
+  font-family: var(--font-mono);
+  font-size: 8px;
+  font-style: normal;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  line-height: 1;
+}
+
+.keyboard-glyph.is-wide {
+  min-width: 40px;
 }
 
 .cabinet-screen-controls {
@@ -859,6 +890,204 @@ button:focus-visible {
   position: relative;
   width: 180px;
   height: 151px;
+}
+
+.input-overlay-keyboard {
+  width: min(390px, calc(100vw - 32px));
+  filter: drop-shadow(0 18px 24px rgba(3, 5, 7, 0.34));
+  opacity: 0.94;
+}
+
+.input-overlay-keyboard .input-overlay-viewport {
+  width: 100%;
+  height: auto;
+}
+
+.controller-connect-prompt {
+  position: absolute;
+  bottom: calc(100% + 11px);
+  left: 50%;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  width: 284px;
+  padding: 9px 10px 9px 12px;
+  border: 1px solid rgba(199, 192, 153, 0.28);
+  border-radius: 3px;
+  background: rgba(8, 10, 10, 0.9);
+  box-shadow: 0 14px 42px rgba(3, 5, 7, 0.26);
+  color: rgba(241, 242, 237, 0.62);
+  font-family: var(--font-mono);
+  font-size: 7px;
+  letter-spacing: 0.04em;
+  line-height: 1.45;
+  pointer-events: auto;
+  transform: translateX(-50%);
+  backdrop-filter: blur(12px);
+}
+
+.controller-connect-prompt span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.controller-connect-prompt b {
+  color: var(--dune-light);
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  font-weight: 720;
+  letter-spacing: 0.08em;
+}
+
+.controller-connect-prompt button {
+  flex: 0 0 auto;
+  padding: 5px 6px;
+  border: 1px solid rgba(241, 242, 237, 0.18);
+  border-radius: 3px;
+  background: rgba(241, 242, 237, 0.04);
+  color: rgba(241, 242, 237, 0.58);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 6px;
+  letter-spacing: 0.08em;
+}
+
+.controller-connect-prompt button:hover {
+  border-color: rgba(199, 192, 153, 0.5);
+  color: var(--dune-light);
+}
+
+.controller-connect-prompt button:active {
+  transform: translateY(1px);
+}
+
+.keyboard-map {
+  display: grid;
+  grid-template-columns: 72px 72px minmax(0, 1fr);
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  min-height: 82px;
+  padding: 10px 12px;
+  border: 1px solid rgba(241, 242, 237, 0.16);
+  border-radius: 3px;
+  background: rgba(7, 10, 11, 0.84);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.055),
+    0 18px 42px rgba(0, 0, 0, 0.22);
+  backdrop-filter: blur(12px);
+}
+
+.keyboard-cluster {
+  display: grid;
+  justify-items: center;
+  gap: 5px;
+}
+
+.keyboard-cluster > span {
+  color: rgba(241, 242, 237, 0.48);
+  font-family: var(--font-mono);
+  font-size: 6px;
+  letter-spacing: 0.11em;
+}
+
+.keyboard-key-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 20px);
+  grid-template-rows: repeat(2, 20px);
+  gap: 3px;
+}
+
+.keyboard-key-grid kbd,
+.mouse-look-key,
+.keyboard-action kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 4px;
+  border: 1px solid rgba(241, 242, 237, 0.27);
+  border-radius: 3px;
+  background: #171918;
+  color: rgba(241, 242, 237, 0.76);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    inset 0 -2px 0 rgba(0, 0, 0, 0.45);
+  font-family: var(--font-mono);
+  font-size: 7px;
+  font-weight: 600;
+  line-height: 1;
+  transition:
+    transform 80ms ease,
+    border-color 80ms ease,
+    background-color 80ms ease,
+    color 80ms ease;
+}
+
+.keyboard-key-grid kbd[data-pressed="true"],
+.mouse-look-key[data-pressed="true"],
+.keyboard-action kbd[data-pressed="true"] {
+  border-color: rgba(253, 245, 198, 0.78);
+  background: rgba(199, 192, 153, 0.22);
+  color: var(--dune-light);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.14);
+  transform: translateY(1px);
+}
+
+.mouse-look-key {
+  min-width: 55px;
+  height: 43px;
+  letter-spacing: 0.08em;
+}
+
+.keyboard-key-grid-wasd kbd:first-child {
+  grid-column: 2;
+}
+
+.keyboard-key-grid-wasd kbd:nth-child(2) {
+  grid-column: 1;
+  grid-row: 2;
+}
+
+.keyboard-key-grid-wasd kbd:nth-child(3) {
+  grid-column: 2;
+  grid-row: 2;
+}
+
+.keyboard-key-grid-wasd kbd:nth-child(4) {
+  grid-column: 3;
+  grid-row: 2;
+}
+
+.keyboard-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: center;
+  gap: 6px 9px;
+  min-width: 0;
+  padding-left: 11px;
+  border-left: 1px solid rgba(241, 242, 237, 0.12);
+}
+
+.keyboard-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+
+.keyboard-action kbd.is-wide {
+  min-width: 38px;
+}
+
+.keyboard-action small {
+  color: rgba(241, 242, 237, 0.48);
+  font-family: var(--font-mono);
+  font-size: 6px;
+  letter-spacing: 0.07em;
+  white-space: nowrap;
 }
 
 .gpv-gamepad {
@@ -2492,8 +2721,7 @@ button:focus-visible {
   }
 
   .room-controls {
-    bottom: 18px;
-    left: 18px;
+    display: none;
   }
 
   .keyboard-hint {
@@ -2516,6 +2744,39 @@ button:focus-visible {
   .input-overlay-viewport {
     width: 150px;
     height: 126px;
+  }
+
+  .input-overlay-keyboard {
+    width: min(320px, calc(100vw - 24px));
+  }
+
+  .input-overlay-keyboard .input-overlay-viewport {
+    width: 100%;
+    height: auto;
+  }
+
+  .input-overlay-keyboard .keyboard-map {
+    grid-template-columns: 58px 58px minmax(0, 1fr);
+    gap: 8px;
+    min-height: 72px;
+    padding: 8px;
+  }
+
+  .input-overlay-keyboard .keyboard-actions {
+    gap: 5px 7px;
+    padding-left: 8px;
+  }
+
+  .input-overlay-keyboard .keyboard-action {
+    gap: 3px;
+  }
+
+  .input-overlay-keyboard .keyboard-action small {
+    font-size: 5px;
+  }
+
+  .controller-connect-prompt {
+    width: min(274px, calc(100vw - 36px));
   }
 
   .gpv-gamepad {
@@ -2715,7 +2976,8 @@ button:focus-visible {
     font-size: 6.5px;
   }
 
-  .quick-action .xbox-glyph {
+  .quick-action .xbox-glyph,
+  .quick-action .keyboard-glyph {
     min-width: 19px;
     height: 19px;
     font-size: 8px;

--- a/examples/world-model-arcade/components/ArcadeExperience.tsx
+++ b/examples/world-model-arcade/components/ArcadeExperience.tsx
@@ -6,10 +6,20 @@ import {
   useLingbotWorld2,
   useLingbotWorld2Message,
 } from "@reactor-models/lingbot-world-2";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from "react";
 import { ArcadeScene } from "@/components/ArcadeScene";
 import { GamepadViewerOverlay } from "@/components/GamepadViewerOverlay";
-import { useControllerInput } from "@/hooks/useControllerInput";
+import {
+  useControllerInput,
+  type InputMethod,
+} from "@/hooks/useControllerInput";
 import {
   captureWorldFrame,
   compareFrameSignatures,
@@ -86,10 +96,20 @@ function XboxGlyph({ button }: { button: FaceButton | "lb" | "rb" | "view" | "me
   return <span className={`xbox-glyph xbox-${button}`}>{button.toUpperCase()}</span>;
 }
 
+function KeyboardGlyph({ label }: { label: string }) {
+  return (
+    <span className={`keyboard-glyph ${label.length > 2 ? "is-wide" : ""}`}>
+      {label}
+    </span>
+  );
+}
+
 function RoomOverlay({
+  inputMethod,
   near,
   onInteract,
 }: {
+  inputMethod: InputMethod;
   near: boolean;
   onInteract: () => void;
 }) {
@@ -98,7 +118,7 @@ function RoomOverlay({
       <section className="room-intro">
         <p className="system-label">WORLD MODEL ARCADE</p>
         <h1>Pick a world.</h1>
-        <p>Walk up to the cabinet. Your controller carries across every game.</p>
+        <p>Walk up to the cabinet. Your controls carry across every game.</p>
       </section>
       <div className={`focus-reticle ${near ? "is-near" : ""}`} aria-hidden="true">
         <span />
@@ -112,9 +132,17 @@ function RoomOverlay({
         Use arcade cabinet
       </button>
       <div className="room-controls">
-        <span><XboxGlyph button="ls" /> MOVE</span>
-        <span><XboxGlyph button="rs" /> LOOK</span>
-        <span className="keyboard-hint">WASD + ARROWS</span>
+        {inputMethod === "keyboard" ? (
+          <>
+            <span><KeyboardGlyph label="WASD" /> MOVE</span>
+            <span><KeyboardGlyph label="MOUSE" /> LOOK</span>
+          </>
+        ) : (
+          <>
+            <span><XboxGlyph button="ls" /> MOVE</span>
+            <span><XboxGlyph button="rs" /> LOOK</span>
+          </>
+        )}
       </div>
     </div>
   );
@@ -168,12 +196,14 @@ function CabinetOverlay({
 
 function BootOverlay({
   game,
+  inputMethod,
   state,
   onCancel,
   onRetry,
   onPreview,
 }: {
   game: ArcadeGame;
+  inputMethod: InputMethod;
   state: BootState;
   onCancel: () => void;
   onRetry: () => void;
@@ -196,8 +226,14 @@ function BootOverlay({
               <h2>THE WORLD DIDN&apos;T OPEN</h2>
               <p>Give it another try, or preview the controls while you wait.</p>
               <div className="boot-actions">
-                <button onClick={onRetry}><XboxGlyph button="a" /> RETRY</button>
-                <button onClick={onPreview}><XboxGlyph button="x" /> LOCAL PREVIEW</button>
+                <button onClick={onRetry}>
+                  {inputMethod === "keyboard" ? <KeyboardGlyph label="ENTER" /> : <XboxGlyph button="a" />}
+                  RETRY
+                </button>
+                <button onClick={onPreview}>
+                  {inputMethod === "keyboard" ? <KeyboardGlyph label="3" /> : <XboxGlyph button="x" />}
+                  LOCAL PREVIEW
+                </button>
               </div>
             </>
           ) : (
@@ -209,7 +245,10 @@ function BootOverlay({
           )}
         </div>
       </section>
-      <button className="cancel-boot" onClick={onCancel}><XboxGlyph button="view" /> CANCEL</button>
+      <button className="cancel-boot" onClick={onCancel}>
+        {inputMethod === "keyboard" ? <KeyboardGlyph label="ESC" /> : <XboxGlyph button="view" />}
+        CANCEL
+      </button>
     </div>
   );
 }
@@ -217,11 +256,13 @@ function BootOverlay({
 function QuickActions({
   game,
   active,
+  inputMethod,
   onDown,
   onUp,
 }: {
   game: ArcadeGame;
   active: FaceButton[];
+  inputMethod: InputMethod;
   onDown: (button: FaceButton) => void;
   onUp: (button: FaceButton) => void;
 }) {
@@ -235,7 +276,11 @@ function QuickActions({
           onPointerUp={() => onUp(button)}
           onPointerLeave={() => onUp(button)}
         >
-          <XboxGlyph button={button} />
+          {inputMethod === "keyboard" ? (
+            <KeyboardGlyph label={String(({ a: 1, b: 2, x: 3, y: 4 } as const)[button])} />
+          ) : (
+            <XboxGlyph button={button} />
+          )}
           <span>{game.actions[button].label}</span>
         </button>
       ))}
@@ -328,6 +373,7 @@ function GameHud({
   paused,
   localPreview,
   activeButtons,
+  inputMethod,
   axesRef,
   buttonsRef,
   resetToken,
@@ -349,6 +395,7 @@ function GameHud({
   paused: boolean;
   localPreview: boolean;
   activeButtons: FaceButton[];
+  inputMethod: InputMethod;
   axesRef: ReturnType<typeof useControllerInput>["axesRef"];
   buttonsRef: ReturnType<typeof useControllerInput>["buttonsRef"];
   resetToken: number;
@@ -684,19 +731,35 @@ function GameHud({
       </div>
       <GameSpecificHud game={game} />
       <div className="stick-help">
-        <span><XboxGlyph button="ls" /> MOVE</span>
-        <span><XboxGlyph button="rs" /> LOOK</span>
+        <span>
+          {inputMethod === "keyboard" ? <KeyboardGlyph label="WASD" /> : <XboxGlyph button="ls" />}
+          MOVE
+        </span>
+        <span>
+          {inputMethod === "keyboard" ? <KeyboardGlyph label="MOUSE" /> : <XboxGlyph button="rs" />}
+          LOOK
+        </span>
       </div>
       <QuickActions
         game={game}
         active={activeButtons}
+        inputMethod={inputMethod}
         onDown={onActionDown}
         onUp={onActionUp}
       />
       <div className="game-system-controls">
-        <button onClick={onToggleDebug}><XboxGlyph button="lb" /> DEBUG</button>
-        <button onClick={onReset}><XboxGlyph button="menu" /> RESTART</button>
-        <button onClick={onExit}><XboxGlyph button="view" /> ARCADE</button>
+        <button onClick={onToggleDebug}>
+          {inputMethod === "keyboard" ? <KeyboardGlyph label="Q" /> : <XboxGlyph button="lb" />}
+          DEBUG
+        </button>
+        <button onClick={onReset}>
+          {inputMethod === "keyboard" ? <KeyboardGlyph label="P" /> : <XboxGlyph button="menu" />}
+          RESTART
+        </button>
+        <button onClick={onExit}>
+          {inputMethod === "keyboard" ? <KeyboardGlyph label="TAB" /> : <XboxGlyph button="view" />}
+          ARCADE
+        </button>
       </div>
       {debugVisible && (
         <aside className="consistency-debug">
@@ -718,6 +781,7 @@ function GameHud({
 }
 
 function ReactorArcade({ configured }: { configured: boolean }) {
+  const appRef = useRef<HTMLElement>(null);
   const lw2 = useLingbotWorld2();
   const { status, sendCommand, uploadFile } = lw2;
   const [phase, setPhase] = useState<Phase>("room");
@@ -737,6 +801,7 @@ function ReactorArcade({ configured }: { configured: boolean }) {
   const [debugVisible, setDebugVisible] = useState(false);
   const [paused, setPaused] = useState(false);
   const [localPreview, setLocalPreview] = useState(false);
+  const [softMouseLook, setSoftMouseLook] = useState(false);
 
   const phaseRef = useRef<Phase>(phase);
   const statusRef = useRef(status);
@@ -1280,6 +1345,70 @@ function ReactorArcade({ configured }: { configured: boolean }) {
 
   const controller = useControllerInput({ onButtonDown, onButtonUp });
 
+  const captureMouseLook = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (
+        event.button !== 0 ||
+        (phaseRef.current !== "room" && phaseRef.current !== "game") ||
+        document.pointerLockElement
+      ) {
+        return;
+      }
+      const target = event.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest("button, a, input, textarea, select, [role='button']")
+      ) {
+        return;
+      }
+      if (typeof event.currentTarget.requestPointerLock !== "function") {
+        setSoftMouseLook(true);
+        return;
+      }
+      try {
+        const request = event.currentTarget.requestPointerLock();
+        request?.catch(() => setSoftMouseLook(true));
+      } catch {
+        setSoftMouseLook(true);
+      }
+    },
+    [],
+  );
+
+  const updateSoftMouseLook = useCallback(
+    (event: ReactPointerEvent<HTMLElement>) => {
+      if (
+        !softMouseLook ||
+        (phaseRef.current !== "room" && phaseRef.current !== "game")
+      ) {
+        return;
+      }
+      controller.applyMouseLook(event.movementX, event.movementY);
+    },
+    [controller.applyMouseLook, softMouseLook],
+  );
+
+  useEffect(() => {
+    if (phase !== "room" && phase !== "game") {
+      setSoftMouseLook(false);
+      if (document.pointerLockElement === appRef.current) {
+        document.exitPointerLock();
+      }
+    }
+  }, [phase]);
+
+  useEffect(() => {
+    if (!softMouseLook) return;
+    const releaseSoftMouseLook = (event: KeyboardEvent) => {
+      if (event.code !== "Escape") return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      setSoftMouseLook(false);
+    };
+    window.addEventListener("keydown", releaseSoftMouseLook, true);
+    return () => window.removeEventListener("keydown", releaseSoftMouseLook, true);
+  }, [softMouseLook]);
+
   useEffect(() => {
     let navigationLatch = 0;
     const timer = window.setInterval(() => {
@@ -1391,21 +1520,34 @@ function ReactorArcade({ configured }: { configured: boolean }) {
 
   const selectedGame = GAMES[selectedIndex];
   const activeGame = currentGameRef.current;
+  const inputMethod = controller.lastDevice;
   const scenePhase: "room" | "cabinet" | "booting" =
     phase === "room" ? "room" : phase === "booting" ? "booting" : "cabinet";
 
   return (
-    <main className="arcade-app">
+    <main
+      ref={appRef}
+      className="arcade-app"
+      data-pointer-locked={controller.pointerLocked ? "true" : "false"}
+      data-mouse-look-active={
+        controller.pointerLocked || softMouseLook ? "true" : "false"
+      }
+      onPointerDown={captureMouseLook}
+      onPointerMove={updateSoftMouseLook}
+      onPointerLeave={() => setSoftMouseLook(false)}
+    >
       {phase !== "game" ? (
         <div className="scene-shell">
           <ArcadeScene
             phase={scenePhase}
             game={selectedGame}
+            inputMethod={inputMethod}
             axesRef={controller.axesRef}
             onNearChange={setNearCabinet}
           />
           {phase === "room" && (
             <RoomOverlay
+              inputMethod={inputMethod}
               near={nearCabinet}
               onInteract={() => {
                 if (nearCabinet) setPhase("cabinet");
@@ -1424,6 +1566,7 @@ function ReactorArcade({ configured }: { configured: boolean }) {
           {phase === "booting" && (
             <BootOverlay
               game={selectedGame}
+              inputMethod={inputMethod}
               state={bootState}
               onCancel={cancelBoot}
               onRetry={launchGame}
@@ -1455,6 +1598,7 @@ function ReactorArcade({ configured }: { configured: boolean }) {
             paused={paused}
             localPreview={localPreview}
             activeButtons={activeButtons}
+            inputMethod={inputMethod}
             axesRef={controller.axesRef}
             buttonsRef={controller.buttonsRef}
             resetToken={hudResetToken}
@@ -1470,7 +1614,10 @@ function ReactorArcade({ configured }: { configured: boolean }) {
         axesRef={controller.axesRef}
         buttonsRef={controller.buttonsRef}
         connected={controller.connected}
+        inputMethod={inputMethod}
+        keysRef={controller.keysRef}
         mode={phase}
+        mouseLookActive={controller.pointerLocked || softMouseLook}
       />
     </main>
   );

--- a/examples/world-model-arcade/components/ArcadeScene.tsx
+++ b/examples/world-model-arcade/components/ArcadeScene.tsx
@@ -10,7 +10,10 @@ import {
 import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { MutableRefObject, useEffect, useMemo, useRef, useState } from "react";
 import * as THREE from "three";
-import type { ControllerAxes } from "@/hooks/useControllerInput";
+import type {
+  ControllerAxes,
+  InputMethod,
+} from "@/hooks/useControllerInput";
 import { GAMES, type ArcadeGame } from "@/lib/games";
 
 type ScenePhase = "room" | "cabinet" | "booting";
@@ -18,6 +21,7 @@ type ScenePhase = "room" | "cabinet" | "booting";
 type ArcadeSceneProps = {
   phase: ScenePhase;
   game: ArcadeGame;
+  inputMethod: InputMethod;
   axesRef: MutableRefObject<ControllerAxes>;
   onNearChange: (near: boolean) => void;
 };
@@ -504,6 +508,7 @@ function drawCover(
 function drawButtonPrompt(
   context: CanvasRenderingContext2D,
   button: "A" | "X",
+  inputMethod: InputMethod,
   label: string,
   x: number,
   y: number,
@@ -518,24 +523,37 @@ function drawButtonPrompt(
   context.fill();
   context.stroke();
 
+  const control =
+    inputMethod === "keyboard" ? (button === "A" ? "ENTER" : "3") : button;
+  const controlWidth = inputMethod === "keyboard" ? (button === "A" ? 58 : 34) : 34;
+  const controlX = x + 14;
+
   context.fillStyle = emphasized ? "#11171a" : "#071014";
-  context.strokeStyle = emphasized ? "rgba(17, 23, 26, 0.62)" : button === "A" ? "#7fa276" : "#7196ac";
+  context.strokeStyle = emphasized
+    ? "rgba(17, 23, 26, 0.62)"
+    : button === "A"
+      ? "#7fa276"
+      : "#7196ac";
   context.beginPath();
-  context.arc(x + 31, y + 31, 17, 0, Math.PI * 2);
+  if (inputMethod === "keyboard") {
+    context.roundRect(controlX, y + 14, controlWidth, 34, 3);
+  } else {
+    context.arc(x + 31, y + 31, 17, 0, Math.PI * 2);
+  }
   context.fill();
   context.stroke();
 
   context.fillStyle = emphasized ? "#f4e8ca" : button === "A" ? "#bad8b1" : "#acd0e3";
-  context.font = "700 18px Arial, sans-serif";
+  context.font = `700 ${inputMethod === "keyboard" ? 12 : 18}px Arial, sans-serif`;
   context.textAlign = "center";
-  context.fillText(button, x + 31, y + 38);
+  context.fillText(control, controlX + controlWidth / 2, y + 37);
   context.textAlign = "left";
   context.fillStyle = emphasized ? "#11171a" : "#f1f2ed";
-  context.font = "700 17px Arial, sans-serif";
-  context.fillText(label, x + 59, y + 38);
+  context.font = `700 ${inputMethod === "keyboard" ? 15 : 17}px Arial, sans-serif`;
+  context.fillText(label, controlX + controlWidth + 12, y + 38);
 }
 
-function useCabinetMenuTexture(game: ArcadeGame) {
+function useCabinetMenuTexture(game: ArcadeGame, inputMethod: InputMethod) {
   const [texture, setTexture] = useState<THREE.CanvasTexture | null>(null);
 
   useEffect(() => {
@@ -599,8 +617,8 @@ function useCabinetMenuTexture(game: ArcadeGame) {
       context.letterSpacing = "0px";
       context.fillText(game.deck, 42, 440, 560);
 
-      drawButtonPrompt(context, "A", "ENTER WORLD", 42, 486, 214, true);
-      drawButtonPrompt(context, "X", "PREVIEW HUD", 270, 486, 214);
+      drawButtonPrompt(context, "A", inputMethod, "ENTER WORLD", 42, 486, 214, true);
+      drawButtonPrompt(context, "X", inputMethod, "PREVIEW HUD", 270, 486, 214);
 
       context.fillStyle = "#879198";
       context.font = "700 13px Arial, sans-serif";
@@ -687,7 +705,7 @@ function useCabinetMenuTexture(game: ArcadeGame) {
       cancelled = true;
       nextTexture.dispose();
     };
-  }, [game]);
+  }, [game, inputMethod]);
 
   return texture;
 }
@@ -703,15 +721,17 @@ function CabinetScrew({ position }: { position: [number, number, number] }) {
 
 function Cabinet({
   game,
+  inputMethod,
   phase,
   surfaceMaps,
 }: {
   game: ArcadeGame;
+  inputMethod: InputMethod;
   phase: ScenePhase;
   surfaceMaps?: SurfaceMaps;
 }) {
   const attractTexture = useAttractTexture();
-  const menuTexture = useCabinetMenuTexture(game);
+  const menuTexture = useCabinetMenuTexture(game, inputMethod);
   const wordmarkTexture = useTexture("/brand/reactor-lockup-white.png");
   const displayTexture = phase === "room" ? attractTexture : menuTexture;
   wordmarkTexture.colorSpace = THREE.SRGBColorSpace;
@@ -1047,6 +1067,7 @@ function Cabinet({
 function SceneRig({
   phase,
   game,
+  inputMethod,
   axesRef,
   onNearChange,
 }: ArcadeSceneProps) {
@@ -1180,6 +1201,7 @@ function SceneRig({
       />
       <Cabinet
         game={game}
+        inputMethod={inputMethod}
         phase={phase}
         surfaceMaps={architecturalMaps?.cabinet}
       />

--- a/examples/world-model-arcade/components/GamepadViewerOverlay.tsx
+++ b/examples/world-model-arcade/components/GamepadViewerOverlay.tsx
@@ -1,29 +1,59 @@
 "use client";
 
-import { MutableRefObject, useEffect, useRef } from "react";
-import type { ControllerAxes } from "@/hooks/useControllerInput";
+import { MutableRefObject, useEffect, useRef, useState } from "react";
+import type {
+  ControllerAxes,
+  InputMethod,
+} from "@/hooks/useControllerInput";
 
 type GamepadViewerOverlayProps = {
   axesRef: MutableRefObject<ControllerAxes>;
   buttonsRef: MutableRefObject<boolean[]>;
   connected: boolean;
+  inputMethod: InputMethod;
+  keysRef: MutableRefObject<Set<string>>;
   mode: "room" | "cabinet" | "booting" | "game";
+  mouseLookActive: boolean;
 };
 
 const FACE_BUTTONS = [0, 1, 2, 3] as const;
 const DPAD_BUTTONS = [12, 13, 14, 15] as const;
 
+const MODE_ACTIONS = {
+  room: [{ code: "Enter", key: "ENTER", label: "USE" }],
+  cabinet: [
+    { code: "Enter", key: "ENTER", label: "OPEN" },
+    { code: "Digit3", key: "3", label: "PREVIEW" },
+    { code: "Tab", key: "TAB", label: "BACK" },
+  ],
+  booting: [{ code: "Escape", key: "ESC", label: "CANCEL" }],
+  game: [
+    { code: "Digit1", key: "1", label: "ACTION" },
+    { code: "Digit2", key: "2", label: "ACTION" },
+    { code: "Digit3", key: "3", label: "ACTION" },
+    { code: "Digit4", key: "4", label: "ACTION" },
+    { code: "Tab", key: "TAB", label: "ARCADE" },
+    { code: "KeyP", key: "P", label: "RESET" },
+  ],
+} as const;
+
 export function GamepadViewerOverlay({
   axesRef,
   buttonsRef,
   connected,
+  inputMethod,
+  keysRef,
   mode,
+  mouseLookActive,
 }: GamepadViewerOverlayProps) {
   const buttonRefs = useRef<Array<HTMLSpanElement | null>>([]);
+  const keyboardKeyRefs = useRef(new Map<string, HTMLElement>());
   const leftStickRef = useRef<HTMLSpanElement>(null);
   const rightStickRef = useRef<HTMLSpanElement>(null);
   const leftTriggerRef = useRef<HTMLSpanElement>(null);
   const rightTriggerRef = useRef<HTMLSpanElement>(null);
+  const [controllerPromptDismissed, setControllerPromptDismissed] =
+    useState(false);
 
   useEffect(() => {
     let frame = 0;
@@ -52,72 +82,150 @@ export function GamepadViewerOverlay({
           ? "inset(0 0 0 0)"
           : "inset(100% 0 0 0)";
       }
+      keyboardKeyRefs.current.forEach((element, code) => {
+        element.setAttribute(
+          "data-pressed",
+          keysRef.current.has(code) ? "true" : "false",
+        );
+      });
       frame = requestAnimationFrame(renderInput);
     };
 
     frame = requestAnimationFrame(renderInput);
     return () => cancelAnimationFrame(frame);
-  }, [axesRef, buttonsRef]);
+  }, [axesRef, buttonsRef, keysRef]);
 
   const bindButton = (index: number) => (element: HTMLSpanElement | null) => {
     buttonRefs.current[index] = element;
   };
 
+  const bindKeyboardKey = (code: string) => (element: HTMLElement | null) => {
+    if (element) keyboardKeyRefs.current.set(code, element);
+    else keyboardKeyRefs.current.delete(code);
+  };
+
+  const actionKeys = MODE_ACTIONS[mode];
+  const showControllerPrompt =
+    mode === "room" && !connected && !controllerPromptDismissed;
+  const mouseLookAvailable = mode === "room" || mode === "game";
+
   return (
-    <aside className={`input-overlay input-overlay-${mode}`} aria-label="Live controller input">
+    <aside
+      className={`input-overlay input-overlay-${mode} input-overlay-${inputMethod}`}
+      aria-label={
+        inputMethod === "keyboard" ? "Live keyboard controls" : "Live controller input"
+      }
+    >
+      {showControllerPrompt && (
+        <div className="controller-connect-prompt">
+          <span>
+            <b>CONTROLLER OPTIONAL</b>
+            Connect one anytime for analog controls.
+          </span>
+          <button
+            type="button"
+            onClick={() => setControllerPromptDismissed(true)}
+            aria-label="Dismiss controller prompt"
+          >
+            HIDE
+          </button>
+        </div>
+      )}
       <div className="input-overlay-caption">
         <span>INPUT VIEW</span>
-        <span>{connected ? "XBOX PAD 01" : "KEYBOARD MAP"}</span>
+        <span>{inputMethod === "gamepad" ? "XBOX PAD 01" : "KEYBOARD MAP"}</span>
       </div>
       <div className="input-overlay-viewport">
-        <div className="gpv-gamepad" aria-hidden="true">
-          <div className="gpv-triggers">
-            <span ref={leftTriggerRef} className="gpv-trigger gpv-left" />
-            <span ref={rightTriggerRef} className="gpv-trigger gpv-right" />
+        {inputMethod === "keyboard" ? (
+          <div className="keyboard-map" aria-hidden="true">
+            <div className="keyboard-cluster">
+              <div className="keyboard-key-grid keyboard-key-grid-wasd">
+                <kbd ref={bindKeyboardKey("KeyW")}>W</kbd>
+                <kbd ref={bindKeyboardKey("KeyA")}>A</kbd>
+                <kbd ref={bindKeyboardKey("KeyS")}>S</kbd>
+                <kbd ref={bindKeyboardKey("KeyD")}>D</kbd>
+              </div>
+              <span>{mode === "cabinet" ? "SELECT" : "MOVE"}</span>
+            </div>
+            <div className="keyboard-cluster">
+              <kbd
+                className="mouse-look-key"
+                data-pressed={mouseLookAvailable && mouseLookActive ? "true" : "false"}
+              >
+                MOUSE
+              </kbd>
+              <span>
+                {mouseLookAvailable
+                  ? mouseLookActive
+                    ? "LOOK ACTIVE"
+                    : "CLICK TO LOOK"
+                  : "SCREEN FIXED"}
+              </span>
+            </div>
+            <div className="keyboard-actions">
+              {actionKeys.map((action) => (
+                <span className="keyboard-action" key={`${action.code}-${action.label}`}>
+                  <kbd
+                    ref={bindKeyboardKey(action.code)}
+                    className={action.key.length > 1 ? "is-wide" : undefined}
+                  >
+                    {action.key}
+                  </kbd>
+                  <small>{action.label}</small>
+                </span>
+              ))}
+            </div>
           </div>
-          <div className="gpv-bumpers">
-            <span ref={bindButton(4)} className="gpv-bumper gpv-left" />
-            <span ref={bindButton(5)} className="gpv-bumper gpv-right" />
-          </div>
-          <div className="gpv-arrows">
-            <span ref={bindButton(8)} className="gpv-select" />
-            <span ref={bindButton(9)} className="gpv-start" />
-          </div>
-          <div className="gpv-buttons">
-            {FACE_BUTTONS.map((index) => (
+        ) : (
+          <div className="gpv-gamepad" aria-hidden="true">
+            <div className="gpv-triggers">
+              <span ref={leftTriggerRef} className="gpv-trigger gpv-left" />
+              <span ref={rightTriggerRef} className="gpv-trigger gpv-right" />
+            </div>
+            <div className="gpv-bumpers">
+              <span ref={bindButton(4)} className="gpv-bumper gpv-left" />
+              <span ref={bindButton(5)} className="gpv-bumper gpv-right" />
+            </div>
+            <div className="gpv-arrows">
+              <span ref={bindButton(8)} className="gpv-select" />
+              <span ref={bindButton(9)} className="gpv-start" />
+            </div>
+            <div className="gpv-buttons">
+              {FACE_BUTTONS.map((index) => (
+                <span
+                  key={index}
+                  ref={bindButton(index)}
+                  className={`gpv-button gpv-button-${["a", "b", "x", "y"][index]}`}
+                />
+              ))}
+            </div>
+            <div className="gpv-sticks">
               <span
-                key={index}
-                ref={bindButton(index)}
-                className={`gpv-button gpv-button-${["a", "b", "x", "y"][index]}`}
+                ref={(element) => {
+                  leftStickRef.current = element;
+                  buttonRefs.current[10] = element;
+                }}
+                className="gpv-stick gpv-left"
               />
-            ))}
-          </div>
-          <div className="gpv-sticks">
-            <span
-              ref={(element) => {
-                leftStickRef.current = element;
-                buttonRefs.current[10] = element;
-              }}
-              className="gpv-stick gpv-left"
-            />
-            <span
-              ref={(element) => {
-                rightStickRef.current = element;
-                buttonRefs.current[11] = element;
-              }}
-              className="gpv-stick gpv-right"
-            />
-          </div>
-          <div className="gpv-dpad">
-            {DPAD_BUTTONS.map((index) => (
               <span
-                key={index}
-                ref={bindButton(index)}
-                className={`gpv-face gpv-${["up", "down", "left", "right"][index - 12]}`}
+                ref={(element) => {
+                  rightStickRef.current = element;
+                  buttonRefs.current[11] = element;
+                }}
+                className="gpv-stick gpv-right"
               />
-            ))}
+            </div>
+            <div className="gpv-dpad">
+              {DPAD_BUTTONS.map((index) => (
+                <span
+                  key={index}
+                  ref={bindButton(index)}
+                  className={`gpv-face gpv-${["up", "down", "left", "right"][index - 12]}`}
+                />
+              ))}
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </aside>
   );

--- a/examples/world-model-arcade/hooks/useControllerInput.ts
+++ b/examples/world-model-arcade/hooks/useControllerInput.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export type ControllerAxes = {
   lx: number;
@@ -9,12 +9,17 @@ export type ControllerAxes = {
   ry: number;
 };
 
+export type InputMethod = "gamepad" | "keyboard";
+
 type ControllerOptions = {
   onButtonDown: (button: number) => void;
   onButtonUp: (button: number) => void;
 };
 
 const DEAD_ZONE = 0.16;
+const MOUSE_LOOK_GAIN = 0.11;
+const MOUSE_LOOK_DECAY = 0.84;
+const MOUSE_LOOK_EPSILON = 0.008;
 const KEY_TO_BUTTON: Record<string, number> = {
   Enter: 0,
   Space: 0,
@@ -49,13 +54,29 @@ export function useControllerInput({ onButtonDown, onButtonUp }: ControllerOptio
   const axesRef = useRef<ControllerAxes>({ lx: 0, ly: 0, rx: 0, ry: 0 });
   const buttonsRef = useRef<boolean[]>(Array(18).fill(false));
   const keyboardRef = useRef(new Set<string>());
+  const mouseLookRef = useRef({ rx: 0, ry: 0 });
   const handlersRef = useRef({ onButtonDown, onButtonUp });
   const [connected, setConnected] = useState(false);
-  const [lastDevice, setLastDevice] = useState<"gamepad" | "keyboard">(
-    "keyboard",
-  );
+  const [lastDevice, setLastDevice] = useState<InputMethod>("keyboard");
+  const [pointerLocked, setPointerLocked] = useState(false);
 
   handlersRef.current = { onButtonDown, onButtonUp };
+
+  const applyMouseLook = useCallback((movementX: number, movementY: number) => {
+    if ((!movementX && !movementY) || !Number.isFinite(movementX + movementY)) {
+      return;
+    }
+    const mouse = mouseLookRef.current;
+    mouse.rx = Math.max(
+      -1,
+      Math.min(1, mouse.rx * 0.35 + movementX * MOUSE_LOOK_GAIN),
+    );
+    mouse.ry = Math.max(
+      -1,
+      Math.min(1, mouse.ry * 0.35 + movementY * MOUSE_LOOK_GAIN),
+    );
+    setLastDevice("keyboard");
+  }, []);
 
   useEffect(() => {
     const keys = keyboardRef.current;
@@ -104,6 +125,31 @@ export function useControllerInput({ onButtonDown, onButtonUp }: ControllerOptio
   }, []);
 
   useEffect(() => {
+    const onPointerLockChange = () => {
+      const locked = Boolean(document.pointerLockElement);
+      setPointerLocked(locked);
+      if (locked) {
+        setLastDevice("keyboard");
+      } else {
+        mouseLookRef.current.rx = 0;
+        mouseLookRef.current.ry = 0;
+      }
+    };
+
+    const onMouseMove = (event: MouseEvent) => {
+      if (!document.pointerLockElement) return;
+      applyMouseLook(event.movementX, event.movementY);
+    };
+
+    document.addEventListener("pointerlockchange", onPointerLockChange);
+    document.addEventListener("mousemove", onMouseMove);
+    return () => {
+      document.removeEventListener("pointerlockchange", onPointerLockChange);
+      document.removeEventListener("mousemove", onMouseMove);
+    };
+  }, [applyMouseLook]);
+
+  useEffect(() => {
     let raf = 0;
     let wasConnected = false;
     const previousButtons = Array(18).fill(false) as boolean[];
@@ -118,15 +164,20 @@ export function useControllerInput({ onButtonDown, onButtonUp }: ControllerOptio
       }
 
       const keys = keyboardRef.current;
-      const keyboardAxes = {
-        lx: (keys.has("KeyD") ? 1 : 0) - (keys.has("KeyA") ? 1 : 0),
-        ly: (keys.has("KeyS") ? 1 : 0) - (keys.has("KeyW") ? 1 : 0),
+      const mouse = mouseLookRef.current;
+      const arrowLook = {
         rx:
           (keys.has("ArrowRight") ? 1 : 0) -
           (keys.has("ArrowLeft") ? 1 : 0),
         ry:
           (keys.has("ArrowDown") ? 1 : 0) -
           (keys.has("ArrowUp") ? 1 : 0),
+      };
+      const keyboardAxes = {
+        lx: (keys.has("KeyD") ? 1 : 0) - (keys.has("KeyA") ? 1 : 0),
+        ly: (keys.has("KeyS") ? 1 : 0) - (keys.has("KeyW") ? 1 : 0),
+        rx: arrowLook.rx || mouse.rx,
+        ry: arrowLook.ry || mouse.ry,
       };
 
       const gamepadAxes = pad
@@ -142,6 +193,11 @@ export function useControllerInput({ onButtonDown, onButtonUp }: ControllerOptio
       );
       if (gamepadActive) setLastDevice("gamepad");
       axesRef.current = gamepadActive ? gamepadAxes : keyboardAxes;
+
+      mouse.rx *= MOUSE_LOOK_DECAY;
+      mouse.ry *= MOUSE_LOOK_DECAY;
+      if (Math.abs(mouse.rx) < MOUSE_LOOK_EPSILON) mouse.rx = 0;
+      if (Math.abs(mouse.ry) < MOUSE_LOOK_EPSILON) mouse.ry = 0;
 
       for (let index = 0; index < previousButtons.length; index += 1) {
         const pressed = Boolean(pad?.buttons[index]?.pressed);
@@ -163,5 +219,13 @@ export function useControllerInput({ onButtonDown, onButtonUp }: ControllerOptio
     return () => cancelAnimationFrame(raf);
   }, []);
 
-  return { axesRef, buttonsRef, connected, lastDevice };
+  return {
+    axesRef,
+    buttonsRef,
+    connected,
+    keysRef: keyboardRef,
+    lastDevice,
+    pointerLocked,
+    applyMouseLook,
+  };
 }


### PR DESCRIPTION
## Summary

- default the arcade demo to a live keyboard control overlay with an optional-controller prompt
- use WASD for movement and mouse look in both the 3D room and live worlds
- add pointer-lock mouse capture with an embedded-browser fallback and Escape release
- adapt cabinet, HUD, and quick-action prompts to the active input method
- document the updated keyboard, mouse, and controller controls

## Testing

- `npm run typecheck`
- `npm run build`
- manual embedded-browser smoke test for click-to-look, mouse movement, and Escape release