### PR TITLE
Add LingBot-World v1 Fast runtime adapter

### DIFF
--- a/models/lingbot-world-v1-fast/README.md
+++ b/models/lingbot-world-v1-fast/README.md
@@ -5,34 +5,30 @@ camera model as an interactive Reactor backend. A client can start from a
 built-in scene or uploaded image, change the prompt, apply six-axis camera
 motion, stream generated video, and record the session.
 
-The adapter and upstream implementation remain separate. This directory owns
-the Reactor integration and a stateful source extension; first load clones the
-exact tested LingBot-World revision into the persistent weights cache and adds
-the extension without changing its tracked files.
-
-Reactor generates the CUDA serving image directly from the `build:` block in
-`reactor.yaml`. This recipe has no handwritten Dockerfile.
+The adapter loads an exact tested LingBot-World revision from the persistent
+weights cache and applies a stateful source extension that exposes its native
+chunk boundary.
 
 ## Prerequisites
 
-- The `reactor` CLI and Docker.
+- The [`reactor` CLI](https://docs.reactor.inc/deploy/platform/installation) and
+  Docker.
 - An NVIDIA GPU, NVIDIA driver, and NVIDIA Container Toolkit. CPU inference is
   unsupported. The recipe requests one B200; a tested 13-chunk rollout used
   about 48 GB of VRAM, so a GPU with at least 64 GB is recommended.
 - About 90 GB on persistent storage for the Fast checkpoint, VAE, UMT5 assets,
-  source checkout, and worker environment, plus space for the generated CUDA
-  image and Docker build cache.
+  source checkout, and worker environment, plus space for the model image and
+  build cache.
 
 ## Run
 
 This directory is a `reactor` workspace. `reactor.yaml` names the model,
-declares CUDA 12.8.1 and Python 3.12, lists the required system packages, and
-points Reactor at `requirements.txt`. The CLI turns that manifest into an image
-definition in memory. See
-[Build a model](https://deploy-docs.reactor.inc/platform/build) for the current
-manifest workflow.
+controls its Reactor Runtime 3.2.3, CUDA 12.8.1, Python 3.12, system packages,
+and Python dependencies. See Reactor's
+[build configuration](https://deploy-docs.reactor.inc/platform/build) for the
+supported fields.
 
-Validate the workspace, build the generated image, and expose one GPU to the
+Validate the workspace, build the model image, and expose one GPU to the
 container:
 
 ```sh
@@ -112,20 +108,16 @@ documented in [`example_image`](example_image).
 
 ## Runtime boundary
 
-LingBot-World Fast is an autoregressive video model. Its public `generate()`
-denoises three latent frames at a time and commits each completed chunk to a
-causal self-attention KV cache, but creates and destroys that cache on every
-call. The included `InteractiveFastRollout` extension exposes the same native
-boundary as a resumable session: model weights load once, one Reactor request
-runs one original four-timestep chunk, and self-KV, absolute RoPE position,
-prompt cross-attention, random generator, and causal VAE feature cache remain
-alive for the next request.
+LingBot-World Fast is an autoregressive video model. The included
+`InteractiveFastRollout` runs its native three-latent, four-timestep boundary as
+a resumable session: model weights load once, and self-KV, absolute RoPE
+position, prompt cross-attention, random generator, and causal VAE feature
+cache remain alive for the next request.
 
 The first three-latent chunk decodes to 9 RGB frames because it includes the
 image anchor. Every later chunk decodes to 12 frames, played at the upstream 16
 FPS. The official 81-frame Fast invocation contains 21 VAE latents; the adapter
-keeps that exact rolling native KV window instead of shortening memory for
-latency.
+keeps that exact rolling native KV window for every session.
 
 Prompt changes replace only cross-attention conditioning at the next chunk
 boundary. Visual self-KV remains intact, so future video responds to the new
@@ -146,16 +138,15 @@ Message delivery remains outside the synchronous inference loop.
 ## Public source and model assets
 
 `lingbot_world_v1.yaml` pins the source and both Hugging Face snapshots. First
-load downloads only the base VAE, UMT5 encoder and tokenizer, and Fast model
-shards. It does not download the unused Base model's low- and high-noise
-transformer weights. Downloads resume after interruption, and marker files
-record the immutable revisions.
+load downloads the base VAE, UMT5 encoder and tokenizer, and Fast model shards.
+Downloads resume after interruption, and marker files record the immutable
+revisions.
 
 Reactor Runtime and LingBot-World require different NumPy major versions. A
 persistent Python 3.12 worker provides dependency isolation while remaining the
 only model process and loading one copy of the weights. The source extension
-contains the chunk boundary; the upstream scheduler, four denoising timesteps,
-self-KV eviction, camera Plücker embedding, and VAE decoder remain unchanged.
+delegates each chunk to the upstream scheduler, four denoising timesteps,
+self-KV eviction, camera Plücker embedding, and VAE decoder.
 
 The CLI bind-mounts `runtime.weights_path` at the same absolute path inside the
 container and exports it as `REACTOR_WEIGHTS_PATH`. The checked-in default is
@@ -170,9 +161,9 @@ ln -s "$LINGBOT_ROOT/weights" \
   "$HOME/.cache/reactor_registry/lingbot-world-v1-fast"
 ```
 
-Docker image layers and BuildKit cache are host-level storage rather than model
-weights. Configure Docker's data root on a large volume before `reactor build`
-when its default system location has limited space.
+The container engine stores image layers and build cache separately from model
+weights. Configure that storage on a large volume before `reactor build` when
+the system disk has limited space.
 
 ## Recording
 

--- a/models/lingbot-world-v1-fast/README.md
+++ b/models/lingbot-world-v1-fast/README.md
@@ -1,0 +1,191 @@
+# Play LingBot-World v1 Fast through Reactor Runtime
+
+Run the public [LingBot-World](https://github.com/robbyant/lingbot-world)
+camera model as an interactive Reactor backend. A client can start from a
+built-in scene or uploaded image, change the prompt, apply six-axis camera
+motion, stream generated video, and record the session.
+
+The adapter and upstream implementation remain separate. This directory owns
+the Reactor integration and a stateful source extension; first load clones the
+exact tested LingBot-World revision into the persistent weights cache and adds
+the extension without changing its tracked files.
+
+Reactor generates the CUDA serving image directly from the `build:` block in
+`reactor.yaml`. This recipe has no handwritten Dockerfile.
+
+## Prerequisites
+
+- The `reactor` CLI and Docker.
+- An NVIDIA GPU, NVIDIA driver, and NVIDIA Container Toolkit. CPU inference is
+  unsupported. The recipe requests one B200; a tested 13-chunk rollout used
+  about 48 GB of VRAM, so a GPU with at least 64 GB is recommended.
+- About 90 GB on persistent storage for the Fast checkpoint, VAE, UMT5 assets,
+  source checkout, and worker environment, plus space for the generated CUDA
+  image and Docker build cache.
+
+## Run
+
+This directory is a `reactor` workspace. `reactor.yaml` names the model,
+declares CUDA 12.8.1 and Python 3.12, lists the required system packages, and
+points Reactor at `requirements.txt`. The CLI turns that manifest into an image
+definition in memory. See
+[Build a model](https://deploy-docs.reactor.inc/platform/build) for the current
+manifest workflow.
+
+Validate the workspace, build the generated image, and expose one GPU to the
+container:
+
+```sh
+cd models/lingbot-world-v1-fast
+reactor validate
+reactor build
+reactor run --gpus device=0
+```
+
+`--gpus device=3` selects host GPU 3 and presents it as device 0 inside the
+container. `reactor run` reuses the image from `reactor build` and builds it
+automatically when the local tag is missing. Rebuild after changing adapter
+code, dependencies, or the manifest.
+
+First startup clones the pinned public source, prepares an isolated upstream
+environment, builds FlashAttention 2, and downloads the selected model assets.
+Later starts reuse all of them from the CLI-mounted weights cache. Public
+downloads require no token, but a Hugging Face token can be forwarded without
+putting its value on the command line when needed:
+
+```sh
+export HF_TOKEN=hf_your_read_token
+reactor run --gpus device=0 -e HF_TOKEN
+```
+
+The default endpoint is `http://localhost:8080`. Pass `--port` to use another
+port:
+
+```sh
+reactor run --gpus device=0 --port 18087
+```
+
+Connect from the [Reactor Sandbox](https://reactor-sandbox.vercel.app/) using
+**Local (Direct)**, or check readiness directly:
+
+```sh
+curl -s localhost:8080/health
+curl -s localhost:8080/schema
+```
+
+## Controls
+
+Generation starts paused. Session startup, `set_image`, `random_image`, and a
+paused `reset` automatically queue one preview chunk so the current world is
+visible without enabling continuous generation.
+
+- `set_image(image, prompt)` starts a fresh world from an uploaded image and
+  optionally replaces the prompt.
+- `random_image` selects another built-in scene and its matching prompt.
+- `set_prompt(prompt)` applies a non-empty text condition at the next chunk
+  boundary without clearing visual self-KV history.
+- `set_forward`, `set_strafe`, and `set_vertical` control translation.
+- `set_pitch`, `set_yaw`, and `set_roll` control rotation.
+- `set_paused(false)` starts continuous one-chunk-at-a-time generation;
+  `set_paused(true)` stops before the next chunk.
+- `step` generates exactly one chunk while paused.
+- `reset(seed)` starts the selected image and prompt again without reloading
+  model weights.
+
+Every camera value is normalized to `[-1, 1]`, with zero neutral. A WASD
+frontend maps W/S to forward ±1 and A/D to strafe ∓1. Pointer, arrow, touch, or
+gamepad input can drive yaw and pitch; additional controls can expose vertical
+translation and roll. Axes are independent, so translation and rotation can be
+combined in the same chunk.
+
+## Start from an image
+
+`set_image` uses Reactor's upload protocol and accepts decoded JPEG, PNG, WebP,
+or BMP files up to 25 MiB and 100 million pixels. Uploading an image preserves
+the pause setting and automatically queues its first chunk.
+
+LingBot-World's camera path expects calibrated intrinsics. An uploaded image
+uses the calibration associated with the currently selected built-in scene,
+matching the upstream fixed 480×832 inference path. The public lakeside and
+Great Wall anchors arrive in the pinned source checkout; their locations are
+documented in [`example_image`](example_image).
+
+## Runtime boundary
+
+LingBot-World Fast is an autoregressive video model. Its public `generate()`
+denoises three latent frames at a time and commits each completed chunk to a
+causal self-attention KV cache, but creates and destroys that cache on every
+call. The included `InteractiveFastRollout` extension exposes the same native
+boundary as a resumable session: model weights load once, one Reactor request
+runs one original four-timestep chunk, and self-KV, absolute RoPE position,
+prompt cross-attention, random generator, and causal VAE feature cache remain
+alive for the next request.
+
+The first three-latent chunk decodes to 9 RGB frames because it includes the
+image anchor. Every later chunk decodes to 12 frames, played at the upstream 16
+FPS. The official 81-frame Fast invocation contains 21 VAE latents; the adapter
+keeps that exact rolling native KV window instead of shortening memory for
+latency.
+
+Prompt changes replace only cross-attention conditioning at the next chunk
+boundary. Visual self-KV remains intact, so future video responds to the new
+text while preserving generated visual history.
+
+## Model messages
+
+Every accepted command returns a typed `state_update` and broadcasts a complete
+snapshot for the client timeline. It contains the active image, prompt, seed,
+pause and step state, all six camera axes, completed chunk count, next affected
+chunk, frame count, rollout limit, and most recent generation time. A joining
+viewer receives the same state immediately.
+
+`rollout_limit_reached` reports when generation pauses at the configured safe
+RoPE boundary. `reset`, `set_image`, or `random_image` starts a fresh timeline.
+Message delivery remains outside the synchronous inference loop.
+
+## Public source and model assets
+
+`lingbot_world_v1.yaml` pins the source and both Hugging Face snapshots. First
+load downloads only the base VAE, UMT5 encoder and tokenizer, and Fast model
+shards. It does not download the unused Base model's low- and high-noise
+transformer weights. Downloads resume after interruption, and marker files
+record the immutable revisions.
+
+Reactor Runtime and LingBot-World require different NumPy major versions. A
+persistent Python 3.12 worker provides dependency isolation while remaining the
+only model process and loading one copy of the weights. The source extension
+contains the chunk boundary; the upstream scheduler, four denoising timesteps,
+self-KV eviction, camera Plücker embedding, and VAE decoder remain unchanged.
+
+The CLI bind-mounts `runtime.weights_path` at the same absolute path inside the
+container and exports it as `REACTOR_WEIGHTS_PATH`. The checked-in default is
+`~/.cache/reactor_registry/lingbot-world-v1-fast`. To keep that stable CLI path
+while placing its contents on a larger volume, create a symlink before the
+first launch:
+
+```sh
+export LINGBOT_ROOT=/path/to/large-volume/lingbot-world-v1
+mkdir -p "$LINGBOT_ROOT/weights" "$HOME/.cache/reactor_registry"
+ln -s "$LINGBOT_ROOT/weights" \
+  "$HOME/.cache/reactor_registry/lingbot-world-v1-fast"
+```
+
+Docker image layers and BuildKit cache are host-level storage rather than model
+weights. Configure Docker's data root on a large volume before `reactor build`
+when its default system location has limited space.
+
+## Recording
+
+`reactor.yaml` records `main_video` by default in four-second chunks and allows
+clips up to five minutes. The model emits video at 16 FPS and no audio.
+
+## Notes
+
+- `stream.context_latents: 21` preserves the upstream Fast memory length;
+  `step` still requests only one native three-latent chunk.
+- `stream.max_chunks: 320` keeps absolute RoPE positions inside the upstream
+  1024-latent table. A fresh image or reset starts another timeline without
+  reloading the checkpoint.
+- Ending a session releases KV, cross-attention, camera, and causal VAE caches
+  while retaining loaded model weights for the next session.
+- Stop `reactor run` to remove the container and release its GPU memory.

--- a/models/lingbot-world-v1-fast/README.md
+++ b/models/lingbot-world-v1-fast/README.md
@@ -71,9 +71,8 @@ curl -s localhost:8080/schema
 
 ## Controls
 
-Generation starts paused. Session startup, `set_image`, `random_image`, and a
-paused `reset` automatically queue one preview chunk so the current world is
-visible without enabling continuous generation.
+Generation starts continuously from the built-in sample. `set_image` and
+`random_image` begin fresh continuous rollouts.
 
 - `set_image(image, prompt)` starts a fresh world from an uploaded image and
   optionally replaces the prompt.
@@ -82,9 +81,6 @@ visible without enabling continuous generation.
   boundary without clearing visual self-KV history.
 - `set_forward`, `set_strafe`, and `set_vertical` control translation.
 - `set_pitch`, `set_yaw`, and `set_roll` control rotation.
-- `set_paused(false)` starts continuous one-chunk-at-a-time generation;
-  `set_paused(true)` stops before the next chunk.
-- `step` generates exactly one chunk while paused.
 - `reset(seed)` starts the selected image and prompt again without reloading
   model weights.
 
@@ -174,8 +170,8 @@ clips up to five minutes. The model emits video without audio.
 
 ## Notes
 
-- `stream.context_latents: 21` preserves the upstream Fast memory length;
-  `step` still requests only one native three-latent chunk.
+- `stream.context_latents: 21` preserves the upstream Fast memory length; each
+  inference turn requests one native three-latent chunk.
 - `stream.max_chunks: 320` keeps absolute RoPE positions inside the upstream
   1024-latent table. A fresh image or reset starts another timeline without
   reloading the checkpoint.

--- a/models/lingbot-world-v1-fast/README.md
+++ b/models/lingbot-world-v1-fast/README.md
@@ -71,8 +71,8 @@ curl -s localhost:8080/schema
 
 ## Controls
 
-Generation starts continuously from the built-in sample. `set_image` and
-`random_image` begin fresh continuous rollouts.
+Generation waits for `set_image` or `random_image`, then begins a fresh
+continuous rollout.
 
 - `set_image(image, prompt)` starts a fresh world from an uploaded image and
   optionally replaces the prompt.
@@ -97,10 +97,10 @@ or BMP files up to 25 MiB and 100 million pixels. Uploading an image preserves
 the pause setting and automatically queues its first chunk.
 
 LingBot-World's camera path expects calibrated intrinsics. An uploaded image
-uses the calibration associated with the currently selected built-in scene,
-matching the upstream fixed 480×832 inference path. The public lakeside and
-Great Wall anchors arrive in the pinned source checkout; their locations are
-documented in [`example_image`](example_image).
+uses the first public sample's calibration until `random_image` selects another
+one, matching the upstream fixed 480×832 inference path. The public lakeside
+and Great Wall anchors arrive in the pinned source checkout; their locations
+are documented in [`example_image`](example_image).
 
 ## Runtime boundary
 

--- a/models/lingbot-world-v1-fast/README.md
+++ b/models/lingbot-world-v1-fast/README.md
@@ -25,7 +25,7 @@ chunk boundary.
 This directory is a `reactor` workspace. `reactor.yaml` names the model,
 controls its Reactor Runtime 3.2.3, CUDA 12.8.1, Python 3.12, system packages,
 and Python dependencies. See Reactor's
-[build configuration](https://deploy-docs.reactor.inc/platform/build) for the
+[build configuration](https://docs.reactor.inc/deploy/platform/build) for the
 supported fields.
 
 Validate the workspace, build the model image, and expose one GPU to the

--- a/models/lingbot-world-v1-fast/README.md
+++ b/models/lingbot-world-v1-fast/README.md
@@ -115,9 +115,11 @@ position, prompt cross-attention, random generator, and causal VAE feature
 cache remain alive for the next request.
 
 The first three-latent chunk decodes to 9 RGB frames because it includes the
-image anchor. Every later chunk decodes to 12 frames, played at the upstream 16
-FPS. The official 81-frame Fast invocation contains 21 VAE latents; the adapter
-keeps that exact rolling native KV window for every session.
+image anchor. Every later chunk decodes to 12 frames. Each turn is submitted as
+one frame batch; playback adapts to measured inference throughput, and the
+output queue holds one complete 12-frame chunk. The official 81-frame Fast
+invocation contains 21 VAE latents; the adapter keeps that exact rolling native
+KV window for every session.
 
 Prompt changes replace only cross-attention conditioning at the next chunk
 boundary. Visual self-KV remains intact, so future video responds to the new
@@ -168,7 +170,7 @@ the system disk has limited space.
 ## Recording
 
 `reactor.yaml` records `main_video` by default in four-second chunks and allows
-clips up to five minutes. The model emits video at 16 FPS and no audio.
+clips up to five minutes. The model emits video without audio.
 
 ## Notes
 

--- a/models/lingbot-world-v1-fast/camera_motion.py
+++ b/models/lingbot-world-v1-fast/camera_motion.py
@@ -1,0 +1,137 @@
+"""Translate normalized six-axis controls into LingBot camera conditions."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MotionConfig:
+    """Define motion applied between LingBot latent camera slots."""
+
+    translation_units_per_latent: float
+    rotation_degrees_per_latent: float
+
+
+class CameraMotionPlanner:
+    """Build native framewise camera-to-world transforms for each chunk."""
+
+    def __init__(self, config: MotionConfig) -> None:
+        self._config = config
+        self.reset()
+
+    def reset(self) -> None:
+        """Return the camera to the identity anchor pose."""
+        self._current_c2w = np.eye(4, dtype=np.float64)
+        self._chunk_index = 0
+
+    def plan_chunk(
+        self,
+        *,
+        strafe: float,
+        vertical: float,
+        forward: float,
+        pitch: float,
+        yaw: float,
+        roll: float,
+    ) -> np.ndarray:
+        """Return three framewise transforms and advance the absolute camera pose.
+
+        The first causal chunk contains the anchor latent followed by two new
+        latent slots, matching the VAE's 9-frame first decode. Later chunks
+        contain three new slots and decode to 12 frames.
+        """
+        controls = (strafe, vertical, forward, pitch, yaw, roll)
+        if any(not -1.0 <= value <= 1.0 for value in controls):
+            raise ValueError("camera controls must be between -1 and 1")
+        config = self._config
+        if config.translation_units_per_latent <= 0:
+            raise ValueError("translation_units_per_latent must be positive")
+        if config.rotation_degrees_per_latent <= 0:
+            raise ValueError("rotation_degrees_per_latent must be positive")
+
+        delta = _camera_delta(
+            strafe=strafe,
+            vertical=vertical,
+            forward=forward,
+            pitch=pitch,
+            yaw=yaw,
+            roll=roll,
+            config=config,
+        )
+        relative = np.empty((3, 4, 4), dtype=np.float32)
+        start = 1 if self._chunk_index == 0 else 0
+        if start:
+            relative[0] = np.eye(4, dtype=np.float32)
+        for index in range(start, 3):
+            previous = self._current_c2w
+            self._current_c2w = previous @ delta
+            relative[index] = np.linalg.inv(previous) @ self._current_c2w
+        self._chunk_index += 1
+        return np.ascontiguousarray(relative)
+
+
+def _camera_delta(
+    *,
+    strafe: float,
+    vertical: float,
+    forward: float,
+    pitch: float,
+    yaw: float,
+    roll: float,
+    config: MotionConfig,
+) -> np.ndarray:
+    """Return one local OpenCV camera transform for a latent interval."""
+    translation = _normalized_vector(strafe, -vertical, forward)
+    translation *= config.translation_units_per_latent
+    rotation = _normalized_vector(pitch, yaw, roll)
+    pitch_step, yaw_step, roll_step = np.radians(
+        rotation * config.rotation_degrees_per_latent
+    )
+    delta = np.eye(4, dtype=np.float64)
+    delta[:3, :3] = (
+        _rotation_z(float(roll_step))
+        @ _rotation_y(float(yaw_step))
+        @ _rotation_x(float(-pitch_step))
+    )
+    delta[:3, 3] = translation
+    return delta
+
+
+def _normalized_vector(x: float, y: float, z: float) -> np.ndarray:
+    """Return a vector whose magnitude does not exceed one."""
+    vector = np.asarray([x, y, z], dtype=np.float64)
+    norm = float(np.linalg.norm(vector))
+    if norm > 1.0:
+        vector /= norm
+    return vector
+
+
+def _rotation_x(angle: float) -> np.ndarray:
+    """Return a right-handed X-axis rotation."""
+    cosine, sine = math.cos(angle), math.sin(angle)
+    return np.asarray(
+        [[1.0, 0.0, 0.0], [0.0, cosine, -sine], [0.0, sine, cosine]],
+        dtype=np.float64,
+    )
+
+
+def _rotation_y(angle: float) -> np.ndarray:
+    """Return a right-handed Y-axis rotation."""
+    cosine, sine = math.cos(angle), math.sin(angle)
+    return np.asarray(
+        [[cosine, 0.0, sine], [0.0, 1.0, 0.0], [-sine, 0.0, cosine]],
+        dtype=np.float64,
+    )
+
+
+def _rotation_z(angle: float) -> np.ndarray:
+    """Return a right-handed Z-axis rotation."""
+    cosine, sine = math.cos(angle), math.sin(angle)
+    return np.asarray(
+        [[cosine, -sine, 0.0], [sine, cosine, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )

--- a/models/lingbot-world-v1-fast/download_snapshot.py
+++ b/models/lingbot-world-v1-fast/download_snapshot.py
@@ -1,0 +1,29 @@
+"""Download one pinned public Hugging Face snapshot into a local directory."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+
+def main() -> None:
+    """Download the requested revision and preserve resumable Hub metadata."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--local-dir", type=Path, required=True)
+    parser.add_argument("--allow-pattern", action="append", default=[])
+    args = parser.parse_args()
+    args.local_dir.mkdir(parents=True, exist_ok=True)
+    snapshot_download(
+        repo_id=args.repo_id,
+        revision=args.revision,
+        local_dir=args.local_dir,
+        allow_patterns=args.allow_pattern or None,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/lingbot-world-v1-fast/example_image/README.md
+++ b/models/lingbot-world-v1-fast/example_image/README.md
@@ -1,0 +1,6 @@
+# Example images
+
+The adapter's `random_image` command loads the public lakeside and Great Wall
+anchors from `examples/03/image.jpg` and `examples/04/image.jpg` in the pinned
+LingBot-World source checkout. Either file can also be uploaded through
+`set_image` when testing the upload flow.

--- a/models/lingbot-world-v1-fast/lingbot_config.py
+++ b/models/lingbot-world-v1-fast/lingbot_config.py
@@ -1,0 +1,516 @@
+"""Prepare pinned public LingBot-World v1 source and model assets."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+import yaml
+from reactor_runtime import get_weights_path
+from reactor_runtime.log import get_logger
+
+logger = get_logger(__name__)
+
+SOURCE_ENV = "LINGBOT_WORLD_V1_PATH"
+WORKER_PYTHON = Path(".venv/bin/python")
+CHECKPOINT_PATH = Path("checkpoints/lingbot-world-base-cam")
+FAST_SUBDIR = Path("lingbot_world_fast")
+SNAPSHOT_MARKER = ".reactor-snapshot.json"
+WORKER_ENV_MARKER = ".reactor-worker-environment.json"
+WORKER_ENV_VERSION = 1
+WORKER_PYTHON_VERSION = "3.12"
+WORKER_TORCH = "torch==2.8.0"
+WORKER_TORCHVISION = "torchvision==0.23.0"
+WORKER_TORCHAUDIO = "torchaudio==2.8.0"
+WORKER_INDEX_URL = "https://download.pytorch.org/whl/cu128"
+WORKER_FLASH_ATTN = "flash-attn==2.8.3"
+
+_REVISION_PATTERN = re.compile(r"[0-9a-f]{40}")
+_BASE_PATTERNS = (
+    "Wan2.1_VAE.pth",
+    "models_t5_umt5-xxl-enc-bf16.pth",
+    "google/umt5-xxl/*",
+)
+_BASE_REQUIRED_FILES = (
+    "Wan2.1_VAE.pth",
+    "models_t5_umt5-xxl-enc-bf16.pth",
+    "google/umt5-xxl/spiece.model",
+    "google/umt5-xxl/tokenizer.json",
+    "google/umt5-xxl/tokenizer_config.json",
+)
+
+
+@dataclass(frozen=True)
+class ModelAsset:
+    """Describe a pinned public model snapshot and its local destination."""
+
+    path: Path
+    repo_id: str
+    revision: str
+
+
+@dataclass(frozen=True)
+class Sample:
+    """Describe one built-in image, prompt, and camera calibration."""
+
+    image: Path
+    intrinsics: Path
+    prompt: str
+
+
+@dataclass(frozen=True)
+class LingBotConfig:
+    """Hold validated LingBot adapter settings."""
+
+    worker_python: Path
+    source_path: Path
+    source_url: str
+    source_revision: str
+    checkpoint: ModelAsset
+    fast_checkpoint: ModelAsset
+    samples: tuple[Sample, ...]
+    seed: int
+    max_chunks: int
+    context_latents: int
+    max_area: int
+    shift: float
+    translation_units_per_latent: float
+    rotation_degrees_per_latent: float
+    runtime_root: Path
+
+
+def read_config(config_path: Path | None) -> LingBotConfig:
+    """Read and validate the LingBot adapter YAML."""
+    if config_path is None:
+        raise ValueError("LingBot-World v1 requires runtime.config in reactor.yaml")
+    document = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    if not isinstance(document, dict):
+        raise TypeError(f"{config_path}: expected a YAML mapping")
+    source = _mapping(document.get("source"), "source")
+    assets = _mapping(document.get("assets"), "assets")
+    inference = _mapping(document.get("inference"), "inference")
+    stream = _mapping(document.get("stream"), "stream")
+    motion = _mapping(document.get("motion"), "motion")
+    source_path = _source_path(source.get("path"))
+    checkpoint = _asset(
+        source_path / CHECKPOINT_PATH,
+        assets.get("base"),
+        "assets.base",
+    )
+    fast_checkpoint = _asset(
+        checkpoint.path / FAST_SUBDIR,
+        assets.get("fast"),
+        "assets.fast",
+    )
+    samples = _samples(source_path, document.get("samples"))
+    max_chunks = int(stream.get("max_chunks", 320))
+    context_latents = int(stream.get("context_latents", 21))
+    if max_chunks <= 0 or max_chunks * 3 > 1024:
+        raise ValueError(
+            "stream.max_chunks must keep the latent RoPE timeline within 1024"
+        )
+    if context_latents < 3 or context_latents % 3:
+        raise ValueError("stream.context_latents must be a positive multiple of 3")
+    max_area = int(inference.get("max_area", 480 * 832))
+    if max_area <= 0:
+        raise ValueError("inference.max_area must be positive")
+    translation = float(motion.get("translation_units_per_latent", 1.0))
+    rotation = float(motion.get("rotation_degrees_per_latent", 8.0))
+    if translation <= 0 or rotation <= 0:
+        raise ValueError("motion rates must be positive")
+    runtime_root = source_path.parent / ".reactor-lingbot-world-v1"
+    return LingBotConfig(
+        worker_python=source_path / WORKER_PYTHON,
+        source_path=source_path,
+        source_url=_repository_url(source.get("url"), "source.url"),
+        source_revision=_revision(source.get("revision"), "source.revision"),
+        checkpoint=checkpoint,
+        fast_checkpoint=fast_checkpoint,
+        samples=samples,
+        seed=int(inference.get("seed", 42)),
+        max_chunks=max_chunks,
+        context_latents=context_latents,
+        max_area=max_area,
+        shift=float(inference.get("shift", 10.0)),
+        translation_units_per_latent=translation,
+        rotation_degrees_per_latent=rotation,
+        runtime_root=runtime_root,
+    )
+
+
+def prepare_runtime(config: LingBotConfig) -> None:
+    """Prepare the pinned source, isolated environment, and Fast checkpoints."""
+    ensure_source_checkout(config)
+    ensure_worker_environment(config)
+    ensure_model_assets(config)
+    _validate_runtime_paths(config)
+
+
+def ensure_source_checkout(config: LingBotConfig) -> None:
+    """Clone the pinned source and apply the resumable Fast rollout extension."""
+    source_path = config.source_path
+    if not source_path.exists():
+        source_path.parent.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "downloading LingBot-World source",
+            url=config.source_url,
+            revision=config.source_revision,
+            destination=str(source_path),
+        )
+        with tempfile.TemporaryDirectory(
+            prefix=".reactor-lingbot-source-",
+            dir=source_path.parent,
+        ) as temporary:
+            checkout = Path(temporary) / "checkout"
+            _run_git(
+                [
+                    "clone",
+                    "--filter=blob:none",
+                    "--no-checkout",
+                    config.source_url,
+                    str(checkout),
+                ]
+            )
+            _run_git(
+                ["-C", str(checkout), "checkout", "--detach", config.source_revision]
+            )
+            with suppress(FileExistsError):
+                checkout.rename(source_path)
+    if not (source_path / ".git").is_dir():
+        raise RuntimeError(f"LingBot source at {source_path} must be a Git checkout")
+    actual = _run_git(["-C", str(source_path), "rev-parse", "HEAD"]).stdout.strip()
+    if actual != config.source_revision:
+        raise RuntimeError(
+            f"LingBot source revision is {actual}; expected {config.source_revision}"
+        )
+    _ensure_stateful_patch(source_path)
+
+
+def ensure_worker_environment(config: LingBotConfig) -> None:
+    """Create the isolated NumPy-1 model environment when missing or stale."""
+    marker = config.worker_python.parents[1] / WORKER_ENV_MARKER
+    expected = {
+        "version": WORKER_ENV_VERSION,
+        "source_revision": config.source_revision,
+        "python": WORKER_PYTHON_VERSION,
+        "torch": WORKER_TORCH,
+        "torchvision": WORKER_TORCHVISION,
+        "torchaudio": WORKER_TORCHAUDIO,
+        "flash_attn": WORKER_FLASH_ATTN,
+        "index_url": WORKER_INDEX_URL,
+    }
+    if config.worker_python.is_file() and _json_matches(marker, expected):
+        return
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError("uv is required to prepare the LingBot worker environment")
+    environment_dir = config.worker_python.parents[1]
+    cache_root = config.source_path.parent / ".cache"
+    uv_environment = _download_environment(cache_root)
+    logger.info(
+        "preparing LingBot model environment",
+        python=WORKER_PYTHON_VERSION,
+        destination=str(environment_dir),
+    )
+    _run_uv(
+        [
+            uv,
+            "venv",
+            "--python",
+            WORKER_PYTHON_VERSION,
+            "--clear",
+            str(environment_dir),
+        ],
+        uv_environment,
+    )
+    _run_uv(
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(config.worker_python),
+            WORKER_TORCH,
+            WORKER_TORCHVISION,
+            WORKER_TORCHAUDIO,
+            "--index-url",
+            WORKER_INDEX_URL,
+        ],
+        uv_environment,
+    )
+    requirements = Path(__file__).with_name("worker-requirements.txt")
+    _run_uv(
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(config.worker_python),
+            "--requirement",
+            str(requirements),
+        ],
+        uv_environment,
+    )
+    _run_uv(
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(config.worker_python),
+            "--no-build-isolation",
+            WORKER_FLASH_ATTN,
+        ],
+        uv_environment,
+    )
+    pending = marker.with_suffix(".tmp")
+    pending.write_text(json.dumps(expected, sort_keys=True), encoding="utf-8")
+    os.replace(pending, marker)
+
+
+def ensure_model_assets(config: LingBotConfig) -> None:
+    """Download only the base components and Fast weights used by this adapter."""
+    _ensure_snapshot(
+        config,
+        config.checkpoint,
+        allow_patterns=_BASE_PATTERNS,
+        required_files=_BASE_REQUIRED_FILES,
+    )
+    fast_required = (
+        "config.json",
+        "diffusion_pytorch_model.safetensors.index.json",
+        *(f"model-{index:05d}-of-00016.safetensors" for index in range(1, 17)),
+    )
+    _ensure_snapshot(
+        config,
+        config.fast_checkpoint,
+        allow_patterns=(),
+        required_files=fast_required,
+    )
+
+
+def _ensure_snapshot(
+    config: LingBotConfig,
+    asset: ModelAsset,
+    *,
+    allow_patterns: Sequence[str],
+    required_files: Sequence[str],
+) -> None:
+    """Download one resumable pinned snapshot and verify its required files."""
+    marker = asset.path / SNAPSHOT_MARKER
+    expected = {"repo_id": asset.repo_id, "revision": asset.revision}
+    if _json_matches(marker, expected) and all(
+        (asset.path / relative).is_file() for relative in required_files
+    ):
+        return
+    asset.path.mkdir(parents=True, exist_ok=True)
+    logger.info(
+        "downloading LingBot model snapshot",
+        repo_id=asset.repo_id,
+        revision=asset.revision,
+        destination=str(asset.path),
+    )
+    command = [
+        str(config.worker_python),
+        str(Path(__file__).with_name("download_snapshot.py")),
+        "--repo-id",
+        asset.repo_id,
+        "--revision",
+        asset.revision,
+        "--local-dir",
+        str(asset.path),
+    ]
+    for pattern in allow_patterns:
+        command.extend(["--allow-pattern", pattern])
+    subprocess.run(
+        command,
+        check=True,
+        env=_download_environment(config.source_path.parent / ".cache"),
+    )
+    missing = [
+        relative for relative in required_files if not (asset.path / relative).is_file()
+    ]
+    if missing:
+        raise RuntimeError(
+            f"snapshot {asset.repo_id}@{asset.revision} is missing required files: {missing}"
+        )
+    pending = marker.with_suffix(".tmp")
+    pending.write_text(json.dumps(expected, sort_keys=True), encoding="utf-8")
+    os.replace(pending, marker)
+
+
+def _ensure_stateful_patch(source_path: Path) -> None:
+    """Apply the adapter's stateful Fast rollout extension exactly once."""
+    patch = Path(__file__).with_name("stateful_rollout.patch")
+    reverse = _check_git(
+        ["-C", str(source_path), "apply", "--reverse", "--check", str(patch)]
+    )
+    if reverse.returncode == 0:
+        return
+    forward = _check_git(["-C", str(source_path), "apply", "--check", str(patch)])
+    if forward.returncode != 0:
+        detail = (
+            forward.stderr.strip() or reverse.stderr.strip() or "patch check failed"
+        )
+        raise RuntimeError(
+            f"LingBot source is incompatible with the stateful patch: {detail}"
+        )
+    logger.info("applying LingBot stateful rollout extension", source=str(source_path))
+    _run_git(["-C", str(source_path), "apply", str(patch)])
+
+
+def _validate_runtime_paths(config: LingBotConfig) -> None:
+    """Fail startup with precise paths when source or assets are incomplete."""
+    required = [
+        config.worker_python,
+        config.source_path / "wan" / "interactive_fast.py",
+        config.checkpoint.path / "Wan2.1_VAE.pth",
+        config.fast_checkpoint.path / "config.json",
+    ]
+    for sample in config.samples:
+        required.extend([sample.image, sample.intrinsics])
+    missing = [str(path) for path in required if not path.is_file()]
+    if missing:
+        raise FileNotFoundError(f"LingBot runtime assets are missing: {missing}")
+    config.runtime_root.mkdir(parents=True, exist_ok=True)
+
+
+def _samples(source_path: Path, value: object) -> tuple[Sample, ...]:
+    """Return validated built-in samples from the pinned source checkout."""
+    if not isinstance(value, list) or not value:
+        raise ValueError("samples must be a non-empty YAML list")
+    result = []
+    for index, raw in enumerate(value):
+        item = _mapping(raw, f"samples[{index}]")
+        prompt = str(item.get("prompt", "")).strip()
+        if not prompt:
+            raise ValueError(f"samples[{index}].prompt must not be empty")
+        result.append(
+            Sample(
+                image=source_path / str(item.get("image", "")),
+                intrinsics=source_path / str(item.get("intrinsics", "")),
+                prompt=prompt,
+            )
+        )
+    return tuple(result)
+
+
+def _asset(path: Path, value: object, name: str) -> ModelAsset:
+    """Return one pinned public model asset."""
+    document = _mapping(value, name)
+    repo_id = str(document.get("repo_id", ""))
+    if "/" not in repo_id:
+        raise ValueError(
+            f"{name}.repo_id must identify a public Hugging Face repository"
+        )
+    return ModelAsset(
+        path=path,
+        repo_id=repo_id,
+        revision=_revision(document.get("revision"), f"{name}.revision"),
+    )
+
+
+def _source_path(value: object) -> Path:
+    """Resolve the source checkout under Runtime's mounted weights root."""
+    configured = os.environ.get(SOURCE_ENV)
+    path = Path(
+        configured if configured else str(value or "lingbot-world-v1")
+    ).expanduser()
+    return (
+        path.resolve() if path.is_absolute() else (get_weights_path() / path).resolve()
+    )
+
+
+def _mapping(value: object, name: str) -> dict[str, Any]:
+    """Return a YAML mapping or raise a precise configuration error."""
+    if not isinstance(value, dict):
+        raise TypeError(f"{name} must be a YAML mapping")
+    return cast(dict[str, Any], value)
+
+
+def _revision(value: object, name: str) -> str:
+    """Return one full immutable Git-style revision."""
+    revision = str(value or "")
+    if not _REVISION_PATTERN.fullmatch(revision):
+        raise ValueError(f"{name} must be a full 40-character revision")
+    return revision
+
+
+def _repository_url(value: object, name: str) -> str:
+    """Return a public HTTPS source URL."""
+    url = str(value or "")
+    if not url.startswith("https://"):
+        raise ValueError(f"{name} must be a public HTTPS URL")
+    return url
+
+
+def _json_matches(path: Path, expected: Mapping[str, object]) -> bool:
+    """Return whether a JSON marker exactly matches expected metadata."""
+    try:
+        return json.loads(path.read_text(encoding="utf-8")) == dict(expected)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+
+
+def _download_environment(cache_root: Path) -> dict[str, str]:
+    """Return download and build caches rooted beside the model checkout."""
+    environment = os.environ.copy()
+    cache_root.mkdir(parents=True, exist_ok=True)
+    environment.update(
+        {
+            "UV_CACHE_DIR": str(cache_root / "uv"),
+            "UV_PYTHON_INSTALL_DIR": str(cache_root / "python"),
+            "HF_HOME": str(cache_root / "huggingface"),
+            "HUGGINGFACE_HUB_CACHE": str(cache_root / "huggingface" / "hub"),
+            "TORCH_HOME": str(cache_root / "torch"),
+            "PIP_CACHE_DIR": str(cache_root / "pip"),
+            "TMPDIR": str(cache_root / "tmp"),
+            "MAX_JOBS": os.environ.get("MAX_JOBS", "16"),
+        }
+    )
+    Path(environment["TMPDIR"]).mkdir(parents=True, exist_ok=True)
+    return environment
+
+
+def _run_uv(command: list[str], environment: Mapping[str, str]) -> None:
+    """Run uv while preserving full subprocess failures."""
+    subprocess.run(command, check=True, env=dict(environment))
+
+
+def _run_git(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run git and return its captured output."""
+    return subprocess.run(
+        _git_command(arguments),
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _check_git(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a non-mutating git check and return its status."""
+    return subprocess.run(
+        _git_command(arguments),
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _git_command(arguments: list[str]) -> list[str]:
+    """Allow Git to inspect the explicit checkout mounted by Runtime."""
+    try:
+        checkout_index = arguments.index("-C") + 1
+        checkout = Path(arguments[checkout_index]).resolve()
+    except (ValueError, IndexError):
+        return ["git", *arguments]
+    return ["git", "-c", f"safe.directory={checkout}", *arguments]

--- a/models/lingbot-world-v1-fast/lingbot_images.py
+++ b/models/lingbot-world-v1-fast/lingbot_images.py
@@ -1,0 +1,63 @@
+"""Validate LingBot anchor uploads and normalize generated frames."""
+
+from __future__ import annotations
+
+import io
+
+import numpy as np
+from PIL import Image, UnidentifiedImageError
+from reactor_runtime import CommandError, UploadedFile
+
+_MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+_MAX_IMAGE_PIXELS = 100_000_000
+_MIME_FORMATS = {
+    "image/bmp": "BMP",
+    "image/jpeg": "JPEG",
+    "image/png": "PNG",
+    "image/webp": "WEBP",
+}
+
+
+def validate_uploaded_image(upload: UploadedFile) -> None:
+    """Validate an uploaded image before replacing the active world anchor."""
+    if upload.size <= 0:
+        raise CommandError("image_empty", "Upload a non-empty anchor image.")
+    if upload.size > _MAX_UPLOAD_BYTES:
+        raise CommandError("image_too_large", "Anchor images must be at most 25 MiB.")
+    expected = _MIME_FORMATS.get(upload.mime_type.lower())
+    if expected is None:
+        raise CommandError(
+            "image_type_unsupported",
+            "Anchor images must be JPEG, PNG, WebP, or BMP.",
+        )
+    try:
+        with Image.open(io.BytesIO(upload.data)) as image:
+            actual = image.format
+            width, height = image.size
+            image.verify()
+    except (OSError, UnidentifiedImageError) as error:
+        raise CommandError(
+            "image_invalid", "The uploaded anchor image cannot be decoded."
+        ) from error
+    if actual != expected:
+        raise CommandError(
+            "image_type_mismatch",
+            f"The upload declares {expected} but contains {actual or 'unknown'} data.",
+        )
+    if width <= 0 or height <= 0 or width * height > _MAX_IMAGE_PIXELS:
+        raise CommandError(
+            "image_dimensions_invalid",
+            "Anchor images must contain at most 100 million pixels.",
+        )
+
+
+def normalize_output_frames(frames: np.ndarray) -> np.ndarray:
+    """Return contiguous uint8 RGB frames suitable for Reactor's video track."""
+    value = np.asarray(frames)
+    if value.ndim != 4 or value.shape[-1] != 3:
+        raise RuntimeError(
+            f"LingBot output must have shape (T, H, W, 3); got {value.shape}"
+        )
+    if value.dtype != np.uint8:
+        value = np.clip(value, 0, 255).astype(np.uint8)
+    return np.ascontiguousarray(value)

--- a/models/lingbot-world-v1-fast/lingbot_schema.py
+++ b/models/lingbot-world-v1-fast/lingbot_schema.py
@@ -13,7 +13,7 @@ from reactor_runtime import (
 
 
 class LingBotWorldOutput(Output):
-    """Carry one generated LingBot-World RGB frame."""
+    """Carry one generated LingBot-World RGB frame batch."""
 
     main_video: Video
 
@@ -23,14 +23,15 @@ class StateUpdate(ModelMessage):
 
     prompt: str = MessageField(
         description=(
-            "Active scene prompt. A successful `set_prompt` change is encoded for the next "
-            "generated `main_video` chunk while the existing visual self-KV history remains."
+            "Active scene prompt, or an empty string before an image is selected. A successful "
+            "`set_prompt` change is encoded for the next generated `main_video` chunk while the "
+            "existing visual self-KV history remains."
         )
     )
     image_source: str = MessageField(
         description=(
-            "Source of the active anchor image: `built_in` after startup or `random_image`, "
-            "and `upload` after `set_image`."
+            "Source of the active anchor image: `none` before selection, `built_in` after "
+            "`random_image`, and `upload` after `set_image`."
         )
     )
     image_name: str = MessageField(
@@ -75,13 +76,13 @@ class StateUpdate(ModelMessage):
     next_chunk: int | None = MessageField(
         description=(
             "One-based chunk that newly accepted camera or prompt controls will first affect. "
-            "Null after the rollout limit is reached."
+            "Null before image selection or after the rollout limit is reached."
         )
     )
     next_chunk_frames: int | None = MessageField(
         description=(
             "Frames emitted by `next_chunk`: 9 for the first causal chunk, 12 thereafter, and "
-            "null after the rollout limit is reached."
+            "null before image selection or after the rollout limit is reached."
         )
     )
     max_chunks: int = MessageField(

--- a/models/lingbot-world-v1-fast/lingbot_schema.py
+++ b/models/lingbot-world-v1-fast/lingbot_schema.py
@@ -1,0 +1,216 @@
+"""Define the public Reactor schema for LingBot-World v1 Fast."""
+
+from __future__ import annotations
+
+from reactor_runtime import (
+    InputField,
+    InputState,
+    MessageField,
+    ModelMessage,
+    Output,
+    Video,
+)
+
+
+class LingBotWorldOutput(Output):
+    """Carry one generated LingBot-World RGB frame."""
+
+    main_video: Video
+
+
+class StateUpdate(ModelMessage):
+    """Report the complete shared world state after each accepted transition."""
+
+    prompt: str = MessageField(
+        description=(
+            "Active scene prompt. A successful `set_prompt` change is encoded for the next "
+            "generated `main_video` chunk while the existing visual self-KV history remains."
+        )
+    )
+    image_source: str = MessageField(
+        description=(
+            "Source of the active anchor image: `built_in` after startup or `random_image`, "
+            "and `upload` after `set_image`."
+        )
+    )
+    image_name: str = MessageField(
+        description="Filename of the active anchor image used by the current or queued rollout."
+    )
+    seed: int = MessageField(
+        description=(
+            "Non-negative random seed for the current or queued rollout. It changes only when "
+            "`reset` receives a non-negative seed."
+        )
+    )
+    paused: bool = MessageField(
+        description=(
+            "Whether continuous generation stops before the next chunk. An in-flight GPU chunk "
+            "can finish before the pause takes effect."
+        )
+    )
+    step_queued: bool = MessageField(
+        description=(
+            "Whether one chunk is queued while paused. It becomes false when that chunk starts "
+            "or another playback command cancels it."
+        )
+    )
+    limit_reached: bool = MessageField(
+        description=(
+            "Whether the rollout exhausted its safe RoPE timeline. Use `reset`, `set_image`, or "
+            "`random_image` before requesting another chunk."
+        )
+    )
+    completed_chunks: int = MessageField(
+        description=(
+            "Number of completed native three-latent chunks in the active world. Chunk 1 emits "
+            "9 frames and each later chunk emits 12 frames."
+        )
+    )
+    last_chunk_seconds: float | None = MessageField(
+        description=(
+            "Wall-clock seconds spent in model generation and causal VAE decode for the most "
+            "recent completed chunk. Null before the first chunk of a fresh world."
+        )
+    )
+    next_chunk: int | None = MessageField(
+        description=(
+            "One-based chunk that newly accepted camera or prompt controls will first affect. "
+            "Null after the rollout limit is reached."
+        )
+    )
+    next_chunk_frames: int | None = MessageField(
+        description=(
+            "Frames emitted by `next_chunk`: 9 for the first causal chunk, 12 thereafter, and "
+            "null after the rollout limit is reached."
+        )
+    )
+    max_chunks: int = MessageField(
+        description="Maximum chunks available before a fresh anchor rollout is required."
+    )
+    forward: float = MessageField(
+        description=(
+            "Active backward-to-forward translation in [-1, 1], sampled at the next chunk "
+            "boundary and held until changed or released."
+        )
+    )
+    strafe: float = MessageField(
+        description=(
+            "Active left-to-right translation in [-1, 1], sampled at the next chunk boundary "
+            "and held until changed or released."
+        )
+    )
+    vertical: float = MessageField(
+        description=(
+            "Active down-to-up translation in [-1, 1], sampled at the next chunk boundary and "
+            "held until changed or released."
+        )
+    )
+    pitch: float = MessageField(
+        description=(
+            "Active downward-to-upward pitch in [-1, 1], sampled at the next chunk boundary and "
+            "held until changed or released."
+        )
+    )
+    yaw: float = MessageField(
+        description=(
+            "Active left-to-right yaw in [-1, 1], sampled at the next chunk boundary and held "
+            "until changed or released."
+        )
+    )
+    roll: float = MessageField(
+        description=(
+            "Active counterclockwise-to-clockwise roll in [-1, 1], sampled at the next chunk "
+            "boundary and held until changed or released."
+        )
+    )
+
+
+class RolloutLimitReached(ModelMessage):
+    """Report that generation paused at the end of the safe timeline."""
+
+    completed_chunks: int = MessageField(
+        description="Number of completed chunks when the rollout reached its configured limit."
+    )
+    max_chunks: int = MessageField(
+        description=(
+            "Configured limit reached by `completed_chunks`; start a fresh anchor rollout to "
+            "continue generation."
+        )
+    )
+
+
+class LingBotWorldState(InputState):
+    """Expose shared text, camera, and playback controls for one LingBot world."""
+
+    prompt: str = InputField(
+        default="",
+        max_length=4096,
+        description=(
+            "Active non-empty scene prompt, up to 4096 characters. A change is encoded at the "
+            "next generated chunk boundary without clearing visual self-KV history."
+        ),
+    )
+    forward: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Backward (-1) to forward (1) translation sampled at chunk boundaries and held "
+            "until changed or released."
+        ),
+    )
+    strafe: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Left (-1) to right (1) translation sampled at chunk boundaries and held until "
+            "changed or released."
+        ),
+    )
+    vertical: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Down (-1) to up (1) translation sampled at chunk boundaries and held until changed "
+            "or released."
+        ),
+    )
+    pitch: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Downward (-1) to upward (1) pitch sampled at chunk boundaries and held until "
+            "changed or released."
+        ),
+    )
+    yaw: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Left (-1) to right (1) yaw sampled at chunk boundaries and held until changed or "
+            "released."
+        ),
+    )
+    roll: float = InputField(
+        default=0.0,
+        ge=-1.0,
+        le=1.0,
+        description=(
+            "Counterclockwise (-1) to clockwise (1) roll sampled at chunk boundaries and held "
+            "until changed or released."
+        ),
+    )
+    paused: bool = InputField(
+        default=True,
+        description=(
+            "Whether generation waits before the next chunk. Startup and fresh images remain "
+            "paused but automatically queue one preview chunk."
+        ),
+    )
+    _step_requested: bool = False
+    _restart_requested: bool = True
+    _limit_reached: bool = False

--- a/models/lingbot-world-v1-fast/lingbot_schema.py
+++ b/models/lingbot-world-v1-fast/lingbot_schema.py
@@ -204,13 +204,17 @@ class LingBotWorldState(InputState):
             "until changed or released."
         ),
     )
-    paused: bool = InputField(
-        default=True,
-        description=(
-            "Whether generation waits before the next chunk. Startup and fresh images remain "
-            "paused but automatically queue one preview chunk."
-        ),
-    )
+    _paused: bool = False
     _step_requested: bool = False
     _restart_requested: bool = True
     _limit_reached: bool = False
+
+    @property
+    def paused(self) -> bool:
+        """Return whether continuous chunk generation is paused."""
+        return self._paused
+
+    @paused.setter
+    def paused(self, value: bool) -> None:
+        """Set whether continuous chunk generation is paused."""
+        self._paused = value

--- a/models/lingbot-world-v1-fast/lingbot_world_v1.py
+++ b/models/lingbot-world-v1-fast/lingbot_world_v1.py
@@ -1,0 +1,641 @@
+"""Serve LingBot-World v1 Fast through Reactor's interactive pipeline API."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import random
+import time
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+import numpy as np
+from reactor_runtime import (
+    ClientInfo,
+    CommandError,
+    Idle,
+    InputField,
+    ReactorPipeline,
+    UploadedFile,
+    connected,
+    disconnected,
+    event,
+    session_ended,
+    session_started,
+)
+from reactor_runtime.log import get_logger
+
+if TYPE_CHECKING:
+    from camera_motion import CameraMotionPlanner, MotionConfig
+    from lingbot_config import LingBotConfig, Sample
+    from lingbot_schema import (
+        LingBotWorldOutput,
+        LingBotWorldState,
+        RolloutLimitReached,
+        StateUpdate,
+    )
+else:
+    module_prefix = f"{__package__}." if __package__ else ""
+    camera_motion = importlib.import_module(f"{module_prefix}camera_motion")
+    lingbot_config = importlib.import_module(f"{module_prefix}lingbot_config")
+    lingbot_images = importlib.import_module(f"{module_prefix}lingbot_images")
+    lingbot_schema = importlib.import_module(f"{module_prefix}lingbot_schema")
+    upstream_backend = importlib.import_module(f"{module_prefix}upstream_backend")
+    CameraMotionPlanner = camera_motion.CameraMotionPlanner
+    MotionConfig = camera_motion.MotionConfig
+    LingBotConfig = lingbot_config.LingBotConfig
+    Sample = lingbot_config.Sample
+    prepare_runtime = lingbot_config.prepare_runtime
+    read_config = lingbot_config.read_config
+    normalize_output_frames = lingbot_images.normalize_output_frames
+    validate_uploaded_image = lingbot_images.validate_uploaded_image
+    LingBotWorldOutput = lingbot_schema.LingBotWorldOutput
+    LingBotWorldState = lingbot_schema.LingBotWorldState
+    RolloutLimitReached = lingbot_schema.RolloutLimitReached
+    StateUpdate = lingbot_schema.StateUpdate
+    LingBotWorkerBackend = upstream_backend.LingBotWorkerBackend
+    WorkerSettings = upstream_backend.WorkerSettings
+
+logger = get_logger(__name__)
+
+FPS = 16
+
+
+class _Backend(Protocol):
+    """Define the blocking model operations used by the Reactor loop."""
+
+    def reset(
+        self,
+        seed: int,
+        anchor_image: Path | UploadedFile,
+        intrinsics: Path,
+        prompt: str,
+    ) -> None:
+        """Start a fresh image-conditioned rollout."""
+
+    def generate_chunk(self, relative_c2ws: np.ndarray, prompt: str) -> np.ndarray:
+        """Generate one causal chunk for camera and text conditions."""
+
+    def end_session(self) -> None:
+        """Release state owned by the completed session."""
+
+
+class LingBotWorldV1(ReactorPipeline):
+    """Generate an image-, prompt-, and camera-controllable LingBot world."""
+
+    state: LingBotWorldState
+    output: LingBotWorldOutput
+    fps = FPS
+    buffer_size = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config: LingBotConfig | None = None
+        self._backend: _Backend | None = None
+        self._planner: CameraMotionPlanner | None = None
+        self._selected_input: Path | UploadedFile | None = None
+        self._selected_intrinsics: Path | None = None
+        self._default_prompt = ""
+        self._seed = 0
+        self._chunk_index = 0
+        self._chunk_in_flight = False
+        self._last_chunk_seconds: float | None = None
+
+    def load(self, config_path: Path | None) -> None:
+        """Prepare public assets and load LingBot-World-Fast once.
+
+        Args:
+            config_path: Path to ``lingbot_world_v1.yaml`` from ``reactor.yaml``.
+        """
+        config = read_config(config_path)
+        prepare_runtime(config)
+        self._config = config
+        self._default_prompt = config.samples[0].prompt
+        self._seed = config.seed
+        self._planner = CameraMotionPlanner(
+            MotionConfig(
+                translation_units_per_latent=config.translation_units_per_latent,
+                rotation_degrees_per_latent=config.rotation_degrees_per_latent,
+            )
+        )
+        self._backend = LingBotWorkerBackend(
+            WorkerSettings(
+                python_executable=config.worker_python,
+                source_path=config.source_path,
+                checkpoint_dir=config.checkpoint.path,
+                runtime_root=config.runtime_root,
+                max_chunks=config.max_chunks,
+                context_latents=config.context_latents,
+                max_area=config.max_area,
+                shift=config.shift,
+            )
+        )
+        logger.info(
+            "LingBot-World v1 Fast ready",
+            source_revision=config.source_revision,
+            fast_revision=config.fast_checkpoint.revision,
+            context_latents=config.context_latents,
+            fps=FPS,
+        )
+
+    @session_started
+    def on_session_started(self) -> None:
+        """Initialize one paused shared world and queue its preview chunk."""
+        config = self._require_config()
+        sample = config.samples[0]
+        self._select_sample(sample)
+        self._seed = config.seed
+        self._clear_controls()
+        self.state.paused = True
+        self.state._step_requested = True
+        self.state._restart_requested = True
+        self.state._limit_reached = False
+        self._chunk_index = 0
+        self._chunk_in_flight = False
+        self._last_chunk_seconds = None
+
+    @connected
+    async def on_connected(self, client: ClientInfo) -> None:
+        """Send the complete shared world state to one joining viewer."""
+        await client.send(self._state_update())
+
+    @disconnected
+    async def on_disconnected(self) -> None:
+        """Release held camera axes when their viewer disconnects."""
+        self._clear_controls()
+        await self.send(self._state_update())
+
+    @session_ended
+    async def on_session_ended(self) -> None:
+        """Release causal caches while retaining loaded weights."""
+        backend = self._backend
+        try:
+            if backend is not None:
+                await asyncio.to_thread(backend.end_session)
+        finally:
+            self._clear_controls()
+            self.state._step_requested = False
+            self.state._restart_requested = True
+            self.state._limit_reached = False
+            self._selected_input = None
+            self._selected_intrinsics = None
+            self._chunk_index = 0
+            self._chunk_in_flight = False
+            self._last_chunk_seconds = None
+
+    @event(
+        name="set_image",
+        description=(
+            "Replace the anchor image and queue the fresh world's first `main_video` chunk. "
+            "Valid at any time; generation remains paused, progress and camera axes reset, and "
+            "the upload is decoded before the command succeeds. Returns `state_update`, or "
+            "`command_error` for invalid image bytes, media type, dimensions, or an empty prompt."
+        ),
+    )
+    def set_image(
+        self,
+        image: UploadedFile = InputField(  # noqa: B008 - schema field declaration
+            description=(
+                "Anchor image delivered through Reactor's upload protocol. JPEG, PNG, WebP, or "
+                "BMP; non-empty, at most 25 MiB and 100 million pixels."
+            )
+        ),
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            description=(
+                "Optional scene prompt up to 4096 characters. A non-empty value conditions the "
+                "preview chunk; an empty value preserves the active prompt."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Select an upload, remain paused, and queue one preview chunk."""
+        validate_uploaded_image(image)
+        normalized = prompt.strip() or self.state.prompt.strip() or self._default_prompt
+        if not normalized:
+            raise CommandError("prompt_required", "LingBot-World requires a prompt.")
+        self._selected_input = image
+        self.state.prompt = normalized
+        self.state.paused = True
+        self._request_restart(auto_step=True)
+        return self._state_update()
+
+    @event(
+        name="random_image",
+        description=(
+            "Select one public LingBot demo image and its matching prompt and calibration, then "
+            "queue the fresh world's first `main_video` chunk. Valid at any time; generation "
+            "remains paused and progress resets. Returns the complete `state_update`."
+        ),
+    )
+    def random_image(self) -> StateUpdate:
+        """Select a built-in sample and queue one paused preview chunk."""
+        sample = random.choice(self._require_config().samples)
+        self._select_sample(sample)
+        self.state.paused = True
+        self._request_restart(auto_step=True)
+        return self._state_update()
+
+    @event(
+        name="set_prompt",
+        description=(
+            "Set text conditioning for the next generated chunk without clearing visual self-KV "
+            "history. Valid after an anchor is selected and before the rollout limit. Returns "
+            "`state_update`, or `command_error` when the prompt is empty, no image is selected, "
+            "or a fresh rollout is required."
+        ),
+    )
+    def set_prompt(
+        self,
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            description=(
+                "Non-empty scene description up to 4096 characters. It replaces the active "
+                "cross-attention context at the next chunk boundary while self-KV history stays."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Queue a prompt change and return the complete shared state."""
+        normalized = prompt.strip()
+        if not normalized:
+            raise CommandError("prompt_required", "LingBot-World requires a prompt.")
+        if self._selected_input is None:
+            raise CommandError(
+                "image_required", "Select an anchor image before setting a prompt."
+            )
+        self._require_available_rollout()
+        self.state.prompt = normalized
+        return self._state_update()
+
+    @event(
+        name="set_forward",
+        description=(
+            "Set backward-to-forward camera translation for the next chunk. Valid before the "
+            "rollout limit; the value is held for later chunks. Returns `state_update`, or "
+            "`command_error` until a fresh rollout is started after the limit."
+        ),
+    )
+    def set_forward(
+        self,
+        forward: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Normalized backward (-1) to forward (1) translation. Zero stops this axis; the "
+                "value is sampled at the next chunk boundary and held."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set forward motion and return the complete shared state."""
+        return self._set_axis("forward", forward)
+
+    @event(
+        name="set_strafe",
+        description=(
+            "Set left-to-right camera translation for the next chunk. Valid before the rollout "
+            "limit; the value is held for later chunks. Returns `state_update`, or "
+            "`command_error` until a fresh rollout is started after the limit."
+        ),
+    )
+    def set_strafe(
+        self,
+        strafe: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Normalized left (-1) to right (1) translation. Zero stops this axis; the value "
+                "is sampled at the next chunk boundary and held."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set strafe motion and return the complete shared state."""
+        return self._set_axis("strafe", strafe)
+
+    @event(
+        name="set_vertical",
+        description=(
+            "Set down-to-up camera translation for the next chunk. Valid before the rollout "
+            "limit; the value is held for later chunks. Returns `state_update`, or "
+            "`command_error` until a fresh rollout is started after the limit."
+        ),
+    )
+    def set_vertical(
+        self,
+        vertical: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Normalized down (-1) to up (1) translation. Zero stops this axis; the value is "
+                "sampled at the next chunk boundary and held."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set vertical motion and return the complete shared state."""
+        return self._set_axis("vertical", vertical)
+
+    @event(
+        name="set_pitch",
+        description=(
+            "Set downward-to-upward camera pitch for the next chunk. Valid before the rollout "
+            "limit; the value is held for later chunks. Returns `state_update`, or "
+            "`command_error` until a fresh rollout is started after the limit."
+        ),
+    )
+    def set_pitch(
+        self,
+        pitch: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Normalized downward (-1) to upward (1) pitch. Zero stops this axis; the value "
+                "is sampled at the next chunk boundary and held."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set pitch and return the complete shared state."""
+        return self._set_axis("pitch", pitch)
+
+    @event(
+        name="set_yaw",
+        description=(
+            "Set left-to-right camera yaw for the next chunk. Valid before the rollout limit; "
+            "the value is held for later chunks. Returns `state_update`, or `command_error` "
+            "until a fresh rollout is started after the limit."
+        ),
+    )
+    def set_yaw(
+        self,
+        yaw: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Normalized left (-1) to right (1) yaw. Zero stops this axis; the value is "
+                "sampled at the next chunk boundary and held."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set yaw and return the complete shared state."""
+        return self._set_axis("yaw", yaw)
+
+    @event(
+        name="set_roll",
+        description=(
+            "Set counterclockwise-to-clockwise camera roll for the next chunk. Valid before the "
+            "rollout limit; the value is held for later chunks. Returns `state_update`, or "
+            "`command_error` until a fresh rollout is started after the limit."
+        ),
+    )
+    def set_roll(
+        self,
+        roll: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Normalized counterclockwise (-1) to clockwise (1) roll. Zero stops this axis; "
+                "the value is sampled at the next chunk boundary and held."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set roll and return the complete shared state."""
+        return self._set_axis("roll", roll)
+
+    @event(
+        name="set_paused",
+        description=(
+            "Pause before the next chunk or resume continuous generation. Valid at any time, "
+            "except that resuming requires an available rollout; either choice releases camera "
+            "axes and cancels a queued manual step. Returns `state_update` or `command_error`."
+        ),
+    )
+    def set_paused(
+        self,
+        paused: bool = InputField(
+            default=True,
+            description=(
+                "True waits before the next chunk; false generates continuously. The change "
+                "takes effect after an in-flight chunk and releases all six camera axes."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Set pause state and return the complete shared state."""
+        if not paused:
+            self._require_available_rollout()
+        self.state.paused = paused
+        self.state._step_requested = False
+        self._clear_controls()
+        return self._state_update()
+
+    @event(
+        name="step",
+        description=(
+            "Queue exactly one native `main_video` chunk without leaving paused mode. Valid only "
+            "while paused and before the rollout limit. Returns `state_update`, or "
+            "`command_error` when continuous generation is active or a reset is required."
+        ),
+    )
+    def step(self) -> StateUpdate:
+        """Queue one paused chunk and return the complete shared state."""
+        self._require_available_rollout()
+        if not self.state.paused:
+            raise CommandError("pause_required", "Pause LingBot-World before stepping.")
+        self.state._step_requested = True
+        return self._state_update()
+
+    @event(
+        name="reset",
+        description=(
+            "Restart from the selected image and prompt and queue one preview chunk. Valid when "
+            "an anchor exists; progress, caches, and camera axes reset while paused mode is "
+            "preserved. Returns `state_update`, or `command_error` when no image is selected."
+        ),
+    )
+    def reset(
+        self,
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description=(
+                "Seed from 0 to 2147483647 for the fresh rollout. Use -1 to retain the active "
+                "seed; a non-negative value becomes active when reset begins."
+            ),
+        ),
+    ) -> StateUpdate:
+        """Queue a reproducible fresh rollout and one paused preview chunk."""
+        if self._selected_input is None:
+            raise CommandError(
+                "image_required", "Select an anchor image before resetting."
+            )
+        if seed >= 0:
+            self._seed = seed
+        self._request_restart(auto_step=self.state.paused)
+        return self._state_update()
+
+    async def inference(self) -> AsyncGenerator[object, None]:
+        """Generate one native chunk per request and emit it at 16 FPS."""
+        backend = self._backend
+        planner = self._planner
+        config = self._require_config()
+        if backend is None or planner is None:
+            raise RuntimeError("LingBot-World v1 was not loaded")
+        while True:
+            if self.state._restart_requested:
+                selected = self._selected_input
+                intrinsics = self._selected_intrinsics
+                if selected is None or intrinsics is None:
+                    yield Idle
+                    continue
+                prompt = self.state.prompt.strip()
+                if not prompt:
+                    raise RuntimeError("LingBot-World requires a non-empty prompt")
+                self.state._restart_requested = False
+                await asyncio.to_thread(
+                    backend.reset,
+                    self._seed,
+                    selected,
+                    intrinsics,
+                    prompt,
+                )
+                if self.state._restart_requested:
+                    continue
+                planner.reset()
+                self._chunk_index = 0
+
+            if self.state._limit_reached:
+                yield Idle
+                continue
+            if self.state.paused and not self.state._step_requested:
+                yield Idle
+                continue
+
+            self.state._step_requested = False
+            camera = planner.plan_chunk(
+                strafe=self.state.strafe,
+                vertical=self.state.vertical,
+                forward=self.state.forward,
+                pitch=self.state.pitch,
+                yaw=self.state.yaw,
+                roll=self.state.roll,
+            )
+            self._chunk_in_flight = True
+            started = time.perf_counter()
+            try:
+                frames = await asyncio.to_thread(
+                    backend.generate_chunk,
+                    camera,
+                    self.state.prompt,
+                )
+            finally:
+                self._chunk_in_flight = False
+            self._last_chunk_seconds = time.perf_counter() - started
+            frames = normalize_output_frames(frames)
+            if self.state._restart_requested:
+                continue
+            self._chunk_index += 1
+            if self._chunk_index >= config.max_chunks:
+                self.state._limit_reached = True
+                self.state.paused = True
+                self._clear_controls()
+                await self.send(
+                    RolloutLimitReached(
+                        completed_chunks=self._chunk_index,
+                        max_chunks=config.max_chunks,
+                    )
+                )
+            await self.send(self._state_update())
+            for frame in frames:
+                if self.state._restart_requested:
+                    break
+                yield LingBotWorldOutput(main_video=frame)
+
+    def _set_axis(self, name: str, value: float) -> StateUpdate:
+        """Set one validated axis and return a complete state snapshot."""
+        self._require_available_rollout()
+        setattr(self.state, name, value)
+        return self._state_update()
+
+    def _select_sample(self, sample: Sample) -> None:
+        """Make one public sample the active image, calibration, and prompt."""
+        self._selected_input = sample.image
+        self._selected_intrinsics = sample.intrinsics
+        self.state.prompt = sample.prompt
+
+    def _clear_controls(self) -> None:
+        """Return every camera axis to neutral."""
+        self.state.forward = 0.0
+        self.state.strafe = 0.0
+        self.state.vertical = 0.0
+        self.state.pitch = 0.0
+        self.state.yaw = 0.0
+        self.state.roll = 0.0
+
+    def _request_restart(self, *, auto_step: bool) -> None:
+        """Queue a fresh causal rollout and release active camera motion."""
+        self._clear_controls()
+        self.state._step_requested = auto_step
+        self.state._restart_requested = True
+        self.state._limit_reached = False
+        self._chunk_index = 0
+        self._last_chunk_seconds = None
+
+    def _require_available_rollout(self) -> None:
+        """Reject controls that cannot apply until a fresh rollout starts."""
+        if self.state._limit_reached:
+            raise CommandError(
+                "rollout_limit_reached",
+                "Reset LingBot-World or select an image before requesting another chunk.",
+            )
+
+    def _require_config(self) -> LingBotConfig:
+        """Return loaded configuration or fail with a lifecycle error."""
+        if self._config is None:
+            raise RuntimeError("LingBot-World v1 was not loaded")
+        return self._config
+
+    def _next_control_chunk(self) -> int:
+        """Return the one-based chunk expected to consume newly accepted controls."""
+        if self.state._restart_requested:
+            return 1
+        return self._chunk_index + 1 + int(self._chunk_in_flight)
+
+    def _state_update(self) -> StateUpdate:
+        """Return a complete client-facing snapshot of shared world state."""
+        config = self._config
+        max_chunks = config.max_chunks if config is not None else 0
+        selected = self._selected_input
+        image_source = "upload" if isinstance(selected, UploadedFile) else "built_in"
+        image_name = selected.name if selected is not None else ""
+        if self.state._limit_reached:
+            next_chunk = None
+            next_chunk_frames = None
+        else:
+            next_chunk = self._next_control_chunk()
+            next_chunk_frames = 9 if next_chunk == 1 else 12
+        return StateUpdate(
+            prompt=self.state.prompt,
+            image_source=image_source,
+            image_name=image_name,
+            seed=self._seed,
+            paused=self.state.paused,
+            step_queued=self.state._step_requested,
+            limit_reached=self.state._limit_reached,
+            completed_chunks=self._chunk_index,
+            last_chunk_seconds=self._last_chunk_seconds,
+            next_chunk=next_chunk,
+            next_chunk_frames=next_chunk_frames,
+            max_chunks=max_chunks,
+            forward=self.state.forward,
+            strafe=self.state.strafe,
+            vertical=self.state.vertical,
+            pitch=self.state.pitch,
+            yaw=self.state.yaw,
+            roll=self.state.roll,
+        )

--- a/models/lingbot-world-v1-fast/lingbot_world_v1.py
+++ b/models/lingbot-world-v1-fast/lingbot_world_v1.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import importlib
 import random
 import time
@@ -167,12 +166,12 @@ class LingBotWorldV1(ReactorPipeline):
         await self.send(self._state_update())
 
     @session_ended
-    async def on_session_ended(self) -> None:
+    def on_session_ended(self) -> None:
         """Release causal caches while retaining loaded weights."""
         backend = self._backend
         try:
             if backend is not None:
-                await asyncio.to_thread(backend.end_session)
+                backend.end_session()
         finally:
             self._clear_controls()
             self.state._step_requested = False
@@ -497,8 +496,7 @@ class LingBotWorldV1(ReactorPipeline):
                 if not prompt:
                     raise RuntimeError("LingBot-World requires a non-empty prompt")
                 self.state._restart_requested = False
-                await asyncio.to_thread(
-                    backend.reset,
+                backend.reset(
                     self._seed,
                     selected,
                     intrinsics,
@@ -528,8 +526,7 @@ class LingBotWorldV1(ReactorPipeline):
             self._chunk_in_flight = True
             started = time.perf_counter()
             try:
-                frames = await asyncio.to_thread(
-                    backend.generate_chunk,
+                frames = backend.generate_chunk(
                     camera,
                     self.state.prompt,
                 )

--- a/models/lingbot-world-v1-fast/lingbot_world_v1.py
+++ b/models/lingbot-world-v1-fast/lingbot_world_v1.py
@@ -140,13 +140,13 @@ class LingBotWorldV1(ReactorPipeline):
 
     @session_started
     def on_session_started(self) -> None:
-        """Initialize one paused shared world and queue its preview chunk."""
+        """Initialize one unpaused shared world and queue its first chunk."""
         config = self._require_config()
         sample = config.samples[0]
         self._select_sample(sample)
         self._seed = config.seed
         self._clear_controls()
-        self.state.paused = True
+        self.state.paused = False
         self.state._step_requested = True
         self.state._restart_requested = True
         self.state._limit_reached = False
@@ -187,7 +187,7 @@ class LingBotWorldV1(ReactorPipeline):
         name="set_image",
         description=(
             "Replace the anchor image and queue the fresh world's first `main_video` chunk. "
-            "Valid at any time; generation remains paused, progress and camera axes reset, and "
+            "Valid at any time; generation runs continuously, progress and camera axes reset, and "
             "the upload is decoded before the command succeeds. Returns `state_update`, or "
             "`command_error` for invalid image bytes, media type, dimensions, or an empty prompt."
         ),
@@ -209,14 +209,14 @@ class LingBotWorldV1(ReactorPipeline):
             ),
         ),
     ) -> StateUpdate:
-        """Select an upload, remain paused, and queue one preview chunk."""
+        """Select an upload and begin a fresh continuous rollout."""
         validate_uploaded_image(image)
         normalized = prompt.strip() or self.state.prompt.strip() or self._default_prompt
         if not normalized:
             raise CommandError("prompt_required", "LingBot-World requires a prompt.")
         self._selected_input = image
         self.state.prompt = normalized
-        self.state.paused = True
+        self.state.paused = False
         self._request_restart(auto_step=True)
         return self._state_update()
 
@@ -225,14 +225,14 @@ class LingBotWorldV1(ReactorPipeline):
         description=(
             "Select one public LingBot demo image and its matching prompt and calibration, then "
             "queue the fresh world's first `main_video` chunk. Valid at any time; generation "
-            "remains paused and progress resets. Returns the complete `state_update`."
+            "runs continuously and progress resets. Returns the complete `state_update`."
         ),
     )
     def random_image(self) -> StateUpdate:
-        """Select a built-in sample and queue one paused preview chunk."""
+        """Select a built-in sample and begin a fresh continuous rollout."""
         sample = random.choice(self._require_config().samples)
         self._select_sample(sample)
-        self.state.paused = True
+        self.state.paused = False
         self._request_restart(auto_step=True)
         return self._state_update()
 
@@ -406,18 +406,11 @@ class LingBotWorldV1(ReactorPipeline):
         """Set roll and return the complete shared state."""
         return self._set_axis("roll", roll)
 
-    @event(
-        name="set_paused",
-        description=(
-            "Pause before the next chunk or resume continuous generation. Valid at any time, "
-            "except that resuming requires an available rollout; either choice releases camera "
-            "axes and cancels a queued manual step. Returns `state_update` or `command_error`."
-        ),
-    )
+    # Keep pause available for future schema re-enablement without exposing it to clients.
     def set_paused(
         self,
         paused: bool = InputField(
-            default=True,
+            default=False,
             description=(
                 "True waits before the next chunk; false generates continuously. The change "
                 "takes effect after an in-flight chunk and releases all six camera axes."
@@ -432,14 +425,7 @@ class LingBotWorldV1(ReactorPipeline):
         self._clear_controls()
         return self._state_update()
 
-    @event(
-        name="step",
-        description=(
-            "Queue exactly one native `main_video` chunk without leaving paused mode. Valid only "
-            "while paused and before the rollout limit. Returns `state_update`, or "
-            "`command_error` when continuous generation is active or a reset is required."
-        ),
-    )
+    # Keep single-step generation available for future schema re-enablement.
     def step(self) -> StateUpdate:
         """Queue one paused chunk and return the complete shared state."""
         self._require_available_rollout()

--- a/models/lingbot-world-v1-fast/lingbot_world_v1.py
+++ b/models/lingbot-world-v1-fast/lingbot_world_v1.py
@@ -60,6 +60,7 @@ else:
 logger = get_logger(__name__)
 
 FPS = 16
+FRAMES_PER_CHUNK = 12
 
 
 class _Backend(Protocol):
@@ -86,8 +87,7 @@ class LingBotWorldV1(ReactorPipeline):
 
     state: LingBotWorldState
     output: LingBotWorldOutput
-    fps = FPS
-    buffer_size = 1
+    buffer_size = FRAMES_PER_CHUNK
 
     def __init__(self) -> None:
         super().__init__()
@@ -480,7 +480,7 @@ class LingBotWorldV1(ReactorPipeline):
         return self._state_update()
 
     async def inference(self) -> AsyncGenerator[object, None]:
-        """Generate one native chunk per request and emit it at 16 FPS."""
+        """Generate and emit one native chunk per request."""
         backend = self._backend
         planner = self._planner
         config = self._require_config()
@@ -551,10 +551,7 @@ class LingBotWorldV1(ReactorPipeline):
                     )
                 )
             await self.send(self._state_update())
-            for frame in frames:
-                if self.state._restart_requested:
-                    break
-                yield LingBotWorldOutput(main_video=frame)
+            yield LingBotWorldOutput(main_video=frames)
 
     def _set_axis(self, name: str, value: float) -> StateUpdate:
         """Set one validated axis and return a complete state snapshot."""
@@ -585,6 +582,7 @@ class LingBotWorldV1(ReactorPipeline):
         self.state._limit_reached = False
         self._chunk_index = 0
         self._last_chunk_seconds = None
+        self.output.flush()
 
     def _require_available_rollout(self) -> None:
         """Reject controls that cannot apply until a fresh rollout starts."""

--- a/models/lingbot-world-v1-fast/lingbot_world_v1.py
+++ b/models/lingbot-world-v1-fast/lingbot_world_v1.py
@@ -140,14 +140,15 @@ class LingBotWorldV1(ReactorPipeline):
 
     @session_started
     def on_session_started(self) -> None:
-        """Initialize one unpaused shared world and queue its first chunk."""
+        """Initialize an empty shared world before its first image selection."""
         config = self._require_config()
-        sample = config.samples[0]
-        self._select_sample(sample)
+        self.state.prompt = ""
+        self._selected_input = None
+        self._selected_intrinsics = None
         self._seed = config.seed
         self._clear_controls()
         self.state.paused = False
-        self.state._step_requested = True
+        self.state._step_requested = False
         self.state._restart_requested = True
         self.state._limit_reached = False
         self._chunk_index = 0
@@ -215,6 +216,8 @@ class LingBotWorldV1(ReactorPipeline):
         if not normalized:
             raise CommandError("prompt_required", "LingBot-World requires a prompt.")
         self._selected_input = image
+        if self._selected_intrinsics is None:
+            self._selected_intrinsics = self._require_config().samples[0].intrinsics
         self.state.prompt = normalized
         self.state.paused = False
         self._request_restart(auto_step=True)
@@ -569,6 +572,11 @@ class LingBotWorldV1(ReactorPipeline):
 
     def _require_available_rollout(self) -> None:
         """Reject controls that cannot apply until a fresh rollout starts."""
+        if self._selected_input is None:
+            raise CommandError(
+                "image_required",
+                "Upload an image or select a random image before this command.",
+            )
         if self.state._limit_reached:
             raise CommandError(
                 "rollout_limit_reached",
@@ -592,9 +600,14 @@ class LingBotWorldV1(ReactorPipeline):
         config = self._config
         max_chunks = config.max_chunks if config is not None else 0
         selected = self._selected_input
-        image_source = "upload" if isinstance(selected, UploadedFile) else "built_in"
+        if isinstance(selected, UploadedFile):
+            image_source = "upload"
+        elif selected is None:
+            image_source = "none"
+        else:
+            image_source = "built_in"
         image_name = selected.name if selected is not None else ""
-        if self.state._limit_reached:
+        if selected is None or self.state._limit_reached:
             next_chunk = None
             next_chunk_frames = None
         else:

--- a/models/lingbot-world-v1-fast/lingbot_world_v1.yaml
+++ b/models/lingbot-world-v1-fast/lingbot_world_v1.yaml
@@ -1,0 +1,45 @@
+source:
+  path: lingbot-world-v1
+  url: https://github.com/robbyant/lingbot-world.git
+  revision: a43bec7f8091c83e9b30b16b912f6fc906236fa6
+
+assets:
+  base:
+    repo_id: robbyant/lingbot-world-base-cam
+    revision: 6fc824ffc338d64c97c77e2eb8c0f4cfc24d82bd
+  fast:
+    repo_id: robbyant/lingbot-world-fast
+    revision: b7a1db2da9bd3ba675ee01c228f41db0309b981e
+
+samples:
+  - image: examples/03/image.jpg
+    intrinsics: examples/03/intrinsics.npy
+    prompt: >-
+      A serene lakeside scene with a lone tree standing in calm water, surrounded by distant
+      snow-capped mountains under a bright blue sky with drifting white clouds. Gentle ripples
+      reflect the tree and sky as the camera moves smoothly through the tranquil landscape.
+  - image: examples/04/image.jpg
+    intrinsics: examples/04/intrinsics.npy
+    prompt: >-
+      A sweeping cinematic journey along the Great Wall of China, winding through golden autumn
+      hills under a brilliant blue sky. Stone pathways stretch into the distance as the camera
+      glides smoothly forward through the ancient landscape.
+
+inference:
+  seed: 42
+  # Official Fast inference resolution and flow-matching shift.
+  max_area: 399360
+  shift: 10.0
+
+stream:
+  # Official 81-frame inference has 21 VAE latents. Preserve that memory length
+  # as a rolling KV window while requesting one three-latent chunk at a time.
+  context_latents: 21
+  # Fast RoPE tables contain 1024 latent positions; 320 chunks use 960.
+  max_chunks: 320
+
+motion:
+  # Upstream demo trajectories move 0.05 units and rotate 2 degrees per RGB
+  # frame, then sample every four frames and normalize non-zero translation.
+  translation_units_per_latent: 1.0
+  rotation_degrees_per_latent: 8.0

--- a/models/lingbot-world-v1-fast/reactor.yaml
+++ b/models/lingbot-world-v1-fast/reactor.yaml
@@ -1,0 +1,52 @@
+$schema: reactor/v1
+
+model:
+  name: lingbot-world-v1-fast-camera
+  version: v0.0.1
+  description: |
+    Explore LingBot-World v1 Fast from an image, prompt, and six-axis camera motion.
+  resources:
+    gpu:
+      type: NVIDIA_B200
+      count: 1
+    cpu:
+      request: "4"
+      limit: "16"
+    memory:
+      request: 32Gi
+      limit: 128Gi
+
+runtime:
+  import: lingbot_world_v1:LingBotWorldV1
+  config: lingbot_world_v1.yaml
+  weights_path: ~/.cache/reactor_registry/lingbot-world-v1-fast
+
+build:
+  # Reactor generates the image definition from this block. The Runtime pin
+  # must match requirements.txt so local builds and hosted releases use the
+  # same authoring surface.
+  runtime_version: "3.1.2"
+  python_requirements: requirements.txt
+  # CUDA 12.8 wheels contain the kernels used by the B200 declared above and
+  # match the isolated upstream worker environment prepared on first load.
+  cuda_version: "12.8.1"
+  python_version: "3.12"
+  system_packages:
+    # First load clones the pinned public source and compiles FlashAttention 2
+    # in the persistent weights cache.
+    - build-essential
+    - git
+    - libgl1
+    - libglib2.0-0
+  runtime_env:
+    TOKENIZERS_PARALLELISM: "false"
+
+recording:
+  enabled: true
+  chunk_seconds: 4
+  clip_max_seconds: 300
+  video_track: main_video
+  video:
+    codec: h264
+    preset: veryfast
+    crf: 23

--- a/models/lingbot-world-v1-fast/reactor.yaml
+++ b/models/lingbot-world-v1-fast/reactor.yaml
@@ -22,10 +22,8 @@ runtime:
   weights_path: ~/.cache/reactor_registry/lingbot-world-v1-fast
 
 build:
-  # Reactor generates the image definition from this block. The Runtime pin
-  # must match requirements.txt so local builds and hosted releases use the
-  # same authoring surface.
-  runtime_version: "3.1.2"
+  # Keep the Runtime release aligned with the adapter's public API usage.
+  runtime_version: "3.2.3"
   python_requirements: requirements.txt
   # CUDA 12.8 wheels contain the kernels used by the B200 declared above and
   # match the isolated upstream worker environment prepared on first load.

--- a/models/lingbot-world-v1-fast/requirements.txt
+++ b/models/lingbot-world-v1-fast/requirements.txt
@@ -1,5 +1,3 @@
-# Runtime and upstream inference use different NumPy major versions. This file
-# describes only the Python 3.12 serving process; load() prepares the isolated
-# upstream model environment from worker-requirements.txt.
-reactor-runtime==3.1.2
+# The Python 3.12 serving process uses Pillow for uploaded image validation.
+# load() prepares the isolated upstream environment from worker-requirements.txt.
 Pillow>=10.1

--- a/models/lingbot-world-v1-fast/requirements.txt
+++ b/models/lingbot-world-v1-fast/requirements.txt
@@ -1,0 +1,5 @@
+# Runtime and upstream inference use different NumPy major versions. This file
+# describes only the Python 3.12 serving process; load() prepares the isolated
+# upstream model environment from worker-requirements.txt.
+reactor-runtime==3.1.2
+Pillow>=10.1

--- a/models/lingbot-world-v1-fast/stateful_rollout.patch
+++ b/models/lingbot-world-v1-fast/stateful_rollout.patch
@@ -1,0 +1,374 @@
+diff --git a/wan/interactive_fast.py b/wan/interactive_fast.py
+new file mode 100644
+index 0000000..441b00f
+--- /dev/null
++++ b/wan/interactive_fast.py
+@@ -0,0 +1,368 @@
++"""Expose LingBot-World-Fast's native causal loop one chunk at a time."""
++
++from __future__ import annotations
++
++import hashlib
++import math
++from contextlib import contextmanager, nullcontext
++
++import numpy as np
++import torch
++import torchvision.transforms.functional as TF
++from einops import rearrange
++
++from .utils.cam_utils import get_Ks_transformed, get_plucker_embeddings
++
++
++class InteractiveFastRollout:
++    """Keep LingBot's native KV and VAE caches alive across chunk requests."""
++
++    def __init__(
++        self,
++        pipe,
++        *,
++        max_chunks: int,
++        context_latents: int = 21,
++        chunk_size: int = 3,
++        max_area: int = 480 * 832,
++        shift: float = 10.0,
++        timesteps_index: tuple[int, ...] = (0, 179, 358, 679),
++        max_sequence_length: int = 512,
++    ) -> None:
++        if chunk_size != 3:
++            raise ValueError("LingBot-World-Fast expects three latent frames per chunk")
++        if context_latents < chunk_size or context_latents % chunk_size:
++            raise ValueError(
++                "context_latents must be a positive multiple of chunk_size"
++            )
++        if max_chunks <= 0 or max_chunks * chunk_size > 1024:
++            raise ValueError(
++                "max_chunks must keep the latent RoPE timeline within 1024 frames"
++            )
++        if pipe.local_attn_size != context_latents:
++            raise ValueError(
++                "the pipeline local attention size must match context_latents "
++                f"({pipe.local_attn_size} != {context_latents})"
++            )
++        self.pipe = pipe
++        self.max_chunks = max_chunks
++        self.context_latents = context_latents
++        self.chunk_size = chunk_size
++        self.max_area = max_area
++        self.shift = shift
++        self.timesteps_index = timesteps_index
++        self.max_sequence_length = max_sequence_length
++        self._active = False
++
++    def reset(self, prompt: str, image, intrinsics: np.ndarray, seed: int) -> None:
++        """Start a fresh causal rollout without reloading model weights."""
++        prompt = prompt.strip()
++        if not prompt:
++            raise ValueError("LingBot-World-Fast requires a non-empty prompt")
++        self.end()
++        pipe = self.pipe
++        image_tensor = TF.to_tensor(image).sub_(0.5).div_(0.5).to(pipe.device)
++        image_h, image_w = image_tensor.shape[1:]
++        aspect_ratio = image_h / image_w
++        self.lat_h = round(
++            np.sqrt(self.max_area * aspect_ratio)
++            // pipe.vae_stride[1]
++            // pipe.patch_size[1]
++            * pipe.patch_size[1]
++        )
++        self.lat_w = round(
++            np.sqrt(self.max_area / aspect_ratio)
++            // pipe.vae_stride[2]
++            // pipe.patch_size[2]
++            * pipe.patch_size[2]
++        )
++        self.height = self.lat_h * pipe.vae_stride[1]
++        self.width = self.lat_w * pipe.vae_stride[2]
++        self.frame_seqlen = self.lat_h * self.lat_w // 4
++        self.max_seq_len = int(
++            math.ceil(self.chunk_size * self.frame_seqlen / pipe.sp_size) * pipe.sp_size
++        )
++
++        packed_intrinsics = torch.as_tensor(intrinsics, dtype=torch.float32)
++        if packed_intrinsics.ndim == 2:
++            packed_intrinsics = packed_intrinsics[0]
++        if tuple(packed_intrinsics.shape) != (4,):
++            raise ValueError(
++                "camera intrinsics must have shape (4,) or (N, 4); "
++                f"got {tuple(packed_intrinsics.shape)}"
++            )
++        self.intrinsics = get_Ks_transformed(
++            packed_intrinsics[None],
++            height_org=480,
++            width_org=832,
++            height_resize=self.height,
++            width_resize=self.width,
++            height_final=self.height,
++            width_final=self.width,
++        )[0].to(pipe.device)
++
++        seed = int(seed)
++        if seed < 0:
++            raise ValueError("interactive seeds must be non-negative")
++        self.seed_generator = torch.Generator(device=pipe.device)
++        self.seed_generator.manual_seed(seed)
++        self.noise = torch.randn(
++            16,
++            self.max_chunks * self.chunk_size,
++            self.lat_h,
++            self.lat_w,
++            dtype=torch.float32,
++            generator=self.seed_generator,
++            device=pipe.device,
++        )
++
++        pipe.scheduler.set_timesteps(pipe.num_train_timesteps, shift=self.shift)
++        self.timesteps = pipe.scheduler.timesteps[list(self.timesteps_index)]
++        self.prompt = prompt
++        self.context = self._encode_prompt(prompt, clear_cache=True)
++        self.cross_kv_cache = self._new_cross_attention_cache()
++        self.cross_attn_initialized = False
++
++        self.anchor_image = (
++            torch.nn.functional.interpolate(
++                image_tensor[None].cpu(),
++                size=(self.height, self.width),
++                mode="bicubic",
++            )
++            .transpose(0, 1)
++            .to(pipe.device)
++        )
++
++        model_args = pipe.model.config
++        kv_size = self.frame_seqlen * self.context_latents
++        head_dim = model_args.dim // model_args.num_heads
++        local_num_heads = model_args.num_heads // pipe.sp_size
++        self.self_kv_cache = pipe._initialize_self_kv_cache(
++            num_layers=model_args.num_layers,
++            shape=[1, kv_size, local_num_heads, head_dim],
++            dtype=pipe.pipe_dtype,
++            device=pipe.device,
++        )
++        pipe.vae.model.clear_cache()
++        self.chunk_index = 0
++        self._active = True
++
++    def generate_chunk(self, relative_c2ws: np.ndarray, prompt: str) -> torch.Tensor:
++        """Generate and decode exactly one native three-latent causal chunk."""
++        if not self._active:
++            raise RuntimeError("start an interactive rollout before generating a chunk")
++        if self.chunk_index >= self.max_chunks:
++            raise RuntimeError("interactive rollout reached its configured chunk limit")
++        prompt = prompt.strip()
++        if not prompt:
++            raise ValueError("LingBot-World-Fast requires a non-empty prompt")
++        if prompt != self.prompt:
++            self.prompt = prompt
++            self.context = self._encode_prompt(prompt, clear_cache=True)
++            self.cross_kv_cache = self._new_cross_attention_cache()
++            self.cross_attn_initialized = False
++
++        c2ws = torch.as_tensor(
++            relative_c2ws, dtype=torch.float32, device=self.pipe.device
++        )
++        expected_pose_shape = (self.chunk_size, 4, 4)
++        if tuple(c2ws.shape) != expected_pose_shape:
++            raise ValueError(
++                f"relative camera poses must have shape {expected_pose_shape}; got {tuple(c2ws.shape)}"
++            )
++        intrinsics = self.intrinsics.repeat(self.chunk_size, 1)
++        plucker = get_plucker_embeddings(c2ws, intrinsics, self.height, self.width)
++        plucker = rearrange(
++            plucker,
++            "f (h c1) (w c2) c -> (f h w) (c c1 c2)",
++            c1=self.height // self.lat_h,
++            c2=self.width // self.lat_w,
++        )
++        plucker = rearrange(
++            plucker[None],
++            "b (f h w) c -> b c f h w",
++            f=self.chunk_size,
++            h=self.lat_h,
++            w=self.lat_w,
++        ).to(self.pipe.param_dtype)
++
++        latent_start = self.chunk_index * self.chunk_size
++        latent_end = latent_start + self.chunk_size
++        current_latent = self.noise[:, latent_start:latent_end]
++        current_condition = self._encode_condition_chunk()
++
++        current_start = latent_start * self.frame_seqlen
++        kv_size = self.frame_seqlen * self.context_latents
++        kwargs = {
++            "context": [self.context[0]],
++            "seq_len": self.max_seq_len,
++            "y": [current_condition],
++            "dit_cond_dict": {"c2ws_plucker_emb": plucker.chunk(1, dim=0)},
++            "kv_cache": self.self_kv_cache,
++            "crossattn_cache": self.cross_kv_cache,
++            "current_start": current_start,
++            "max_attention_size": kv_size,
++            "frame_seqlen": self.frame_seqlen,
++        }
++
++        @contextmanager
++        def noop_no_sync():
++            yield
++
++        no_sync_model = getattr(self.pipe.model, "no_sync", noop_no_sync)
++        with (
++            torch.amp.autocast("cuda", dtype=self.pipe.param_dtype),
++            torch.no_grad(),
++            no_sync_model(),
++        ):
++            for timestep_index, timestep_value in enumerate(self.timesteps):
++                timestep = timestep_value[None].to(self.pipe.device)
++                noise_pred = self.pipe.model(
++                    x=[current_latent],
++                    t=timestep,
++                    cross_attn_first_call=not self.cross_attn_initialized,
++                    **kwargs,
++                )[0]
++                self.cross_attn_initialized = True
++                x0 = self.pipe._convert_flow_pred_to_x0(
++                    flow_pred=noise_pred,
++                    xt=current_latent,
++                    timestep=timestep_value,
++                    scheduler=self.pipe.scheduler,
++                )
++                if timestep_index < len(self.timesteps) - 1:
++                    current_latent = self.pipe.scheduler.add_noise(
++                        x0,
++                        torch.randn(
++                            x0.shape,
++                            generator=self.seed_generator,
++                            device=x0.device,
++                            dtype=x0.dtype,
++                        ),
++                        self.timesteps[timestep_index + 1],
++                    )
++            zero_timestep = (self.timesteps[-1] * 0.0)[None].to(self.pipe.device)
++            self.pipe.model(
++                x=[x0],
++                t=zero_timestep,
++                cross_attn_first_call=False,
++                **kwargs,
++            )
++
++        video = self._decode_chunk(x0)
++        self.chunk_index += 1
++        return video
++
++    def end(self) -> None:
++        """Release rollout caches while preserving loaded model weights."""
++        if not self._active:
++            return
++        self._active = False
++        for name in (
++            "noise",
++            "anchor_image",
++            "context",
++            "self_kv_cache",
++            "cross_kv_cache",
++            "seed_generator",
++        ):
++            if hasattr(self, name):
++                delattr(self, name)
++        self.pipe.vae.model.clear_cache()
++        torch.cuda.empty_cache()
++
++    def _encode_prompt(self, prompt: str, *, clear_cache: bool) -> list[torch.Tensor]:
++        """Encode one prompt with the upstream T5 path and bounded cache."""
++        pipe = self.pipe
++        if clear_cache:
++            pipe.clear_text_cache()
++        cache_key = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
++        if cache_key not in pipe._t5_cache:
++            if not pipe.t5_cpu:
++                pipe.text_encoder.model.to(pipe.device)
++                context = pipe.text_encoder([prompt], pipe.device)
++            else:
++                context = pipe.text_encoder([prompt], torch.device("cpu"))
++                context = [tensor.to(pipe.device) for tensor in context]
++            pipe._t5_cache[cache_key] = context
++        return pipe._t5_cache[cache_key]
++
++    def _new_cross_attention_cache(self):
++        """Allocate cross-attention storage for the active prompt."""
++        model_args = self.pipe.model.config
++        head_dim = model_args.dim // model_args.num_heads
++        return self.pipe._initialize_crossattn_cache(
++            num_layers=model_args.num_layers,
++            shape=[1, self.max_sequence_length, model_args.num_heads, head_dim],
++            dtype=self.pipe.pipe_dtype,
++            device=self.pipe.device,
++        )
++
++    def _encode_condition_chunk(self) -> torch.Tensor:
++        """Encode the anchor-plus-zero I2V condition with causal VAE state."""
++        vae = self.pipe.vae
++        model = vae.model
++        encoded = []
++        with self._vae_autocast():
++            for latent_offset in range(self.chunk_size):
++                if self.chunk_index == 0 and latent_offset == 0:
++                    video_input = self.anchor_image[None]
++                else:
++                    video_input = torch.zeros(
++                        1,
++                        3,
++                        self.pipe.vae_stride[0],
++                        self.height,
++                        self.width,
++                        dtype=self.anchor_image.dtype,
++                        device=self.pipe.device,
++                    )
++                model._enc_conv_idx = [0]
++                features = model.encoder(
++                    video_input,
++                    feat_cache=model._enc_feat_map,
++                    feat_idx=model._enc_conv_idx,
++                )
++                mean, _ = model.conv1(features).chunk(2, dim=1)
++                mean = mean - vae.scale[0].view(1, model.z_dim, 1, 1, 1)
++                mean = mean * vae.scale[1].view(1, model.z_dim, 1, 1, 1)
++                encoded.append(mean.float().squeeze(0))
++        mask = torch.zeros(
++            4,
++            self.chunk_size,
++            self.lat_h,
++            self.lat_w,
++            dtype=encoded[0].dtype,
++            device=self.pipe.device,
++        )
++        if self.chunk_index == 0:
++            mask[:, 0] = 1
++        return torch.cat([mask, torch.cat(encoded, dim=1)])
++
++    def _decode_chunk(self, latent: torch.Tensor) -> torch.Tensor:
++        """Decode a latent chunk while retaining the upstream causal VAE cache."""
++        vae = self.pipe.vae
++        model = vae.model
++        z = latent[None]
++        with self._vae_autocast():
++            z = z / vae.scale[1].view(1, model.z_dim, 1, 1, 1)
++            z = z + vae.scale[0].view(1, model.z_dim, 1, 1, 1)
++            decoded_input = model.conv2(z)
++            frames = []
++            for latent_index in range(decoded_input.shape[2]):
++                model._conv_idx = [0]
++                frames.append(
++                    model.decoder(
++                        decoded_input[:, :, latent_index : latent_index + 1],
++                        feat_cache=model._feat_map,
++                        feat_idx=model._conv_idx,
++                    )
++                )
++        return torch.cat(frames, dim=2).float().clamp_(-1, 1).squeeze(0)
++
++    def _vae_autocast(self):
++        """Match the upstream VAE precision without deprecated AMP APIs."""
++        dtype = self.pipe.vae.dtype
++        if dtype in (torch.float16, torch.bfloat16):
++            return torch.amp.autocast("cuda", dtype=dtype)
++        return nullcontext()

--- a/models/lingbot-world-v1-fast/tests/test_lingbot_world_v1.py
+++ b/models/lingbot-world-v1-fast/tests/test_lingbot_world_v1.py
@@ -1,0 +1,81 @@
+"""Test LingBot-World v1 session and image-selection contracts."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from reactor_runtime import CommandError, UploadedFile
+
+MODEL_DIR = Path(__file__).parents[1]
+sys.path.insert(0, str(MODEL_DIR))
+
+lingbot_schema = importlib.import_module("lingbot_schema")
+lingbot_world_v1 = importlib.import_module("lingbot_world_v1")
+
+
+def _world() -> Any:
+    sample = SimpleNamespace(
+        image=Path("sample.jpg"),
+        intrinsics=Path("intrinsics.npy"),
+        prompt="A calm lakeside world",
+    )
+    config: Any = SimpleNamespace(seed=42, samples=(sample,), max_chunks=320)
+    world = lingbot_world_v1.LingBotWorldV1()
+    world.state = lingbot_schema.LingBotWorldState()
+    world._config = config
+    world._default_prompt = sample.prompt
+    return world
+
+
+def test_session_waits_for_an_explicit_image_selection() -> None:
+    """Expose an empty idle world until upload or random selection succeeds."""
+    world = _world()
+
+    world.on_session_started()
+    state = world._state_update()
+
+    assert world._selected_input is None
+    assert world._selected_intrinsics is None
+    assert state.prompt == ""
+    assert state.image_source == "none"
+    assert state.image_name == ""
+    assert state.next_chunk is None
+    assert state.next_chunk_frames is None
+    assert state.paused is False
+    assert state.step_queued is False
+
+
+def test_first_upload_uses_the_default_public_calibration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Allow upload to initialize a world before any built-in image is selected."""
+    world = _world()
+    world.on_session_started()
+    monkeypatch.setattr(
+        lingbot_world_v1, "validate_uploaded_image", lambda _image: None
+    )
+    upload = UploadedFile(name="anchor.png", mime_type="image/png", data=b"image")
+
+    state = world.set_image(upload, "")
+
+    assert world._selected_input is upload
+    assert world._selected_intrinsics == Path("intrinsics.npy")
+    assert state.prompt == "A calm lakeside world"
+    assert state.image_source == "upload"
+    assert state.image_name == "anchor.png"
+    assert state.next_chunk == 1
+    assert state.next_chunk_frames == 9
+
+
+def test_camera_controls_require_an_image() -> None:
+    """Reject motion that has no selected world to control."""
+    world = _world()
+    world.on_session_started()
+
+    with pytest.raises(CommandError):
+        world.set_forward(1.0)

--- a/models/lingbot-world-v1-fast/upstream_backend.py
+++ b/models/lingbot-world-v1-fast/upstream_backend.py
@@ -1,0 +1,209 @@
+"""Keep LingBot weights and causal state resident in an isolated worker."""
+
+from __future__ import annotations
+
+import atexit
+import json
+import os
+import subprocess
+import tempfile
+import threading
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from reactor_runtime import UploadedFile
+from reactor_runtime.log import get_logger
+
+logger = get_logger(__name__)
+
+_RESPONSE_PREFIX = "REACTOR_LINGBOT_V1_RESPONSE "
+_UPLOAD_SUFFIXES = {
+    "image/bmp": ".bmp",
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+}
+
+
+@dataclass(frozen=True)
+class WorkerSettings:
+    """Hold paths and inference settings passed to the model worker."""
+
+    python_executable: Path
+    source_path: Path
+    checkpoint_dir: Path
+    runtime_root: Path
+    max_chunks: int
+    context_latents: int
+    max_area: int
+    shift: float
+
+
+class LingBotWorkerBackend:
+    """Run the NumPy-1 upstream stack without duplicating its model process."""
+
+    def __init__(self, settings: WorkerSettings) -> None:
+        self._settings = settings
+        settings.runtime_root.mkdir(parents=True, exist_ok=True)
+        self._temporary = tempfile.TemporaryDirectory(
+            prefix="reactor-lingbot-world-v1-",
+            dir=settings.runtime_root,
+        )
+        self._root = Path(self._temporary.name)
+        self._lock = threading.Lock()
+        self._request_id = 0
+        self._recent_output: deque[str] = deque(maxlen=100)
+        worker = Path(__file__).with_name("worker.py")
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = os.pathsep.join(
+            filter(None, (str(settings.source_path), environment.get("PYTHONPATH", "")))
+        )
+        cache_root = settings.source_path.parent / ".cache"
+        environment.update(
+            {
+                "HF_HOME": str(cache_root / "huggingface"),
+                "HUGGINGFACE_HUB_CACHE": str(cache_root / "huggingface" / "hub"),
+                "TORCH_HOME": str(cache_root / "torch"),
+                "TMPDIR": str(cache_root / "tmp"),
+                "PYTORCH_ALLOC_CONF": "expandable_segments:True",
+                "TOKENIZERS_PARALLELISM": "false",
+            }
+        )
+        Path(environment["TMPDIR"]).mkdir(parents=True, exist_ok=True)
+        self._process = subprocess.Popen(
+            [str(settings.python_executable), str(worker)],
+            cwd=settings.source_path,
+            env=environment,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        atexit.register(self.close)
+        self._request(
+            "initialize",
+            checkpoint_dir=str(settings.checkpoint_dir),
+            runtime_root=str(self._root / "worker"),
+            max_chunks=settings.max_chunks,
+            context_latents=settings.context_latents,
+            max_area=settings.max_area,
+            shift=settings.shift,
+        )
+
+    def reset(
+        self,
+        seed: int,
+        anchor_image: Path | UploadedFile,
+        intrinsics: Path,
+        prompt: str,
+    ) -> None:
+        """Start a fresh rollout from one image, calibration, and prompt."""
+        upload_path: Path | None = None
+        if isinstance(anchor_image, UploadedFile):
+            suffix = _UPLOAD_SUFFIXES.get(anchor_image.mime_type.lower(), ".image")
+            upload_path = self._root / f"anchor_{self._request_id + 1}{suffix}"
+            upload_path.write_bytes(anchor_image.data)
+            image_path = upload_path
+        else:
+            image_path = anchor_image
+        try:
+            self._request(
+                "reset",
+                seed=int(seed),
+                anchor_image=str(image_path),
+                intrinsics=str(intrinsics),
+                prompt=prompt,
+            )
+        finally:
+            if upload_path is not None:
+                upload_path.unlink(missing_ok=True)
+
+    def generate_chunk(self, relative_c2ws: np.ndarray, prompt: str) -> np.ndarray:
+        """Generate one native chunk while preserving upstream KV and VAE caches."""
+        poses = np.asarray(relative_c2ws, dtype=np.float32)
+        if poses.shape != (3, 4, 4) or not np.isfinite(poses).all():
+            raise ValueError(
+                "LingBot relative camera poses must be finite with shape (3, 4, 4)"
+            )
+        response = self._request(
+            "generate",
+            relative_c2ws=poses.tolist(),
+            prompt=prompt,
+        )
+        output = Path(str(response["output"]))
+        try:
+            frames = np.load(output, allow_pickle=False)
+            expected = int(response["frame_count"])
+            if frames.shape[0] != expected or frames.shape[-1] != 3:
+                raise RuntimeError(
+                    f"LingBot generated shape {frames.shape}; expected {expected} RGB frames"
+                )
+            return np.ascontiguousarray(frames, dtype=np.uint8)
+        finally:
+            output.unlink(missing_ok=True)
+
+    def end_session(self) -> None:
+        """Release rollout caches while retaining the loaded model weights."""
+        self._request("end_session")
+
+    def close(self) -> None:
+        """Stop the worker and remove its NVMe request workspace."""
+        process = getattr(self, "_process", None)
+        if process is None:
+            return
+        self._process = None
+        if process.poll() is None:
+            try:
+                assert process.stdin is not None
+                process.stdin.write(
+                    json.dumps({"id": -1, "command": "shutdown"}) + "\n"
+                )
+                process.stdin.flush()
+                process.wait(timeout=10)
+            except (BrokenPipeError, subprocess.TimeoutExpired):
+                process.terminate()
+                try:
+                    process.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+        self._temporary.cleanup()
+
+    def _request(self, command: str, **payload: object) -> dict[str, Any]:
+        """Send one JSON-line request and return its correlated response."""
+        with self._lock:
+            process = self._process
+            if process is None or process.poll() is not None:
+                detail = "\n".join(self._recent_output)
+                raise RuntimeError(f"LingBot worker is not running\n{detail}")
+            self._request_id += 1
+            request_id = self._request_id
+            request = {"id": request_id, "command": command, **payload}
+            assert process.stdin is not None
+            assert process.stdout is not None
+            process.stdin.write(json.dumps(request) + "\n")
+            process.stdin.flush()
+            while True:
+                line = process.stdout.readline()
+                if not line:
+                    detail = "\n".join(self._recent_output)
+                    raise RuntimeError(
+                        f"LingBot worker exited with code {process.poll()}\n{detail}"
+                    )
+                line = line.rstrip()
+                if not line.startswith(_RESPONSE_PREFIX):
+                    self._recent_output.append(line)
+                    if line:
+                        logger.info("LingBot worker", output=line[-1000:])
+                    continue
+                response = json.loads(line.removeprefix(_RESPONSE_PREFIX))
+                if int(response.get("id", -2)) != request_id:
+                    continue
+                if not bool(response.get("ok")):
+                    detail = str(response.get("error", "LingBot worker request failed"))
+                    logs = "\n".join(self._recent_output)
+                    raise RuntimeError(f"{detail}\n{logs}")
+                return response

--- a/models/lingbot-world-v1-fast/worker-requirements.txt
+++ b/models/lingbot-world-v1-fast/worker-requirements.txt
@@ -1,0 +1,17 @@
+opencv-python>=4.9.0.80
+diffusers>=0.31.0
+transformers>=4.49.0,<=4.51.3
+tokenizers>=0.20.3
+accelerate>=1.1.1
+tqdm
+imageio[ffmpeg]
+easydict
+ftfy
+imageio-ffmpeg
+numpy>=1.23.5,<2
+scipy
+huggingface-hub>=0.34
+einops
+ninja
+packaging
+wheel

--- a/models/lingbot-world-v1-fast/worker.py
+++ b/models/lingbot-world-v1-fast/worker.py
@@ -1,0 +1,179 @@
+"""Serve upstream LingBot-World-Fast through a small JSON-line protocol."""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+
+_RESPONSE_PREFIX = "REACTOR_LINGBOT_V1_RESPONSE "
+
+
+class LingBotRuntime:
+    """Own one loaded Fast model and one optional causal rollout."""
+
+    def __init__(self, settings: dict[str, Any]) -> None:
+        import torch
+        import wan
+        from wan.configs import WAN_CONFIGS
+        from wan.interactive_fast import InteractiveFastRollout
+
+        self._torch = torch
+        self._runtime_root = Path(settings["runtime_root"]).resolve()
+        self._runtime_root.mkdir(parents=True, exist_ok=True)
+        self._counter = 0
+        config = WAN_CONFIGS["i2v-A14B"]
+        context_latents = int(settings["context_latents"])
+        checkpoint_dir = Path(settings["checkpoint_dir"]).resolve()
+        if "cam" not in checkpoint_dir.name:
+            raise ValueError(
+                "LingBot Fast camera checkpoints must use a path containing 'cam'"
+            )
+        torch.cuda.set_device(0)
+        self._pipe = wan.WanI2VFast(
+            config=config,
+            checkpoint_dir=str(checkpoint_dir),
+            device_id=0,
+            rank=0,
+            t5_fsdp=False,
+            dit_fsdp=False,
+            use_sp=False,
+            t5_cpu=False,
+            init_on_cpu=False,
+            convert_model_dtype=False,
+            pipe_dtype=torch.bfloat16,
+            local_attn_size=context_latents,
+            sink_size=0,
+        )
+        self._rollout = InteractiveFastRollout(
+            self._pipe,
+            max_chunks=int(settings["max_chunks"]),
+            context_latents=context_latents,
+            chunk_size=3,
+            max_area=int(settings["max_area"]),
+            shift=float(settings["shift"]),
+        )
+        self._active = False
+
+    def reset(
+        self, image_path: Path, intrinsics_path: Path, prompt: str, seed: int
+    ) -> None:
+        """Start a fresh image-conditioned causal rollout."""
+        if not image_path.is_file():
+            raise FileNotFoundError(
+                f"LingBot anchor image does not exist: {image_path}"
+            )
+        if not intrinsics_path.is_file():
+            raise FileNotFoundError(
+                f"LingBot intrinsics do not exist: {intrinsics_path}"
+            )
+        with Image.open(image_path) as image:
+            anchor = image.convert("RGB")
+            intrinsics = np.load(intrinsics_path, allow_pickle=False)
+            self._rollout.reset(prompt, anchor, intrinsics, seed)
+        self._active = True
+
+    def generate(self, relative_c2ws: np.ndarray, prompt: str) -> tuple[Path, int]:
+        """Generate one chunk and persist its uint8 RGB frames for the parent."""
+        if not self._active:
+            raise RuntimeError("reset LingBot before generating a chunk")
+        video = self._rollout.generate_chunk(relative_c2ws, prompt)
+        frames = (
+            video.permute(1, 2, 3, 0)
+            .add(1.0)
+            .mul(127.5)
+            .clamp(0, 255)
+            .to(self._torch.uint8)
+            .cpu()
+            .numpy()
+        )
+        frames = np.ascontiguousarray(frames)
+        expected = 9 if self._rollout.chunk_index == 1 else 12
+        if frames.shape[0] != expected:
+            raise RuntimeError(
+                f"LingBot causal VAE decoded {frames.shape[0]} frames; expected {expected}"
+            )
+        self._counter += 1
+        output = self._runtime_root / f"chunk_{self._counter:06d}.npy"
+        np.save(output, frames, allow_pickle=False)
+        return output, expected
+
+    def end_session(self) -> None:
+        """Release causal caches while preserving model weights."""
+        self._rollout.end()
+        self._active = False
+
+    def close(self) -> None:
+        """Release active rollout state."""
+        self.end_session()
+
+
+def _respond(request_id: int, *, ok: bool, **payload: object) -> None:
+    """Write one correlated worker response."""
+    print(
+        _RESPONSE_PREFIX
+        + json.dumps({"id": request_id, "ok": ok, **payload}, ensure_ascii=False),
+        flush=True,
+    )
+
+
+def main() -> int:
+    """Serve requests until the parent closes stdin or asks to stop."""
+    runtime: LingBotRuntime | None = None
+    for line in sys.stdin:
+        request = json.loads(line)
+        request_id = int(request["id"])
+        command = str(request["command"])
+        if command == "shutdown":
+            if runtime is not None:
+                runtime.close()
+            _respond(request_id, ok=True)
+            return 0
+        try:
+            if command == "initialize":
+                runtime = LingBotRuntime(request)
+                _respond(request_id, ok=True)
+            elif command == "reset":
+                if runtime is None:
+                    raise RuntimeError("LingBot worker is not initialized")
+                runtime.reset(
+                    Path(request["anchor_image"]),
+                    Path(request["intrinsics"]),
+                    str(request["prompt"]),
+                    int(request["seed"]),
+                )
+                _respond(request_id, ok=True)
+            elif command == "generate":
+                if runtime is None:
+                    raise RuntimeError("LingBot worker is not initialized")
+                output, frame_count = runtime.generate(
+                    np.asarray(request["relative_c2ws"], dtype=np.float32),
+                    str(request["prompt"]),
+                )
+                _respond(
+                    request_id,
+                    ok=True,
+                    output=str(output),
+                    frame_count=frame_count,
+                )
+            elif command == "end_session":
+                if runtime is not None:
+                    runtime.end_session()
+                _respond(request_id, ok=True)
+            else:
+                raise ValueError(f"unknown LingBot worker command: {command}")
+        except Exception as error:  # noqa: BLE001 - report model failures to the parent protocol
+            traceback.print_exc()
+            _respond(request_id, ok=False, error=f"{type(error).__name__}: {error}")
+    if runtime is not None:
+        runtime.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

  LingBot-World v1 Fast has the causal model structure needed for an interactive world, but its public inference entry
  point creates the KV and VAE caches inside a single finite generation call. Reactor needs that native three-latent
  boundary to survive across client commands so camera, image, and prompt updates can drive one chunk at a time without
  reloading the model or discarding memory.

  ## What Changed

  This adds a Reactor model recipe that keeps the pinned Fast camera model in one persistent worker and exposes image
  upload, built-in scenes, prompt changes, six-axis camera motion, pause, step, and reset through a polished schema. The
  source extension preserves the upstream four-step scheduler, rolling 21-latent self-KV window, cross-attention
  conditioning, and causal VAE cache while returning one native chunk per request.

  The workspace builds through the `build:` block in `reactor.yaml` without a handwritten Dockerfile. First startup
  prepares the pinned public source, isolated CUDA worker environment, and selected Fast assets in Reactor’s mounted
  weights cache. The README documents the current `reactor validate`, `reactor build`, and `reactor run` workflow.
