### PR TITLE
Add the Matrix-Game-2.0 Reactor adapter

### DIFF
--- a/models/matrix-game-2-0/.dockerignore
+++ b/models/matrix-game-2-0/.dockerignore
@@ -1,0 +1,28 @@
+# Python build and cache artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+
+# Local Python environments
+.venv/
+venv/
+
+# Editor and operating-system state
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Source control and local container overrides
+.git/
+.gitignore
+Dockerfile
+.dockerignore
+
+# Runtime assets are downloaded into the mounted weights path, never copied
+# into the image build context.
+weights/

--- a/models/matrix-game-2-0/README.md
+++ b/models/matrix-game-2-0/README.md
@@ -29,7 +29,7 @@ This directory is a `reactor` workspace. `reactor.yaml` names the model,
 configures its Reactor Runtime 3.2.3 image, mounts the persistent weights cache,
 and enables recording. `requirements.txt` contains the inference dependencies.
 See Reactor's
-[build configuration](https://deploy-docs.reactor.inc/platform/build) for the
+[build configuration](https://docs.reactor.inc/deploy/platform/build) for the
 supported fields.
 
 Check the host, build the image, and expose one free GPU to the container:

--- a/models/matrix-game-2-0/README.md
+++ b/models/matrix-game-2-0/README.md
@@ -65,8 +65,8 @@ reactor build && reactor run --gpus device=0 --port 8080
 
 ## Controls
 
-A session starts paused with no scene selected. Selecting an image automatically
-generates the first chunk even while paused.
+A session starts unpaused with no scene selected. Selecting an image starts
+continuous generation from the first chunk.
 
 - `set_key_state(key, pressed)` holds or releases `w`, `a`, `s`, or `d` for
   forthcoming chunks. Held keys persist and can be combined; W+A and W+D become
@@ -76,16 +76,13 @@ generates the first chunk even while paused.
 - `set_yaw(yaw)` holds normalized turn-left or turn-right velocity in
   `[-1, 1]`.
 - `release_controls` returns keyboard and camera conditions to neutral.
-- `set_paused(false)` begins continuous generation one native chunk at a time;
-  `set_paused(true)` stops before the next chunk.
-- `step` generates exactly one chunk while paused.
 - `reset(seed)` clears every autoregressive cache, rebuilds the selected image
   conditioning, and automatically generates a fresh first chunk. Pass `-1` to
   keep the active seed.
 
 Keyboard and camera values are sampled together at the next chunk boundary.
 Changing a control while one chunk is in flight applies it to the following
-chunk. Pausing or ending the session releases all controls.
+chunk. Ending the session releases all controls.
 
 ## Start from a public demo
 
@@ -107,7 +104,7 @@ their rollout state are session-scoped and released when the session ends.
 ## Autoregressive inference
 
 The adapter loads the official model, image VAE/CLIP encoder, causal VAE decoder,
-and universal distilled checkpoint in the Runtime process. Each `step` advances
+and universal distilled checkpoint in the Runtime process. Each inference turn advances
 the same native three-latent block as upstream `inference_streaming.py` and
 continues its incremental state.
 

--- a/models/matrix-game-2-0/README.md
+++ b/models/matrix-game-2-0/README.md
@@ -117,9 +117,11 @@ keyboard and mouse action KV caches, the visual cross-attention cache, and all
 three-step distilled denoising schedule, context-cache commit, and 360-latent
 horizon remain unchanged.
 
-The first causal decode emits 9 RGB frames and each later decode emits 12 at 25
-FPS. One rollout therefore provides 120 interactive chunks before the adapter
-pauses and requires `reset`, `set_image`, or `random_image`.
+The first causal decode emits 9 RGB frames and each later decode emits 12.
+Playback adapts to measured inference throughput, and the output queue holds
+one complete 12-frame chunk. One rollout therefore provides 120 interactive
+chunks before the adapter pauses and requires `reset`, `set_image`, or
+`random_image`.
 
 ## Model messages
 

--- a/models/matrix-game-2-0/README.md
+++ b/models/matrix-game-2-0/README.md
@@ -1,0 +1,162 @@
+# Play Matrix-Game-2.0 through Reactor Runtime
+
+Run SkyworkAI's public
+[Matrix-Game-2.0](https://github.com/SkyworkAI/Matrix-Game) universal distilled
+model as an interactive Reactor backend. Use this recipe when a client needs to
+start from a public demo or uploaded image, apply native keyboard and
+mouse-camera controls, stream autoregressive video, and record the session.
+
+The adapter and upstream implementation remain separate. This directory owns
+only the Reactor integration. On first load it fetches the exact tested source
+revision and checkpoint into Reactor's mounted weights cache without editing the
+upstream checkout. Reactor builds the model image from the `build:` block in
+`reactor.yaml`; this recipe has no Dockerfile.
+
+## Prerequisites
+
+- The `reactor` CLI and Docker, configured as described in the
+  [Reactor build documentation](https://deploy-docs.reactor.inc/platform/build).
+- An NVIDIA GPU, NVIDIA driver, and NVIDIA Container Toolkit. CPU inference is
+  intentionally unsupported. The published resource request targets one B200.
+- About 12 GB in Reactor's weights cache, plus approximately 30 GB of Docker
+  image and build working space.
+
+When the system disk is small, place both Reactor's weights cache and the Docker
+daemon's data root on a high-capacity volume. `runtime.weights_path` controls the
+host directory mounted for source and checkpoints; Docker image and BuildKit
+storage are configured on the Docker daemon itself.
+
+## Run
+
+This directory is a `reactor` workspace. `reactor.yaml` names the model,
+declares its generated image build, mounts the persistent weights cache, and
+configures recording. `requirements.txt` contains inference dependencies only;
+`build.runtime_version` is the single Reactor Runtime version pin.
+
+Check the host, build the image, and expose one free GPU to the container:
+
+```sh
+cd models/matrix-game-2-0
+reactor doctor
+reactor build
+reactor run --gpus device=0 --port 8080
+```
+
+The CLI renders the YAML build definition into a Dockerfile in memory and hands
+it to BuildKit. It installs Reactor Runtime 3.1.2, Python 3.12, CUDA 12.8, the
+model dependencies, and the required system packages without writing a
+Dockerfile into the workspace. `reactor run` reuses the local image, building it
+automatically when its tag is absent.
+
+On first load the adapter sparsely clones the pinned `Matrix-Game-2` source and
+downloads only the universal distilled checkpoint, Wan 2.1 VAE, image encoder,
+and tokenizer files from the pinned Hugging Face snapshot. Interrupted downloads
+resume from the mounted cache, and later runs reuse the same assets.
+
+Check readiness and inspect the generated command schema with:
+
+```sh
+curl -s http://localhost:8080/health
+curl -s http://localhost:8080/schema
+```
+
+Rebuild after editing files copied into the model image:
+
+```sh
+reactor build && reactor run --gpus device=0 --port 8080
+```
+
+## Controls
+
+A session starts paused with no scene selected. Selecting an image automatically
+generates the first chunk even while paused.
+
+- `set_key_state(key, pressed)` holds or releases `w`, `a`, `s`, or `d` for
+  forthcoming chunks. Held keys persist and can be combined; W+A and W+D become
+  the same multi-hot actions used by the official universal model.
+- `set_pitch(pitch)` holds normalized look-down or look-up velocity in
+  `[-1, 1]`.
+- `set_yaw(yaw)` holds normalized turn-left or turn-right velocity in
+  `[-1, 1]`.
+- `release_controls` returns keyboard and camera conditions to neutral.
+- `set_paused(false)` begins continuous generation one native chunk at a time;
+  `set_paused(true)` stops before the next chunk.
+- `step` generates exactly one chunk while paused.
+- `reset(seed)` clears every autoregressive cache, rebuilds the selected image
+  conditioning, and automatically generates a fresh first chunk. Pass `-1` to
+  keep the active seed.
+
+Keyboard and camera values are sampled together at the next chunk boundary.
+Changing a control while one chunk is in flight applies it to the following
+chunk. Pausing or ending the session releases all controls.
+
+## Start from a public demo
+
+`random_image` selects one of the public universal example images in the pinned
+Matrix-Game checkout. It clears the active rollout and all controls, rebuilds
+image conditioning, and automatically queues one chunk. Repeated calls choose a
+different configured image when possible.
+
+## Start from an image
+
+Upload a JPEG, PNG, WebP, or BMP through Reactor's upload protocol, then pass its
+upload reference to `set_image`. The adapter applies EXIF orientation, validates
+the decoded image, and uses the official centered aspect-ratio crop and 352x640
+resize before creating the visual condition.
+
+Uploads are limited to 25 MiB and 100 million decoded pixels. Uploaded bytes and
+their rollout state are session-scoped and released when the session ends.
+
+## Autoregressive inference
+
+The adapter loads the official model, image VAE/CLIP encoder, causal VAE decoder,
+and universal distilled checkpoint in the Runtime process. Each `step` advances
+the same native three-latent block as upstream `inference_streaming.py`; it does
+not rerun an offline rollout or rebuild history from rendered frames.
+
+The active rollout preserves the diffusion model's 30 rolling KV caches, the
+keyboard and mouse action KV caches, the visual cross-attention cache, and all
+32 causal VAE decoder cache tensors. The official `local_attn_size: 6`,
+three-step distilled denoising schedule, context-cache commit, and 360-latent
+horizon remain unchanged.
+
+The first causal decode emits 9 RGB frames and each later decode emits 12 at 25
+FPS. One rollout therefore provides 120 interactive chunks before the adapter
+pauses and requires `reset`, `set_image`, or `random_image`.
+
+## Model messages
+
+Commands and generation publish typed messages for the client timeline:
+
+- `action_changed` contains the addressed key, whether it is held, the complete
+  held-key set, and the first chunk that will sample it.
+- `camera_motion_changed` contains both camera axes and the first chunk that will
+  sample them.
+- `state_update` is a complete snapshot of image selection, pause and queue
+  state, rollout progress, seed, and active controls. A joining viewer receives
+  one immediately; successful state changes broadcast another.
+- `chunk_complete` contains the chunk index, decoded frame count, sampled
+  controls, and measured inference time.
+- `rollout_limit_reached` reports the exhausted official chunk horizon.
+
+Message delivery stays outside the synchronous inference path.
+
+## Recording
+
+`reactor.yaml` records `main_video` as H.264 in four-second chunks and allows
+clips up to five minutes. The generated image includes FFmpeg. Matrix-Game-2.0
+does not emit audio.
+
+## Notes
+
+- `matrix_game_2.yaml` pins the upstream source revision, checkpoint snapshot,
+  universal distilled variant, 360-latent horizon, seed, and public demo images.
+- Set `MATRIX_GAME_2_PATH` to an existing `Matrix-Game-2` source directory to
+  reuse a checkout. Its Git revision must match the pinned revision.
+- Matrix-Game-2.0 removed the text-conditioning branch from its released 2.0
+  inference model, so this adapter does not expose a prompt command the
+  checkpoint cannot consume.
+- The image uses Matrix-Game-2.0's native Flash Attention 2.8.3 dependency. This
+  recipe deliberately does not add Flash Attention 4, CUDA Graphs, or warmup;
+  those are separate inference-optimization work.
+- Stop `reactor run` to remove the container and release its GPU memory.

--- a/models/matrix-game-2-0/README.md
+++ b/models/matrix-game-2-0/README.md
@@ -6,32 +6,31 @@ model as an interactive Reactor backend. Use this recipe when a client needs to
 start from a public demo or uploaded image, apply native keyboard and
 mouse-camera controls, stream autoregressive video, and record the session.
 
-The adapter and upstream implementation remain separate. This directory owns
-only the Reactor integration. On first load it fetches the exact tested source
-revision and checkpoint into Reactor's mounted weights cache without editing the
-upstream checkout. Reactor builds the model image from the `build:` block in
-`reactor.yaml`; this recipe has no Dockerfile.
+The adapter loads an exact tested source revision and checkpoint from Reactor's
+mounted weights cache and calls the upstream autoregressive components
+directly. The `build:` block in `reactor.yaml` controls the model image.
 
 ## Prerequisites
 
-- The `reactor` CLI and Docker, configured as described in the
-  [Reactor build documentation](https://deploy-docs.reactor.inc/platform/build).
+- The [`reactor` CLI](https://docs.reactor.inc/deploy/platform/installation) and
+  Docker.
 - An NVIDIA GPU, NVIDIA driver, and NVIDIA Container Toolkit. CPU inference is
   intentionally unsupported. The published resource request targets one B200.
 - About 12 GB in Reactor's weights cache, plus approximately 30 GB of Docker
   image and build working space.
 
-When the system disk is small, place both Reactor's weights cache and the Docker
-daemon's data root on a high-capacity volume. `runtime.weights_path` controls the
-host directory mounted for source and checkpoints; Docker image and BuildKit
-storage are configured on the Docker daemon itself.
+When the system disk is small, place Reactor's weights cache and the container
+engine's image storage on a high-capacity volume. `runtime.weights_path`
+controls the host directory mounted for source and checkpoints.
 
 ## Run
 
 This directory is a `reactor` workspace. `reactor.yaml` names the model,
-declares its generated image build, mounts the persistent weights cache, and
-configures recording. `requirements.txt` contains inference dependencies only;
-`build.runtime_version` is the single Reactor Runtime version pin.
+configures its Reactor Runtime 3.2.3 image, mounts the persistent weights cache,
+and enables recording. `requirements.txt` contains the inference dependencies.
+See Reactor's
+[build configuration](https://deploy-docs.reactor.inc/platform/build) for the
+supported fields.
 
 Check the host, build the image, and expose one free GPU to the container:
 
@@ -42,15 +41,13 @@ reactor build
 reactor run --gpus device=0 --port 8080
 ```
 
-The CLI renders the YAML build definition into a Dockerfile in memory and hands
-it to BuildKit. It installs Reactor Runtime 3.1.2, Python 3.12, CUDA 12.8, the
-model dependencies, and the required system packages without writing a
-Dockerfile into the workspace. `reactor run` reuses the local image, building it
-automatically when its tag is absent.
+The configured image contains Reactor Runtime 3.2.3, Python 3.12, CUDA 12.8,
+the model dependencies, and the required system packages. `reactor run` reuses
+the local image, building it automatically when its tag is absent.
 
 On first load the adapter sparsely clones the pinned `Matrix-Game-2` source and
-downloads only the universal distilled checkpoint, Wan 2.1 VAE, image encoder,
-and tokenizer files from the pinned Hugging Face snapshot. Interrupted downloads
+downloads the universal distilled checkpoint, Wan 2.1 VAE, image encoder, and
+tokenizer files from the pinned Hugging Face snapshot. Interrupted downloads
 resume from the mounted cache, and later runs reuse the same assets.
 
 Check readiness and inspect the generated command schema with:
@@ -111,8 +108,8 @@ their rollout state are session-scoped and released when the session ends.
 
 The adapter loads the official model, image VAE/CLIP encoder, causal VAE decoder,
 and universal distilled checkpoint in the Runtime process. Each `step` advances
-the same native three-latent block as upstream `inference_streaming.py`; it does
-not rerun an offline rollout or rebuild history from rendered frames.
+the same native three-latent block as upstream `inference_streaming.py` and
+continues its incremental state.
 
 The active rollout preserves the diffusion model's 30 rolling KV caches, the
 keyboard and mouse action KV caches, the visual cross-attention cache, and all
@@ -144,7 +141,7 @@ Message delivery stays outside the synchronous inference path.
 ## Recording
 
 `reactor.yaml` records `main_video` as H.264 in four-second chunks and allows
-clips up to five minutes. The generated image includes FFmpeg. Matrix-Game-2.0
+clips up to five minutes. The model image includes FFmpeg. Matrix-Game-2.0
 does not emit audio.
 
 ## Notes
@@ -153,10 +150,7 @@ does not emit audio.
   universal distilled variant, 360-latent horizon, seed, and public demo images.
 - Set `MATRIX_GAME_2_PATH` to an existing `Matrix-Game-2` source directory to
   reuse a checkout. Its Git revision must match the pinned revision.
-- Matrix-Game-2.0 removed the text-conditioning branch from its released 2.0
-  inference model, so this adapter does not expose a prompt command the
-  checkpoint cannot consume.
-- The image uses Matrix-Game-2.0's native Flash Attention 2.8.3 dependency. This
-  recipe deliberately does not add Flash Attention 4, CUDA Graphs, or warmup;
-  those are separate inference-optimization work.
+- The released Matrix-Game-2.0 checkpoint accepts image and action
+  conditioning. The command schema exposes those native inputs.
+- The image uses Matrix-Game-2.0's native Flash Attention 2.8.3 dependency.
 - Stop `reactor run` to remove the container and release its GPU memory.

--- a/models/matrix-game-2-0/matrix_game_2.py
+++ b/models/matrix-game-2-0/matrix_game_2.py
@@ -88,12 +88,12 @@ class MatrixGame2(ReactorPipeline):
 
     @session_started
     def on_session_started(self) -> None:
-        """Initialize a paused shared world before its first viewer connects."""
+        """Initialize an unpaused shared world before its first viewer connects."""
         config = self._require_config()
         self._selected_input = None
         self._image_source = "none"
         self._seed = config.seed
-        self.state.paused = True
+        self.state.paused = False
         self.state._step_requested = False
         self.state._restart_requested = False
         self.state._limit_reached = False
@@ -136,8 +136,8 @@ class MatrixGame2(ReactorPipeline):
         description=(
             "Select an uploaded starting image and initialize a fresh autoregressive world. "
             "Valid at any time; the image is center-cropped to Matrix's 352x640 input, clears "
-            "the prior rollout and controls, and automatically queues one `main_video` chunk "
-            "even while paused. Returns `StateUpdate` on success, or `CommandError` when the "
+            "the prior rollout and controls, and starts continuous `main_video` generation. "
+            "Returns `StateUpdate` on success, or `CommandError` when the "
             "upload is not a valid JPEG, PNG, WebP, or BMP within the size limits."
         ),
     )
@@ -155,6 +155,7 @@ class MatrixGame2(ReactorPipeline):
         validate_uploaded_image(image)
         self._selected_input = image
         self._image_source = "upload"
+        self.state.paused = False
         self._request_restart(auto_step=True)
         return self._state_update()
 
@@ -163,8 +164,8 @@ class MatrixGame2(ReactorPipeline):
         description=(
             "Select one configured public Matrix universal example and initialize a fresh "
             "autoregressive world. Valid at any time; it chooses a different built-in image "
-            "when possible, clears the prior rollout and controls, and automatically queues "
-            "one `main_video` chunk even while paused. Returns `StateUpdate` on success."
+            "when possible, clears the prior rollout and controls, and starts continuous "
+            "`main_video` generation. Returns `StateUpdate` on success."
         ),
     )
     def random_image(self) -> StateUpdate:
@@ -175,6 +176,7 @@ class MatrixGame2(ReactorPipeline):
             choices = [path for path in choices if path != self._selected_input]
         self._selected_input = secrets.choice(choices)
         self._image_source = "built_in"
+        self.state.paused = False
         self._request_restart(auto_step=True)
         return self._state_update()
 
@@ -287,19 +289,11 @@ class MatrixGame2(ReactorPipeline):
         self._clear_controls()
         return self._state_update()
 
-    @event(
-        name="set_paused",
-        description=(
-            "Pause before the next native chunk or resume continuous generation. Pausing is "
-            "valid at any time; resuming requires a selected image and an available chunk. "
-            "Either choice releases held controls and cancels a queued manual step. Returns "
-            "`StateUpdate` on success, or `CommandError` when generation cannot resume."
-        ),
-    )
+    # Keep pause available for future schema re-enablement without exposing it to clients.
     def set_paused(
         self,
         paused: bool = InputField(
-            default=True,
+            default=False,
             description=(
                 "Set true to stop before the next three-latent chunk, or false to generate "
                 "continuously. The change takes effect after any in-flight chunk."
@@ -314,15 +308,7 @@ class MatrixGame2(ReactorPipeline):
         self._clear_controls()
         return self._state_update()
 
-    @event(
-        name="step",
-        description=(
-            "Queue exactly one native three-latent `main_video` chunk without leaving paused "
-            "mode. Valid only while paused, after image selection, and before the rollout "
-            "horizon. Returns `StateUpdate` on success, or `CommandError` when continuous "
-            "generation is running, no image is selected, or a reset is required."
-        ),
-    )
+    # Keep single-step generation available for future schema re-enablement.
     def step(self) -> StateUpdate:
         """Queue one paused chunk and return the complete shared world state."""
         self._require_playable_rollout()
@@ -337,7 +323,7 @@ class MatrixGame2(ReactorPipeline):
         name="reset",
         description=(
             "Restart from the selected image with empty model, keyboard, mouse, cross-attention, "
-            "and causal VAE caches. Valid after image selection; it preserves paused mode, "
+            "and causal VAE caches. Valid after image selection; it resumes continuous generation, "
             "clears controls and progress, and automatically queues one visible chunk. Returns "
             "`StateUpdate` on success, or `CommandError` when no image is selected."
         ),
@@ -361,6 +347,7 @@ class MatrixGame2(ReactorPipeline):
             )
         if seed >= 0:
             self._seed = seed
+        self.state.paused = False
         self._request_restart(auto_step=True)
         return self._state_update()
 

--- a/models/matrix-game-2-0/matrix_game_2.py
+++ b/models/matrix-game-2-0/matrix_game_2.py
@@ -1,0 +1,518 @@
+"""Serve Matrix-Game-2.0 distilled autoregressive inference through Reactor."""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+import time
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+from reactor_runtime import (
+    ClientInfo,
+    CommandError,
+    Idle,
+    InputField,
+    ReactorPipeline,
+    UploadedFile,
+    connected,
+    disconnected,
+    event,
+    session_ended,
+    session_started,
+)
+from reactor_runtime.log import get_logger
+
+from matrix_game_2_assets import (
+    load_input_image,
+    prepare_runtime_assets,
+    read_config,
+    validate_uploaded_image,
+)
+from matrix_game_2_backend import FPS, ChunkAction, MatrixGame2Backend
+from matrix_game_2_types import (
+    KEYBOARD_KEYS,
+    ActionChanged,
+    CameraMotionChanged,
+    ChunkComplete,
+    MatrixGame2Config,
+    MatrixGame2Output,
+    MatrixGame2State,
+    RolloutLimitReached,
+    StateUpdate,
+)
+
+logger = get_logger(__name__)
+
+
+class MatrixGame2(ReactorPipeline):
+    """Generate a keyboard- and mouse-camera-controlled Matrix world from an image."""
+
+    state: MatrixGame2State
+    output: MatrixGame2Output
+    fps = FPS
+    buffer_size = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config: MatrixGame2Config | None = None
+        self._backend: MatrixGame2Backend | None = None
+        self._selected_input: Path | UploadedFile | None = None
+        self._image_source = "none"
+        self._seed = 0
+        self._chunk_index = 0
+        self._last_chunk_frames = 0
+        self._chunk_in_flight = False
+
+    def load(self, config_path: Path | None) -> None:
+        """Load the pinned universal distilled checkpoint once.
+
+        Args:
+            config_path: Path to ``matrix_game_2.yaml`` from ``reactor.yaml``.
+        """
+        config = read_config(config_path)
+        model_path = prepare_runtime_assets(config)
+        backend = MatrixGame2Backend(
+            source_path=config.source_path,
+            model_path=model_path,
+            checkpoint_file=config.checkpoint_file,
+            max_latent_frames=config.max_latent_frames,
+        )
+        self._config = config
+        self._backend = backend
+        self._seed = config.seed
+        self.output.fps = FPS
+        logger.info(
+            "Matrix-Game-2.0 model ready",
+            source_revision=config.source_revision,
+            checkpoint_revision=config.model_revision,
+            max_chunks=config.max_chunks,
+            fps=FPS,
+        )
+
+    @session_started
+    def on_session_started(self) -> None:
+        """Initialize a paused shared world before its first viewer connects."""
+        config = self._require_config()
+        self._selected_input = None
+        self._image_source = "none"
+        self._seed = config.seed
+        self.state.paused = True
+        self.state._step_requested = False
+        self.state._restart_requested = False
+        self.state._limit_reached = False
+        self._chunk_index = 0
+        self._last_chunk_frames = 0
+        self._chunk_in_flight = False
+        self._clear_controls()
+
+    @connected
+    async def on_connected(self, client: ClientInfo) -> None:
+        """Send the complete shared world state to one joining viewer."""
+        await client.send(self._state_update())
+
+    @disconnected
+    async def on_disconnected(self) -> None:
+        """Release held controls when their viewer leaves the live session."""
+        self._clear_controls()
+        await self.send(self._state_update())
+
+    @session_ended
+    async def on_session_ended(self) -> None:
+        """Release image data and causal caches owned by the completed session."""
+        backend = self._backend
+        try:
+            if backend is not None:
+                await asyncio.to_thread(backend.end_rollout)
+        finally:
+            self._selected_input = None
+            self._image_source = "none"
+            self.state._step_requested = False
+            self.state._restart_requested = False
+            self.state._limit_reached = False
+            self._chunk_index = 0
+            self._last_chunk_frames = 0
+            self._chunk_in_flight = False
+            self._clear_controls()
+
+    @event(
+        name="set_image",
+        description=(
+            "Select an uploaded starting image and initialize a fresh autoregressive world. "
+            "Valid at any time; the image is center-cropped to Matrix's 352x640 input, clears "
+            "the prior rollout and controls, and automatically queues one `main_video` chunk "
+            "even while paused. Returns `StateUpdate` on success, or `CommandError` when the "
+            "upload is not a valid JPEG, PNG, WebP, or BMP within the size limits."
+        ),
+    )
+    def set_image(
+        self,
+        image: UploadedFile = InputField(  # noqa: B008 - schema field declaration
+            description=(
+                "Starting image sent through Reactor's upload protocol. JPEG, PNG, WebP, or "
+                "BMP; at most 25 MiB and 100 million decoded pixels. Selection starts a fresh "
+                "rollout and automatically generates its first chunk."
+            )
+        ),
+    ) -> StateUpdate:
+        """Select uploaded image bytes and return the queued world state."""
+        validate_uploaded_image(image)
+        self._selected_input = image
+        self._image_source = "upload"
+        self._request_restart(auto_step=True)
+        return self._state_update()
+
+    @event(
+        name="random_image",
+        description=(
+            "Select one configured public Matrix universal example and initialize a fresh "
+            "autoregressive world. Valid at any time; it chooses a different built-in image "
+            "when possible, clears the prior rollout and controls, and automatically queues "
+            "one `main_video` chunk even while paused. Returns `StateUpdate` on success."
+        ),
+    )
+    def random_image(self) -> StateUpdate:
+        """Select a public example image and return the queued world state."""
+        config = self._require_config()
+        choices = list(config.random_images)
+        if isinstance(self._selected_input, Path) and len(choices) > 1:
+            choices = [path for path in choices if path != self._selected_input]
+        self._selected_input = secrets.choice(choices)
+        self._image_source = "built_in"
+        self._request_restart(auto_step=True)
+        return self._state_update()
+
+    @event(
+        name="set_key_state",
+        description=(
+            "Hold or release one WASD movement key for forthcoming chunks. Requires a selected "
+            "image; the complete held-key set is sampled as the official four-value multi-hot "
+            "condition when the next chunk starts. Emits `action_changed` and broadcasts "
+            "`state_update` on success, or `command_error` when a reset is required."
+        ),
+    )
+    async def set_key_state(
+        self,
+        key: str = InputField(
+            default="w",
+            choices=KEYBOARD_KEYS,
+            description=(
+                "Movement key to hold or release: W forward, S backward, A left, or D right. "
+                "Held keys can be combined, including W+A and W+D."
+            ),
+        ),
+        pressed: bool = InputField(
+            default=True,
+            description=(
+                "Set true on key-down and false on key-up. The resulting held-key set persists "
+                "until another key event or `release_controls`."
+            ),
+        ),
+    ) -> ActionChanged:
+        """Update one held WASD key and report the complete discrete action."""
+        self._require_playable_rollout()
+        if pressed:
+            self.state._pressed_keys = self.state._pressed_keys.union((key,))
+        else:
+            self.state._pressed_keys = self.state._pressed_keys.difference((key,))
+        message = ActionChanged(
+            key=key,
+            pressed=pressed,
+            pressed_keys=sorted(self.state._pressed_keys),
+            applies_to_chunk=self._next_control_chunk(),
+        )
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="set_pitch",
+        description=(
+            "Set continuous look-down or look-up camera velocity for forthcoming chunks. "
+            "Requires a selected image; the normalized value is sampled at the next chunk "
+            "boundary and mapped to Matrix's native vertical mouse condition. Emits "
+            "`camera_motion_changed` and broadcasts `state_update` on success."
+        ),
+    )
+    async def set_pitch(
+        self,
+        pitch: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Look down (-1) to look up (1) velocity held until changed; zero is neutral."
+            ),
+        ),
+    ) -> CameraMotionChanged:
+        """Queue normalized pitch and return the complete camera action."""
+        self._require_playable_rollout()
+        self.state.pitch = pitch
+        message = self._camera_motion_changed()
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="set_yaw",
+        description=(
+            "Set continuous turn-left or turn-right camera velocity for forthcoming chunks. "
+            "Requires a selected image; the normalized value is sampled at the next chunk "
+            "boundary and mapped to Matrix's native horizontal mouse condition. Emits "
+            "`camera_motion_changed` and broadcasts `state_update` on success."
+        ),
+    )
+    async def set_yaw(
+        self,
+        yaw: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Turn left (-1) to turn right (1) velocity held until changed; zero is neutral."
+            ),
+        ),
+    ) -> CameraMotionChanged:
+        """Queue normalized yaw and return the complete camera action."""
+        self._require_playable_rollout()
+        self.state.yaw = yaw
+        message = self._camera_motion_changed()
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="release_controls",
+        description=(
+            "Return keyboard and camera conditions to neutral. Valid at any time; neutral "
+            "values are sampled by the next generated chunk without resetting visual history. "
+            "Returns `StateUpdate` with all three controls cleared."
+        ),
+    )
+    def release_controls(self) -> StateUpdate:
+        """Clear held keyboard and camera controls and return shared state."""
+        self._clear_controls()
+        return self._state_update()
+
+    @event(
+        name="set_paused",
+        description=(
+            "Pause before the next native chunk or resume continuous generation. Pausing is "
+            "valid at any time; resuming requires a selected image and an available chunk. "
+            "Either choice releases held controls and cancels a queued manual step. Returns "
+            "`StateUpdate` on success, or `CommandError` when generation cannot resume."
+        ),
+    )
+    def set_paused(
+        self,
+        paused: bool = InputField(
+            default=True,
+            description=(
+                "Set true to stop before the next three-latent chunk, or false to generate "
+                "continuously. The change takes effect after any in-flight chunk."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set pause state and return the complete shared world state."""
+        if not paused:
+            self._require_playable_rollout()
+        self.state.paused = paused
+        self.state._step_requested = False
+        self._clear_controls()
+        return self._state_update()
+
+    @event(
+        name="step",
+        description=(
+            "Queue exactly one native three-latent `main_video` chunk without leaving paused "
+            "mode. Valid only while paused, after image selection, and before the rollout "
+            "horizon. Returns `StateUpdate` on success, or `CommandError` when continuous "
+            "generation is running, no image is selected, or a reset is required."
+        ),
+    )
+    def step(self) -> StateUpdate:
+        """Queue one paused chunk and return the complete shared world state."""
+        self._require_playable_rollout()
+        if not self.state.paused:
+            raise CommandError(
+                "pause_required", "Pause Matrix-Game-2.0 before stepping."
+            )
+        self.state._step_requested = True
+        return self._state_update()
+
+    @event(
+        name="reset",
+        description=(
+            "Restart from the selected image with empty model, keyboard, mouse, cross-attention, "
+            "and causal VAE caches. Valid after image selection; it preserves paused mode, "
+            "clears controls and progress, and automatically queues one visible chunk. Returns "
+            "`StateUpdate` on success, or `CommandError` when no image is selected."
+        ),
+    )
+    def reset(
+        self,
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description=(
+                "Seed for the fresh rollout from 0 to 2147483647. Use -1 to retain the active "
+                "seed; a non-negative value becomes active when reset begins."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Queue a cache reset and return the complete shared world state."""
+        if self._selected_input is None:
+            raise CommandError(
+                "image_required", "Select a Matrix image before resetting."
+            )
+        if seed >= 0:
+            self._seed = seed
+        self._request_restart(auto_step=True)
+        return self._state_update()
+
+    async def inference(self) -> AsyncGenerator[object, None]:
+        """Generate and emit one official causal chunk per Reactor turn."""
+        backend = self._require_backend()
+        config = self._require_config()
+
+        while True:
+            if self.state._restart_requested:
+                selected_input = self._selected_input
+                if selected_input is None:
+                    yield Idle
+                    continue
+                self.state._restart_requested = False
+                image = load_input_image(selected_input)
+                await asyncio.to_thread(backend.reset, image, self._seed)
+                if self.state._restart_requested:
+                    continue
+                self._chunk_index = 0
+                self._last_chunk_frames = 0
+                self.state._limit_reached = False
+                await self.send(self._state_update())
+
+            if self._selected_input is None or self.state._limit_reached:
+                yield Idle
+                continue
+            if self.state.paused and not self.state._step_requested:
+                yield Idle
+                continue
+
+            self.state._step_requested = False
+            action = ChunkAction(
+                pressed_keys=tuple(sorted(self.state._pressed_keys)),
+                pitch=self.state.pitch,
+                yaw=self.state.yaw,
+            )
+            self._chunk_in_flight = True
+            started_at = time.perf_counter()
+            try:
+                frames = await asyncio.to_thread(backend.generate_chunk, action)
+            finally:
+                self._chunk_in_flight = False
+            inference_seconds = time.perf_counter() - started_at
+            if self.state._restart_requested:
+                continue
+
+            self._chunk_index += 1
+            self._last_chunk_frames = int(frames.shape[0])
+            if self._chunk_index >= config.max_chunks:
+                self.state._limit_reached = True
+                self.state.paused = True
+                self._clear_controls()
+                await self.send(
+                    RolloutLimitReached(
+                        completed_chunks=self._chunk_index,
+                        max_chunks=config.max_chunks,
+                    )
+                )
+            await self.send(
+                ChunkComplete(
+                    chunk=self._chunk_index,
+                    frames=self._last_chunk_frames,
+                    inference_seconds=inference_seconds,
+                    pressed_keys=list(action.pressed_keys),
+                    pitch=action.pitch,
+                    yaw=action.yaw,
+                )
+            )
+            await self.send(self._state_update())
+
+            for frame in frames:
+                if self.state._restart_requested:
+                    break
+                yield MatrixGame2Output(main_video=frame)
+
+    def _request_restart(self, *, auto_step: bool) -> None:
+        """Queue fresh image conditioning and release current controls and progress."""
+        self._clear_controls()
+        self.state._restart_requested = True
+        self.state._step_requested = auto_step
+        self.state._limit_reached = False
+        self._chunk_index = 0
+        self._last_chunk_frames = 0
+
+    def _clear_controls(self) -> None:
+        """Return the universal keyboard and mouse-camera conditions to neutral."""
+        self.state._pressed_keys = frozenset()
+        self.state.pitch = 0.0
+        self.state.yaw = 0.0
+
+    def _camera_motion_changed(self) -> CameraMotionChanged:
+        """Describe the complete continuous camera state after an axis event."""
+        return CameraMotionChanged(
+            pitch=self.state.pitch,
+            yaw=self.state.yaw,
+            applies_to_chunk=self._next_control_chunk(),
+        )
+
+    def _require_playable_rollout(self) -> None:
+        """Reject controls that cannot affect a generated chunk."""
+        if self._selected_input is None:
+            raise CommandError("image_required", "Select a Matrix image first.")
+        if self.state._limit_reached:
+            raise CommandError(
+                "rollout_limit_reached",
+                "Reset Matrix-Game-2.0 before requesting another chunk.",
+            )
+
+    def _next_control_chunk(self) -> int:
+        """Return the one-based chunk expected to sample controls accepted now."""
+        if self.state._restart_requested:
+            return 1
+        return self._chunk_index + 1 + int(self._chunk_in_flight)
+
+    def _state_update(self) -> StateUpdate:
+        """Return a complete client-facing snapshot of the shared world state."""
+        config = self._config
+        max_chunks = config.max_chunks if config is not None else 0
+        selected = self._selected_input
+        return StateUpdate(
+            image_source=self._image_source,
+            image_name=selected.name if selected is not None else "",
+            seed=self._seed,
+            paused=self.state.paused,
+            step_queued=self.state._step_requested,
+            reset_queued=self.state._restart_requested,
+            chunk_in_flight=self._chunk_in_flight,
+            limit_reached=self.state._limit_reached,
+            completed_chunks=self._chunk_index,
+            next_chunk=None
+            if selected is None or self.state._limit_reached
+            else self._next_control_chunk(),
+            max_chunks=max_chunks,
+            last_chunk_frames=self._last_chunk_frames,
+            pressed_keys=sorted(self.state._pressed_keys),
+            pitch=self.state.pitch,
+            yaw=self.state.yaw,
+        )
+
+    def _require_config(self) -> MatrixGame2Config:
+        """Return loaded configuration or raise a lifecycle error."""
+        if self._config is None:
+            raise RuntimeError("Matrix-Game-2.0 was not loaded")
+        return self._config
+
+    def _require_backend(self) -> MatrixGame2Backend:
+        """Return the loaded upstream backend or raise a lifecycle error."""
+        if self._backend is None:
+            raise RuntimeError("Matrix-Game-2.0 was not loaded")
+        return self._backend

--- a/models/matrix-game-2-0/matrix_game_2.py
+++ b/models/matrix-game-2-0/matrix_game_2.py
@@ -419,13 +419,11 @@ class MatrixGame2(ReactorPipeline):
             )
             await self.send(self._state_update())
 
-            for frame in frames:
-                if self.state._restart_requested:
-                    break
-                yield MatrixGame2Output(main_video=frame)
+            yield MatrixGame2Output(main_video=frames)
 
     def _request_restart(self, *, auto_step: bool) -> None:
         """Queue fresh image conditioning and release current controls and progress."""
+        self.output.flush()
         self._clear_controls()
         self.state._restart_requested = True
         self.state._step_requested = auto_step

--- a/models/matrix-game-2-0/matrix_game_2.py
+++ b/models/matrix-game-2-0/matrix_game_2.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import secrets
 import time
 from collections.abc import AsyncGenerator
@@ -115,12 +114,12 @@ class MatrixGame2(ReactorPipeline):
         await self.send(self._state_update())
 
     @session_ended
-    async def on_session_ended(self) -> None:
+    def on_session_ended(self) -> None:
         """Release image data and causal caches owned by the completed session."""
         backend = self._backend
         try:
             if backend is not None:
-                await asyncio.to_thread(backend.end_rollout)
+                backend.end_rollout()
         finally:
             self._selected_input = None
             self._image_source = "none"
@@ -378,7 +377,7 @@ class MatrixGame2(ReactorPipeline):
                     continue
                 self.state._restart_requested = False
                 image = load_input_image(selected_input)
-                await asyncio.to_thread(backend.reset, image, self._seed)
+                backend.reset(image, self._seed)
                 if self.state._restart_requested:
                     continue
                 self._chunk_index = 0
@@ -402,7 +401,7 @@ class MatrixGame2(ReactorPipeline):
             self._chunk_in_flight = True
             started_at = time.perf_counter()
             try:
-                frames = await asyncio.to_thread(backend.generate_chunk, action)
+                frames = backend.generate_chunk(action)
             finally:
                 self._chunk_in_flight = False
             inference_seconds = time.perf_counter() - started_at

--- a/models/matrix-game-2-0/matrix_game_2.py
+++ b/models/matrix-game-2-0/matrix_game_2.py
@@ -29,7 +29,7 @@ from matrix_game_2_assets import (
     read_config,
     validate_uploaded_image,
 )
-from matrix_game_2_backend import FPS, ChunkAction, MatrixGame2Backend
+from matrix_game_2_backend import FRAMES_PER_CHUNK, ChunkAction, MatrixGame2Backend
 from matrix_game_2_types import (
     KEYBOARD_KEYS,
     ActionChanged,
@@ -50,8 +50,7 @@ class MatrixGame2(ReactorPipeline):
 
     state: MatrixGame2State
     output: MatrixGame2Output
-    fps = FPS
-    buffer_size = 1
+    buffer_size = FRAMES_PER_CHUNK
 
     def __init__(self) -> None:
         super().__init__()
@@ -81,13 +80,11 @@ class MatrixGame2(ReactorPipeline):
         self._config = config
         self._backend = backend
         self._seed = config.seed
-        self.output.fps = FPS
         logger.info(
             "Matrix-Game-2.0 model ready",
             source_revision=config.source_revision,
             checkpoint_revision=config.model_revision,
             max_chunks=config.max_chunks,
-            fps=FPS,
         )
 
     @session_started

--- a/models/matrix-game-2-0/matrix_game_2.yaml
+++ b/models/matrix-game-2-0/matrix_game_2.yaml
@@ -1,0 +1,26 @@
+source:
+  # Relative paths are resolved below REACTOR_WEIGHTS_PATH. Set
+  # MATRIX_GAME_2_PATH to reuse an existing Matrix-Game-2 source directory.
+  path: Matrix-Game
+  url: https://github.com/SkyworkAI/Matrix-Game.git
+  revision: 71c3cd7f741311f8100f6cf9cde942b6c1378d11
+
+model:
+  # The universal distilled checkpoint has the broadest control and image
+  # coverage while retaining the fastest official three-step denoising path.
+  repo_id: Skywork/Matrix-Game-2.0
+  revision: f1729d99a80e0f07993a77d7dad4a3190e23c2c8
+  checkpoint_file: base_distilled_model/base_distill.safetensors
+
+inference:
+  seed: 0
+  # This is the official streaming default: 360 latent frames, grouped into
+  # 120 native three-latent chunks. Keep it unchanged for memory evaluation.
+  max_latent_frames: 360
+
+inputs:
+  random_images:
+    - demo_images/universal/0000.png
+    - demo_images/universal/0002.png
+    - demo_images/universal/0011.png
+    - demo_images/universal/0016.png

--- a/models/matrix-game-2-0/matrix_game_2_assets.py
+++ b/models/matrix-game-2-0/matrix_game_2_assets.py
@@ -1,0 +1,314 @@
+"""Prepare public Matrix-Game-2.0 source, weights, and image inputs."""
+
+from __future__ import annotations
+
+import io
+import os
+import re
+import subprocess
+import tempfile
+from collections.abc import Mapping
+from contextlib import suppress
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from PIL import Image, ImageOps, UnidentifiedImageError
+from reactor_runtime import CommandError, UploadedFile, get_weights_path
+from reactor_runtime.log import get_logger
+
+from matrix_game_2_types import MatrixGame2Config
+
+logger = get_logger(__name__)
+
+SOURCE_ENV = "MATRIX_GAME_2_PATH"
+_REVISION_PATTERN = re.compile(r"[0-9a-f]{40}")
+_UPLOAD_MAX_BYTES = 25 * 1024 * 1024
+_UPLOAD_MAX_PIXELS = 100_000_000
+_IMAGE_FORMATS = {"BMP", "JPEG", "PNG", "WEBP"}
+_MODEL_ALLOW_PATTERNS = (
+    "Wan2.1_VAE.pth",
+    "models_clip_open-clip-xlm-roberta-large-vit-huge-14.pth",
+    "xlm-roberta-large/*",
+    "base_distilled_model/base_distill.safetensors",
+)
+
+
+def read_config(config_path: Path | None) -> MatrixGame2Config:
+    """Read and validate the Matrix-Game-2.0 adapter YAML."""
+    if config_path is None:
+        raise ValueError("Matrix-Game-2.0 requires runtime.config in reactor.yaml")
+    document = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise TypeError(f"{config_path}: expected a YAML mapping")
+
+    source = _mapping(document.get("source"), "source")
+    model = _mapping(document.get("model"), "model")
+    inference = _mapping(document.get("inference"), "inference")
+    inputs = _mapping(document.get("inputs"), "inputs")
+
+    configured_source = os.environ.get(SOURCE_ENV)
+    if configured_source:
+        source_path = Path(configured_source).expanduser().resolve()
+        checkout_path = source_path.parent
+    else:
+        checkout_value = str(source.get("path", "Matrix-Game"))
+        checkout_path = _weights_relative_path(checkout_value)
+        source_path = checkout_path / "Matrix-Game-2"
+
+    max_latent_frames = int(inference.get("max_latent_frames", 360))
+    if max_latent_frames != 360:
+        raise ValueError(
+            "inference.max_latent_frames must remain 360 to match the official rollout"
+        )
+
+    random_values = inputs.get("random_images")
+    if not isinstance(random_values, list) or not random_values:
+        raise ValueError("inputs.random_images must be a non-empty list")
+    random_images = tuple(
+        source_path / _relative_path(value, "inputs.random_images")
+        for value in random_values
+    )
+
+    repo_id = str(model.get("repo_id", ""))
+    if "/" not in repo_id:
+        raise ValueError("model.repo_id must identify a public Hugging Face repository")
+    checkpoint_file = str(
+        model.get(
+            "checkpoint_file",
+            "base_distilled_model/base_distill.safetensors",
+        )
+    )
+    if checkpoint_file != "base_distilled_model/base_distill.safetensors":
+        raise ValueError(
+            "model.checkpoint_file must select the universal distilled checkpoint"
+        )
+
+    return MatrixGame2Config(
+        checkout_path=checkout_path,
+        source_path=source_path,
+        source_url=_public_url(source.get("url"), "source.url"),
+        source_revision=_revision(source.get("revision"), "source.revision"),
+        model_repo_id=repo_id,
+        model_revision=_revision(model.get("revision"), "model.revision"),
+        model_cache=get_weights_path() / "matrix-game-2-0" / "huggingface",
+        checkpoint_file=checkpoint_file,
+        seed=int(inference.get("seed", 0)),
+        max_latent_frames=max_latent_frames,
+        random_images=random_images,
+    )
+
+
+def prepare_runtime_assets(config: MatrixGame2Config) -> Path:
+    """Prepare the pinned upstream checkout and distilled public checkpoint."""
+    ensure_source_checkout(config)
+    _validate_source_files(config)
+    for image in config.random_images:
+        if not image.is_file():
+            raise FileNotFoundError(
+                f"configured Matrix example image does not exist: {image}"
+            )
+
+    from huggingface_hub import snapshot_download
+
+    config.model_cache.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        "preparing Matrix-Game-2.0 checkpoint",
+        repo_id=config.model_repo_id,
+        revision=config.model_revision,
+        cache=str(config.model_cache),
+    )
+    snapshot = Path(
+        snapshot_download(
+            repo_id=config.model_repo_id,
+            revision=config.model_revision,
+            cache_dir=config.model_cache,
+            allow_patterns=list(_MODEL_ALLOW_PATTERNS),
+        )
+    )
+    _validate_model_snapshot(config, snapshot)
+    return snapshot
+
+
+def ensure_source_checkout(config: MatrixGame2Config) -> None:
+    """Clone the pinned public source when it is absent and verify its revision."""
+    if not config.source_path.exists():
+        if os.environ.get(SOURCE_ENV):
+            raise FileNotFoundError(
+                f"{SOURCE_ENV} does not exist: {config.source_path}"
+            )
+        destination = config.checkout_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "downloading Matrix source checkout",
+            url=config.source_url,
+            revision=config.source_revision,
+            destination=str(destination),
+        )
+        with tempfile.TemporaryDirectory(
+            prefix=".reactor-matrix-game-2-",
+            dir=destination.parent,
+        ) as temporary:
+            checkout = Path(temporary) / "checkout"
+            _run_git(
+                [
+                    "clone",
+                    "--filter=blob:none",
+                    "--no-checkout",
+                    "--sparse",
+                    config.source_url,
+                    str(checkout),
+                ]
+            )
+            _run_git(["-C", str(checkout), "sparse-checkout", "set", "Matrix-Game-2"])
+            _run_git(
+                ["-C", str(checkout), "checkout", "--detach", config.source_revision]
+            )
+            with suppress(FileExistsError):
+                checkout.rename(destination)
+    if not config.source_path.is_dir():
+        raise FileNotFoundError(
+            f"Matrix-Game-2 source directory does not exist: {config.source_path}"
+        )
+    actual = _run_git(
+        ["-C", str(config.source_path), "rev-parse", "HEAD"]
+    ).stdout.strip()
+    if actual != config.source_revision:
+        raise RuntimeError(
+            f"Matrix source revision is {actual}; expected {config.source_revision}"
+        )
+
+
+def validate_uploaded_image(image: UploadedFile) -> None:
+    """Reject oversized, mislabeled, or undecodable uploaded image bytes."""
+    if not image.mime_type.startswith("image/"):
+        raise CommandError("unsupported_media", f"{image.name} is not an image.")
+    if not image.data:
+        raise CommandError("invalid_image", f"{image.name} is empty.")
+    if image.size > _UPLOAD_MAX_BYTES:
+        raise CommandError(
+            "image_too_large",
+            f"{image.name} exceeds the {_UPLOAD_MAX_BYTES // (1024 * 1024)} MiB limit.",
+        )
+    try:
+        with Image.open(io.BytesIO(image.data)) as decoded:
+            if decoded.format not in _IMAGE_FORMATS:
+                raise CommandError(
+                    "unsupported_media",
+                    f"{image.name} must be JPEG, PNG, WebP, or BMP.",
+                )
+            width, height = decoded.size
+            if width <= 0 or height <= 0 or width * height > _UPLOAD_MAX_PIXELS:
+                raise CommandError(
+                    "image_too_large",
+                    f"{image.name} exceeds the {_UPLOAD_MAX_PIXELS}-pixel limit.",
+                )
+            decoded.verify()
+    except CommandError:
+        raise
+    except (OSError, UnidentifiedImageError, ValueError) as error:
+        raise CommandError(
+            "invalid_image", f"{image.name} cannot be decoded."
+        ) from error
+
+
+def load_input_image(value: Path | UploadedFile) -> Image.Image:
+    """Return one EXIF-corrected RGB image from a path or uploaded bytes."""
+    try:
+        if isinstance(value, UploadedFile):
+            source: str | io.BytesIO = io.BytesIO(value.data)
+        else:
+            source = str(value)
+        with Image.open(source) as decoded:
+            return ImageOps.exif_transpose(decoded).convert("RGB")
+    except (OSError, UnidentifiedImageError, ValueError) as error:
+        name = value.name
+        raise RuntimeError(f"failed to load Matrix starting image: {name}") from error
+
+
+def _validate_source_files(config: MatrixGame2Config) -> None:
+    """Raise a precise error when a required upstream inference file is absent."""
+    required = (
+        "configs/inference_yaml/inference_universal.yaml",
+        "configs/distilled_model/universal/config.json",
+        "pipeline/causal_inference.py",
+        "demo_utils/vae_block3.py",
+        "wan/vae/wanx_vae.py",
+    )
+    missing = [
+        relative
+        for relative in required
+        if not (config.source_path / relative).is_file()
+    ]
+    if missing:
+        raise FileNotFoundError(
+            "Matrix source is missing required inference files: " + ", ".join(missing)
+        )
+
+
+def _validate_model_snapshot(config: MatrixGame2Config, snapshot: Path) -> None:
+    """Raise a precise error when the downloaded inference snapshot is incomplete."""
+    required = (
+        config.checkpoint_file,
+        "Wan2.1_VAE.pth",
+        "models_clip_open-clip-xlm-roberta-large-vit-huge-14.pth",
+        "xlm-roberta-large/tokenizer.json",
+    )
+    missing = [relative for relative in required if not (snapshot / relative).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            "Matrix checkpoint snapshot is missing required files: "
+            + ", ".join(missing)
+        )
+
+
+def _mapping(value: object, name: str) -> dict[str, Any]:
+    """Return a YAML mapping or raise a precise configuration error."""
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{name} must be a YAML mapping")
+    return cast(dict[str, Any], dict(value))
+
+
+def _relative_path(value: object, name: str) -> Path:
+    """Return a safe path relative to the upstream source root."""
+    path = Path(str(value))
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(
+            f"{name} entries must be relative paths inside the source checkout"
+        )
+    return path
+
+
+def _weights_relative_path(value: str) -> Path:
+    """Resolve a configured checkout directory under Runtime's weights root."""
+    path = Path(value).expanduser()
+    return path if path.is_absolute() else get_weights_path() / path
+
+
+def _revision(value: object, name: str) -> str:
+    """Return one full immutable Git-style revision."""
+    revision = str(value or "")
+    if not _REVISION_PATTERN.fullmatch(revision):
+        raise ValueError(f"{name} must be a full 40-character revision")
+    return revision
+
+
+def _public_url(value: object, name: str) -> str:
+    """Return one public HTTPS repository URL."""
+    url = str(value or "")
+    if not url.startswith("https://"):
+        raise ValueError(f"{name} must be a public HTTPS URL")
+    return url
+
+
+def _run_git(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run Git without an interactive credential prompt."""
+    environment = os.environ.copy()
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    return subprocess.run(
+        ["git", *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )

--- a/models/matrix-game-2-0/matrix_game_2_backend.py
+++ b/models/matrix-game-2-0/matrix_game_2_backend.py
@@ -1,0 +1,444 @@
+"""Run the upstream Matrix-Game-2.0 causal rollout one native chunk at a time."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from reactor_runtime.log import get_logger
+
+logger = get_logger(__name__)
+
+LATENTS_PER_CHUNK = 3
+LATENT_HEIGHT = 44
+LATENT_WIDTH = 80
+FRAME_HEIGHT = 352
+FRAME_WIDTH = 640
+FPS = 25
+
+_KEYBOARD_VECTOR_ORDER = ("w", "s", "a", "d")
+_NATIVE_CAMERA_SCALE = 0.1
+
+
+def _keyboard_vector(pressed_keys: tuple[str, ...]) -> tuple[float, ...]:
+    unsupported_keys = set(pressed_keys).difference(_KEYBOARD_VECTOR_ORDER)
+    if unsupported_keys:
+        raise ValueError(
+            f"unsupported Matrix keyboard keys: {sorted(unsupported_keys)}"
+        )
+    return tuple(float(key in pressed_keys) for key in _KEYBOARD_VECTOR_ORDER)
+
+
+def _mouse_vector(pitch: float, yaw: float) -> tuple[float, float]:
+    if not -1.0 <= pitch <= 1.0 or not -1.0 <= yaw <= 1.0:
+        raise ValueError("Matrix pitch and yaw must remain in [-1, 1]")
+    return pitch * _NATIVE_CAMERA_SCALE, yaw * _NATIVE_CAMERA_SCALE
+
+
+@dataclass(frozen=True)
+class ChunkAction:
+    """Hold the universal checkpoint controls sampled for one chunk."""
+
+    pressed_keys: tuple[str, ...]
+    pitch: float
+    yaw: float
+
+
+class MatrixGame2Backend:
+    """Own model weights and the active upstream autoregressive cache state."""
+
+    def __init__(
+        self,
+        *,
+        source_path: Path,
+        model_path: Path,
+        checkpoint_file: str,
+        max_latent_frames: int,
+    ) -> None:
+        self._source_path = source_path
+        self._model_path = model_path
+        self._checkpoint_file = checkpoint_file
+        self._max_latent_frames = max_latent_frames
+        self._current_start_frame = 0
+        self._conditional_dict: dict[str, Any] | None = None
+        self._sampled_noise: Any = None
+        self._vae_cache: list[Any] | None = None
+
+        modules = self._load_upstream_modules(source_path)
+        self._torch = modules["torch"]
+        self._rearrange = modules["rearrange"]
+        self._cond_current = modules["cond_current"]
+        self._zero_vae_cache = modules["zero_vae_cache"]
+        self._set_seed = modules["set_seed"]
+        self._transforms = modules["transforms"]
+
+        torch = self._torch
+        if not torch.cuda.is_available():
+            raise RuntimeError("Matrix-Game-2.0 requires a CUDA accelerator")
+        self._device = torch.device("cuda")
+        self._weight_dtype = torch.bfloat16
+
+        inference_config = modules["OmegaConf"].load(
+            source_path / "configs/inference_yaml/inference_universal.yaml"
+        )
+        inference_config.model_kwargs.model_config = str(
+            source_path / "configs/distilled_model/universal"
+        )
+        if str(inference_config.mode) != "universal":
+            raise ValueError("Matrix adapter requires the universal inference mode")
+        if int(inference_config.num_frame_per_block) != LATENTS_PER_CHUNK:
+            raise ValueError(
+                f"Matrix universal inference must use {LATENTS_PER_CHUNK} latents per chunk"
+            )
+
+        generator = modules["WanDiffusionWrapper"](
+            **getattr(inference_config, "model_kwargs", {}),
+            is_causal=True,
+        )
+        vae_decoder = modules["VAEDecoderWrapper"]()
+        vae_weights = torch.load(
+            model_path / "Wan2.1_VAE.pth",
+            map_location="cpu",
+            weights_only=True,
+        )
+        decoder_weights = {
+            key: value
+            for key, value in vae_weights.items()
+            if "decoder." in key or "conv2" in key
+        }
+        vae_decoder.load_state_dict(decoder_weights)
+        vae_decoder.to(self._device, torch.float16)
+        vae_decoder.requires_grad_(False)
+        vae_decoder.eval()
+
+        pipeline = modules["CausalInferenceStreamingPipeline"](
+            inference_config,
+            generator=generator,
+            vae_decoder=vae_decoder,
+        )
+        checkpoint = model_path / checkpoint_file
+        pipeline.generator.load_state_dict(modules["load_file"](checkpoint))
+        pipeline = pipeline.to(device=self._device, dtype=self._weight_dtype)
+        pipeline.vae_decoder.to(torch.float16)
+        pipeline.requires_grad_(False)
+        pipeline.eval()
+        if int(pipeline.local_attn_size) != 6:
+            raise ValueError(
+                "the universal distilled checkpoint must retain local_attn_size=6"
+            )
+
+        vae = modules["get_wanx_vae_wrapper"](model_path, torch.float16)
+        vae.requires_grad_(False)
+        vae.eval()
+        vae = vae.to(self._device, self._weight_dtype)
+
+        self._config = inference_config
+        self._pipeline = pipeline
+        self._vae = vae
+        self._frame_process = self._transforms.Compose(
+            [
+                self._transforms.Resize(
+                    size=(FRAME_HEIGHT, FRAME_WIDTH), antialias=True
+                ),
+                self._transforms.ToTensor(),
+                self._transforms.Normalize(
+                    mean=[0.5, 0.5, 0.5],
+                    std=[0.5, 0.5, 0.5],
+                ),
+            ]
+        )
+        logger.info(
+            "Matrix-Game-2.0 upstream backend ready",
+            checkpoint=str(checkpoint),
+            local_attention_frames=int(pipeline.local_attn_size),
+            latent_frames_per_chunk=LATENTS_PER_CHUNK,
+        )
+
+    @property
+    def completed_chunks(self) -> int:
+        """Return the number of chunks already committed to the active caches."""
+        return self._current_start_frame // LATENTS_PER_CHUNK
+
+    def reset(self, image: Image.Image, seed: int) -> None:
+        """Initialize official image conditioning, noise, and empty causal caches."""
+        torch = self._torch
+        self._set_seed(seed)
+        image = self._resize_crop(image, FRAME_HEIGHT, FRAME_WIDTH)
+        image_tensor = self._frame_process(image)[None, :, None, :, :].to(
+            dtype=self._weight_dtype,
+            device=self._device,
+        )
+
+        padding_frames = 4 * (self._max_latent_frames - 1)
+        padding_video = torch.zeros_like(image_tensor).repeat(
+            1,
+            1,
+            padding_frames,
+            1,
+            1,
+        )
+        image_condition = torch.concat([image_tensor, padding_video], dim=2)
+        image_condition = self._vae.encode(
+            image_condition,
+            device=self._device,
+            tiled=True,
+            tile_size=[44, 80],
+            tile_stride=[23, 38],
+        ).to(self._device)
+        mask_condition = torch.ones_like(image_condition)
+        mask_condition[:, :, 1:] = 0
+        condition_concat = torch.cat(
+            [mask_condition[:, :4], image_condition],
+            dim=1,
+        )
+        visual_context = self._vae.clip.encode_video(image_tensor)
+
+        rgb_action_frames = (self._max_latent_frames - 1) * 4 + 1
+        self._conditional_dict = {
+            "cond_concat": condition_concat.to(
+                device=self._device,
+                dtype=self._weight_dtype,
+            ),
+            "visual_context": visual_context.to(
+                device=self._device,
+                dtype=self._weight_dtype,
+            ),
+            "mouse_cond": torch.zeros(
+                (1, rgb_action_frames, 2),
+                device=self._device,
+                dtype=self._weight_dtype,
+            ),
+            "keyboard_cond": torch.zeros(
+                (1, rgb_action_frames, 4),
+                device=self._device,
+                dtype=self._weight_dtype,
+            ),
+        }
+        self._sampled_noise = torch.randn(
+            (
+                1,
+                16,
+                self._max_latent_frames,
+                LATENT_HEIGHT,
+                LATENT_WIDTH,
+            ),
+            device=self._device,
+            dtype=self._weight_dtype,
+        )
+        self._vae_cache = [None for _ in self._zero_vae_cache]
+        self._current_start_frame = 0
+        self._initialize_upstream_caches()
+
+    def generate_chunk(self, action: ChunkAction) -> np.ndarray:
+        """Advance the exact upstream denoise/cache/decode sequence by one chunk."""
+        torch = self._torch
+        conditional_dict = self._conditional_dict
+        sampled_noise = self._sampled_noise
+        vae_cache = self._vae_cache
+        if conditional_dict is None or sampled_noise is None or vae_cache is None:
+            raise RuntimeError("select a Matrix starting image before generating")
+        if self._current_start_frame + LATENTS_PER_CHUNK > self._max_latent_frames:
+            raise RuntimeError("Matrix rollout has reached its official latent horizon")
+        start = self._current_start_frame
+        noisy_input = sampled_noise[:, :, start : start + LATENTS_PER_CHUNK]
+        replacement = {
+            "keyboard": torch.tensor(
+                _keyboard_vector(action.pressed_keys),
+                device=self._device,
+                dtype=self._weight_dtype,
+            ),
+            "mouse": torch.tensor(
+                _mouse_vector(action.pitch, action.yaw),
+                device=self._device,
+                dtype=self._weight_dtype,
+            ),
+        }
+        chunk_condition, self._conditional_dict = self._cond_current(
+            conditional_dict,
+            start,
+            LATENTS_PER_CHUNK,
+            replace=replacement,
+            mode="universal",
+        )
+
+        with torch.inference_mode():
+            for index, current_timestep in enumerate(
+                self._pipeline.denoising_step_list
+            ):
+                timestep = (
+                    torch.ones(
+                        (1, LATENTS_PER_CHUNK),
+                        device=self._device,
+                        dtype=torch.int64,
+                    )
+                    * current_timestep
+                )
+                _, denoised_prediction = self._pipeline.generator(
+                    noisy_image_or_video=noisy_input,
+                    conditional_dict=chunk_condition,
+                    timestep=timestep,
+                    kv_cache=self._pipeline.kv_cache1,
+                    kv_cache_mouse=self._pipeline.kv_cache_mouse,
+                    kv_cache_keyboard=self._pipeline.kv_cache_keyboard,
+                    crossattn_cache=self._pipeline.crossattn_cache,
+                    current_start=start * self._pipeline.frame_seq_length,
+                )
+                if index < len(self._pipeline.denoising_step_list) - 1:
+                    next_timestep = self._pipeline.denoising_step_list[index + 1]
+                    flat_prediction = self._rearrange(
+                        denoised_prediction,
+                        "b c f h w -> (b f) c h w",
+                    )
+                    noisy_input = self._pipeline.scheduler.add_noise(
+                        flat_prediction,
+                        torch.randn_like(flat_prediction),
+                        next_timestep
+                        * torch.ones(
+                            (LATENTS_PER_CHUNK,),
+                            device=self._device,
+                            dtype=torch.long,
+                        ),
+                    )
+                    noisy_input = self._rearrange(
+                        noisy_input,
+                        "(b f) c h w -> b c f h w",
+                        b=denoised_prediction.shape[0],
+                    )
+
+            context_timestep = torch.ones_like(timestep) * self._config.context_noise
+            self._pipeline.generator(
+                noisy_image_or_video=denoised_prediction,
+                conditional_dict=chunk_condition,
+                timestep=context_timestep,
+                kv_cache=self._pipeline.kv_cache1,
+                kv_cache_mouse=self._pipeline.kv_cache_mouse,
+                kv_cache_keyboard=self._pipeline.kv_cache_keyboard,
+                crossattn_cache=self._pipeline.crossattn_cache,
+                current_start=start * self._pipeline.frame_seq_length,
+            )
+            video, updated_vae_cache = self._pipeline.vae_decoder(
+                denoised_prediction.transpose(1, 2).half(),
+                *vae_cache,
+            )
+
+        self._vae_cache = updated_vae_cache
+        self._current_start_frame += LATENTS_PER_CHUNK
+        frames = self._rearrange(video, "B T C H W -> B T H W C")
+        frames = (
+            ((frames.float() + 1) * 127.5).clip(0, 255).to(torch.uint8).cpu().numpy()[0]
+        )
+        expected_frames = 9 if self.completed_chunks == 1 else 12
+        if frames.shape != (expected_frames, FRAME_HEIGHT, FRAME_WIDTH, 3):
+            raise RuntimeError(
+                "unexpected Matrix causal decode shape: "
+                f"expected {(expected_frames, FRAME_HEIGHT, FRAME_WIDTH, 3)}, "
+                f"got {frames.shape}"
+            )
+        return np.ascontiguousarray(frames)
+
+    def end_rollout(self) -> None:
+        """Release image conditioning and all session-scoped causal caches."""
+        self._conditional_dict = None
+        self._sampled_noise = None
+        self._vae_cache = None
+        self._current_start_frame = 0
+        self._pipeline.kv_cache1 = None
+        self._pipeline.kv_cache_mouse = None
+        self._pipeline.kv_cache_keyboard = None
+        self._pipeline.crossattn_cache = None
+        self._torch.cuda.empty_cache()
+
+    def _initialize_upstream_caches(self) -> None:
+        """Allocate caches with the upstream checkpoint's native local window."""
+        pipeline = self._pipeline
+        pipeline.kv_cache1 = None
+        pipeline.kv_cache_mouse = None
+        pipeline.kv_cache_keyboard = None
+        pipeline.crossattn_cache = None
+        pipeline._initialize_kv_cache(
+            batch_size=1,
+            dtype=self._weight_dtype,
+            device=self._device,
+        )
+        pipeline._initialize_kv_cache_mouse_and_keyboard(
+            batch_size=1,
+            dtype=self._weight_dtype,
+            device=self._device,
+        )
+        pipeline._initialize_crossattn_cache(
+            batch_size=1,
+            dtype=self._weight_dtype,
+            device=self._device,
+        )
+
+    @staticmethod
+    def _resize_crop(image: Image.Image, height: int, width: int) -> Image.Image:
+        """Apply the same centered aspect-ratio crop as official streaming inference."""
+        source_width, source_height = image.size
+        if source_height / source_width > height / width:
+            new_width = source_width
+            new_height = int(new_width * height / width)
+        else:
+            new_height = source_height
+            new_width = int(new_height * width / height)
+        left = (source_width - new_width) / 2
+        top = (source_height - new_height) / 2
+        right = (source_width + new_width) / 2
+        bottom = (source_height + new_height) / 2
+        return image.crop((left, top, right, bottom))
+
+    @staticmethod
+    def _load_upstream_modules(source_path: Path) -> dict[str, Any]:
+        """Import only modules exercised by the official streaming inference path."""
+        source = str(source_path)
+        if source not in sys.path:
+            sys.path.insert(0, source)
+
+        import torch
+        from einops import rearrange
+        from omegaconf import OmegaConf
+        from safetensors.torch import load_file
+        from torchvision.transforms import v2
+
+        causal_inference = importlib.import_module("pipeline.causal_inference")
+        constants = importlib.import_module("demo_utils.constant")
+        misc = importlib.import_module("utils.misc")
+        vae_block = importlib.import_module("demo_utils.vae_block3")
+        wan_wrapper = importlib.import_module("utils.wan_wrapper")
+        wanx_vae = importlib.import_module("wan.vae.wanx_vae")
+
+        expected_root = source_path.resolve()
+        for module in (
+            causal_inference,
+            constants,
+            misc,
+            vae_block,
+            wan_wrapper,
+            wanx_vae,
+        ):
+            module_file = Path(module.__file__).resolve()
+            if expected_root not in module_file.parents:
+                raise RuntimeError(
+                    f"upstream module {module.__name__} resolved outside {source_path}: "
+                    f"{module_file}"
+                )
+
+        return {
+            "torch": torch,
+            "rearrange": rearrange,
+            "OmegaConf": OmegaConf,
+            "load_file": load_file,
+            "transforms": v2,
+            "CausalInferenceStreamingPipeline": causal_inference.CausalInferenceStreamingPipeline,
+            "cond_current": causal_inference.cond_current,
+            "zero_vae_cache": constants.ZERO_VAE_CACHE,
+            "set_seed": misc.set_seed,
+            "VAEDecoderWrapper": vae_block.VAEDecoderWrapper,
+            "WanDiffusionWrapper": wan_wrapper.WanDiffusionWrapper,
+            "get_wanx_vae_wrapper": wanx_vae.get_wanx_vae_wrapper,
+        }

--- a/models/matrix-game-2-0/matrix_game_2_backend.py
+++ b/models/matrix-game-2-0/matrix_game_2_backend.py
@@ -20,6 +20,8 @@ LATENT_WIDTH = 80
 FRAME_HEIGHT = 352
 FRAME_WIDTH = 640
 FPS = 25
+FIRST_CHUNK_FRAMES = 9
+FRAMES_PER_CHUNK = 12
 
 _KEYBOARD_VECTOR_ORDER = ("w", "s", "a", "d")
 _NATIVE_CAMERA_SCALE = 0.1
@@ -332,7 +334,9 @@ class MatrixGame2Backend:
         frames = (
             ((frames.float() + 1) * 127.5).clip(0, 255).to(torch.uint8).cpu().numpy()[0]
         )
-        expected_frames = 9 if self.completed_chunks == 1 else 12
+        expected_frames = (
+            FIRST_CHUNK_FRAMES if self.completed_chunks == 1 else FRAMES_PER_CHUNK
+        )
         if frames.shape != (expected_frames, FRAME_HEIGHT, FRAME_WIDTH, 3):
             raise RuntimeError(
                 "unexpected Matrix causal decode shape: "

--- a/models/matrix-game-2-0/matrix_game_2_types.py
+++ b/models/matrix-game-2-0/matrix_game_2_types.py
@@ -1,0 +1,246 @@
+"""Define Matrix-Game-2.0 configuration and public Reactor schema."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from reactor_runtime import (
+    InputField,
+    InputState,
+    MessageField,
+    ModelMessage,
+    Output,
+    Video,
+)
+
+KEYBOARD_KEYS = ["w", "a", "s", "d"]
+
+
+@dataclass(frozen=True)
+class MatrixGame2Config:
+    """Hold validated source, checkpoint, and rollout settings."""
+
+    checkout_path: Path
+    source_path: Path
+    source_url: str
+    source_revision: str
+    model_repo_id: str
+    model_revision: str
+    model_cache: Path
+    checkpoint_file: str
+    seed: int
+    max_latent_frames: int
+    random_images: tuple[Path, ...]
+
+    @property
+    def max_chunks(self) -> int:
+        """Return the number of native three-latent chunks in one rollout."""
+        return self.max_latent_frames // 3
+
+
+class MatrixGame2Output(Output):
+    """Stream one generated Matrix-Game-2.0 RGB frame on `main_video`."""
+
+    main_video: Video
+
+
+class StateUpdate(ModelMessage):
+    """Emitted after connection, accepted commands, and completed chunks."""
+
+    image_source: str = MessageField(
+        description=(
+            "Source of the selected starting image: `built_in`, `upload`, or `none` before "
+            "an image has been selected."
+        )
+    )
+    image_name: str = MessageField(
+        description=(
+            "Filename of the selected starting image, or an empty string before selection. "
+            "The image becomes active when a queued reset begins."
+        )
+    )
+    seed: int = MessageField(
+        description=(
+            "Random seed used by the current or queued rollout. A non-negative `seed` passed "
+            "to `reset` replaces it."
+        )
+    )
+    paused: bool = MessageField(
+        description=(
+            "Whether continuous generation stops before the next native chunk. An in-flight "
+            "chunk can still finish."
+        )
+    )
+    step_queued: bool = MessageField(
+        description=(
+            "Whether exactly one chunk is queued while paused. It returns to false when that "
+            "chunk starts or another playback command cancels it."
+        )
+    )
+    reset_queued: bool = MessageField(
+        description=(
+            "Whether the selected image is waiting to initialize a fresh autoregressive "
+            "rollout before another chunk is generated."
+        )
+    )
+    chunk_in_flight: bool = MessageField(
+        description=(
+            "Whether the GPU is currently generating one three-latent chunk. Commands "
+            "accepted while true apply at the following chunk boundary."
+        )
+    )
+    limit_reached: bool = MessageField(
+        description=(
+            "Whether the official 360-latent rollout horizon is exhausted. When true, "
+            "`reset`, `set_image`, or `random_image` is required before generation continues."
+        )
+    )
+    completed_chunks: int = MessageField(
+        description=(
+            "Number of native three-latent chunks completed in the active rollout. It returns "
+            "to zero when a fresh image-conditioned rollout begins."
+        )
+    )
+    next_chunk: int | None = MessageField(
+        description=(
+            "One-based chunk expected to consume controls accepted now, or null before image "
+            "selection and after the rollout horizon is exhausted."
+        )
+    )
+    max_chunks: int = MessageField(
+        description=(
+            "Number of three-latent chunks available in the official 360-latent rollout "
+            "horizon. The universal distilled checkpoint uses 120."
+        )
+    )
+    last_chunk_frames: int = MessageField(
+        description=(
+            "Number of RGB frames emitted by the most recently completed chunk. It is 9 for "
+            "the first causal VAE decode, 12 thereafter, and 0 before generation."
+        )
+    )
+    pressed_keys: list[str] = MessageField(
+        description=(
+            "Sorted WASD keys held for `next_chunk`. Multiple keys produce the official "
+            "multi-hot keyboard condition, such as `w` plus `a` for forward-left."
+        )
+    )
+    pitch: float = MessageField(
+        description=(
+            "Normalized look-down (-1) to look-up (1) velocity held for `next_chunk`; zero "
+            "is neutral."
+        )
+    )
+    yaw: float = MessageField(
+        description=(
+            "Normalized turn-left (-1) to turn-right (1) velocity held for `next_chunk`; "
+            "zero is neutral."
+        )
+    )
+
+
+class ChunkComplete(ModelMessage):
+    """Emitted after one native autoregressive chunk finishes on the GPU."""
+
+    chunk: int = MessageField(
+        description="One-based index of the chunk that finished in the active rollout."
+    )
+    frames: int = MessageField(
+        description=(
+            "Number of decoded RGB frames in this chunk: 9 for chunk 1 and 12 for later "
+            "chunks."
+        )
+    )
+    inference_seconds: float = MessageField(
+        description=(
+            "Wall-clock seconds spent generating and causally decoding this chunk, excluding "
+            "video playout time."
+        )
+    )
+    pressed_keys: list[str] = MessageField(
+        description="Sorted WASD keys sampled as a multi-hot condition for this chunk."
+    )
+    pitch: float = MessageField(
+        description="Normalized pitch velocity sampled for this completed chunk."
+    )
+    yaw: float = MessageField(
+        description="Normalized yaw velocity sampled for this completed chunk."
+    )
+
+
+class ActionChanged(ModelMessage):
+    """Emitted when `set_key_state` changes one held WASD key."""
+
+    key: str = MessageField(description="WASD key addressed by the control event.")
+    pressed: bool = MessageField(
+        description="Whether the addressed key is now held for forthcoming chunks."
+    )
+    pressed_keys: list[str] = MessageField(
+        description="Complete sorted WASD key set held after applying the event."
+    )
+    applies_to_chunk: int = MessageField(
+        description="One-based chunk that will first sample the updated multi-hot key state."
+    )
+
+
+class CameraMotionChanged(ModelMessage):
+    """Emitted when a continuous camera event changes forthcoming motion."""
+
+    pitch: float = MessageField(
+        description="Look-down (-1) to look-up (1) velocity held for forthcoming chunks."
+    )
+    yaw: float = MessageField(
+        description="Turn-left (-1) to turn-right (1) velocity held for forthcoming chunks."
+    )
+    applies_to_chunk: int = MessageField(
+        description="One-based chunk that will first sample both camera values."
+    )
+
+
+class RolloutLimitReached(ModelMessage):
+    """Emitted when generation pauses at the official latent horizon."""
+
+    completed_chunks: int = MessageField(
+        description="Number of completed chunks when the rollout reached its horizon."
+    )
+    max_chunks: int = MessageField(
+        description=(
+            "Configured chunk horizon now exhausted; select an image or call `reset` to start "
+            "a fresh rollout."
+        )
+    )
+
+
+class MatrixGame2State(InputState):
+    """Expose shared Matrix keyboard, mouse-camera, and playback controls."""
+
+    paused: bool = InputField(
+        default=True,
+        description=(
+            "Whether continuous `main_video` generation is paused before the next chunk. "
+            "Image selection and `reset` still queue one visible chunk while true."
+        ),
+    )
+    pitch: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Normalized look-down (-1) to look-up (1) velocity sampled at chunk boundaries "
+            "and held until `set_pitch` changes it or controls are released."
+        ),
+    )
+    yaw: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Normalized turn-left (-1) to turn-right (1) velocity sampled at chunk boundaries "
+            "and held until `set_yaw` changes it or controls are released."
+        ),
+    )
+    _pressed_keys: frozenset[str] = frozenset()
+    _step_requested: bool = False
+    _restart_requested: bool = False
+    _limit_reached: bool = False

--- a/models/matrix-game-2-0/matrix_game_2_types.py
+++ b/models/matrix-game-2-0/matrix_game_2_types.py
@@ -40,7 +40,7 @@ class MatrixGame2Config:
 
 
 class MatrixGame2Output(Output):
-    """Stream one generated Matrix-Game-2.0 RGB frame on `main_video`."""
+    """Stream one generated Matrix-Game-2.0 RGB frame batch on `main_video`."""
 
     main_video: Video
 

--- a/models/matrix-game-2-0/matrix_game_2_types.py
+++ b/models/matrix-game-2-0/matrix_game_2_types.py
@@ -215,13 +215,7 @@ class RolloutLimitReached(ModelMessage):
 class MatrixGame2State(InputState):
     """Expose shared Matrix keyboard, mouse-camera, and playback controls."""
 
-    paused: bool = InputField(
-        default=True,
-        description=(
-            "Whether continuous `main_video` generation is paused before the next chunk. "
-            "Image selection and `reset` still queue one visible chunk while true."
-        ),
-    )
+    _paused: bool = False
     pitch: float = InputField(
         default=0.0,
         ge=-1.0,
@@ -244,3 +238,13 @@ class MatrixGame2State(InputState):
     _step_requested: bool = False
     _restart_requested: bool = False
     _limit_reached: bool = False
+
+    @property
+    def paused(self) -> bool:
+        """Return whether continuous chunk generation is paused."""
+        return self._paused
+
+    @paused.setter
+    def paused(self, value: bool) -> None:
+        """Set whether continuous chunk generation is paused."""
+        self._paused = value

--- a/models/matrix-game-2-0/reactor.yaml
+++ b/models/matrix-game-2-0/reactor.yaml
@@ -1,0 +1,60 @@
+$schema: reactor/v1
+
+# Reactor model spec for the Matrix-Game-2.0 universal distilled recipe.
+
+model:
+  # Change this name before publishing if it already belongs to another account.
+  name: matrix-game-2-0-universal-distilled
+  version: v0.0.1
+  description: |
+    Explore an autoregressive world from an image with composable WASD movement
+    and continuous pitch and yaw camera controls.
+
+  resources:
+    # The CUDA 12.8 and PyTorch 2.8 build includes Blackwell kernels. Model
+    # weights, action caches, visual context, and the causal VAE remain resident
+    # for the session, so the recipe requests one complete accelerator.
+    gpu:
+      type: NVIDIA_B200
+      count: 1
+    cpu:
+      request: "4"
+      limit: "8"
+    # Loading stages the generator, image encoder, and VAE through host memory.
+    memory:
+      request: 8Gi
+      limit: 48Gi
+
+runtime:
+  import: matrix_game_2:MatrixGame2
+  config: matrix_game_2.yaml
+
+  # `reactor run` bind-mounts this directory at the same absolute path inside
+  # the container. Source and checkpoints downloaded on first load survive
+  # image rebuilds and subsequent runs.
+  weights_path: ~/.cache/reactor_registry/matrix-game-2-0
+
+build:
+  # Reactor renders this image definition into a Dockerfile in memory. Keep
+  # reactor-runtime out of requirements.txt: this is its single version pin.
+  runtime_version: "3.1.2"
+  python_requirements: requirements.txt
+  cuda_version: "12.8.1"
+  python_version: "3.12"
+  system_packages:
+    - ffmpeg
+    - git
+    - libgl1
+    - libglib2.0-0
+  runtime_env:
+    TOKENIZERS_PARALLELISM: "false"
+
+recording:
+  enabled: true
+  chunk_seconds: 4
+  clip_max_seconds: 300
+  video_track: main_video
+  video:
+    codec: h264
+    preset: veryfast
+    crf: 23

--- a/models/matrix-game-2-0/reactor.yaml
+++ b/models/matrix-game-2-0/reactor.yaml
@@ -35,9 +35,8 @@ runtime:
   weights_path: ~/.cache/reactor_registry/matrix-game-2-0
 
 build:
-  # Reactor renders this image definition into a Dockerfile in memory. Keep
-  # reactor-runtime out of requirements.txt: this is its single version pin.
-  runtime_version: "3.1.2"
+  # Keep the Runtime release aligned with the adapter's public API usage.
+  runtime_version: "3.2.3"
   python_requirements: requirements.txt
   cuda_version: "12.8.1"
   python_version: "3.12"

--- a/models/matrix-game-2-0/requirements.txt
+++ b/models/matrix-game-2-0/requirements.txt
@@ -1,0 +1,23 @@
+# `build.cuda_version` supplies the CUDA 12.8 wheel index. The Runtime is
+# installed from `build.runtime_version` in reactor.yaml in the same uv pass.
+torch==2.8.0
+torchvision==0.23.0
+
+# Matrix-Game-2.0's native universal distilled inference path.
+numpy>=2.1,<3
+diffusers==0.35.1
+transformers>=4.49,<5
+huggingface-hub>=0.34,<2
+safetensors>=0.4
+omegaconf>=2.3
+einops>=0.7
+flash-attn @ https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3%2Bcu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
+opencv-python-headless>=4.10
+imageio>=2.34
+imageio-ffmpeg>=0.5
+pillow>=10.1
+pyyaml>=6.0
+tqdm>=4.66
+easydict>=1.13
+ftfy>=6.2
+regex>=2024.5


### PR DESCRIPTION
## Why

  Matrix-Game-2.0 provides a causal streaming inference path whose behavior depends on persistent diffusion, action,
  cross-attention, and VAE caches. The cookbook needs an interactive adapter that preserves this native rollout while
  exposing image conditioning, keyboard actions, camera controls, pause, and single-chunk stepping through Reactor.

  ## What Changed

  This adds an in-process adapter for the universal distilled checkpoint, pinned to immutable public source and model
  revisions. It advances one native three-latent chunk per inference turn while retaining the official local-attention
  window, cache updates, and 360-latent rollout horizon.

  The recipe exposes uploaded and public demo images, composable WASD controls, continuous pitch and yaw, pause, step,
  reset, typed state messages, and recording. Its image is generated from the `build:` configuration in `reactor.yaml`;
  no Dockerfile is checked in. The documented workflow uses `reactor build` and `reactor run`.

  The adapter was validated with the current Reactor CLI and tested on a B200 through 12 autoregressive chunks, covering
  diagonal and cardinal movement plus both camera axes. The model generated 141 frames and the Runtime recorder reported
  no dropped frames.