### PR TITLE
Add the Echo-WM audiovisual world model

### DIFF
--- a/models/echo-wm/README.md
+++ b/models/echo-wm/README.md
@@ -1,0 +1,160 @@
+# Echo-WM Flash
+
+Explore a prompt-, image-, and camera-controlled audiovisual world with
+[Echo-WM](https://github.com/jd-opensource/JoyAI-Echo/tree/main/echo_wm) and
+Reactor.
+
+## Runtime boundary
+
+The adapter keeps one Echo-WM rollout alive across interactive turns. An image
+anchors the first frame, a prompt conditions the world, and four pure-camera
+axes control motion. Each inference turn advances the released causal model by
+one three-latent block and preserves its bounded audio-video KV caches for the
+next turn.
+
+This recipe uses the four-step
+[`echo-wm-flash.safetensors`](https://huggingface.co/Echo-Team/Echo-WM) release
+at 1280×704 and 24 FPS. It retains Echo-WM's 19-frame local video cache,
+7-frame sink, aligned audio caches, and `[1000, 750, 500, 250]` timestep
+schedule. The pinned JoyAI-Echo checkout remains an unmodified upstream source
+tree; the Reactor integration lives entirely in this directory.
+
+One model output contains synchronized `main_video` and `main_audio` tracks.
+The first output carries the anchor plus 24 generated frames and 50,000 mono
+audio samples. Later outputs carry 24 frames and 48,000 samples, representing
+one second of generated world time per chunk. Playout uses Echo-WM's native
+24 FPS rate so the 48 kHz audio samples remain aligned with their video frames.
+
+## Run with the Reactor CLI
+
+This directory is a Reactor workspace. Its `reactor.yaml` manifest defines the
+Python 3.12 serving image, Reactor Runtime 3.2.3, CUDA and system dependencies,
+the model entry point, GPU resource, recording tracks, and persistent weights
+directory. See the [Reactor CLI installation
+guide](https://docs.reactor.inc/deploy/platform/installation) and [build
+configuration guide](https://docs.reactor.inc/deploy/platform/build) for host
+setup and supported manifest fields.
+
+The default configuration targets Linux and one NVIDIA B200. Install the
+NVIDIA Container Toolkit, accept the public Gemma 3 license on Hugging Face,
+and expose a read token before the first asset download:
+
+```sh
+cd models/echo-wm
+export HF_TOKEN=hf_your_read_token
+
+reactor build
+reactor run --gpus device=0 -e HF_TOKEN
+```
+
+`--gpus device=3` selects host GPU 3 and presents it as device 0 in the serving
+container. `reactor run` serves on `http://localhost:8080` by default. Choose a
+different port when needed:
+
+```sh
+reactor build && reactor run --gpus device=0 --port 18091 -e HF_TOKEN
+```
+
+Model startup finishes after the source and model assets are prepared, one
+warmup chunk completes, and the attention backend passes its numerical check.
+Use the selected port to inspect readiness and the generated model contract:
+
+```sh
+curl -fsS http://localhost:18091/health
+curl -fsS http://localhost:18091/schema
+```
+
+## Demo frontend
+
+The [`demo`](./demo) directory contains the AlayaWorld-style interactive
+frontend adapted to Echo-WM's image, prompt, four-axis camera, field-of-view,
+video, and audio contract. With the model serving on its default port:
+
+```sh
+cd demo
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000), connect, then choose a
+built-in scene or upload an image. See the [demo guide](./demo/README.md) for
+alternate ports, keyboard controls, and hosted connection settings.
+
+The manifest stores persistent model data under
+`~/.cache/reactor_registry/echo-wm-flash`. Change `runtime.weights_path` to use
+another high-capacity host volume; the source, checkpoints, Hugging Face cache,
+uploaded images, and compiled kernel cache are all resolved beneath that mount.
+
+## Public source and model assets
+
+Startup prepares missing assets automatically and validates every pinned
+revision:
+
+- [JoyAI-Echo](https://github.com/jd-opensource/JoyAI-Echo) supplies the
+  original Echo-WM model, camera conditioning, KV-cache, and codec code.
+- [Echo-Team/Echo-WM](https://huggingface.co/Echo-Team/Echo-WM) supplies the
+  four-step distilled checkpoint.
+- [Gemma 3 12B QAT](https://huggingface.co/google/gemma-3-12b-it-qat-q4_0-unquantized)
+  supplies the gated text encoder.
+
+`source.revision`, checkpoint revisions, and local paths are declared in
+`echo_wm.yaml`. Existing valid files are reused on later starts.
+
+## Interaction contract
+
+A session starts in running mode and waits for an image. `set_image` accepts a
+JPEG, PNG, WebP, or BMP upload plus an optional prompt and seed. A blank prompt
+uses the image-neutral `inference.default_upload_prompt` from `echo_wm.yaml`,
+independent of every previously selected image. `random_image` selects one of
+the pinned upstream causal examples with its paired prompt. Selecting an image
+starts a fresh rollout without reloading model weights.
+
+When the session is running, image selection begins continuous generation. When
+the session is paused, image selection preserves the pause state and queues two
+preview chunks so a client can display the new world before another command.
+`set_paused(true)` stops before the next unqueued chunk, and `step` queues one
+chunk while remaining paused.
+
+`set_camera_motion` updates Echo-WM's four native pure-camera inputs atomically:
+
+- `forward`: backward (-1) to forward (1)
+- `strafe`: left (-1) to right (1)
+- `pitch`: look down (-1) to up (1)
+- `yaw`: turn left (-1) to right (1)
+
+The values are held and sampled at the next chunk boundary. `release_camera`
+returns all four axes to neutral, and `set_fov` controls the horizontal field of
+view from 30 through 120 degrees. A frontend can map these values to keyboard,
+pointer, touch, or gamepad controls.
+
+Echo-WM fixes its text cross-attention KV for one rollout. `set_prompt` therefore
+starts a fresh rollout from the selected image so chunk one is conditioned by
+the acknowledged prompt; paused mode queues that first chunk as a preview.
+`reset` also starts from the selected image and can retain or replace the seed.
+
+Every successful mutation emits a specific model message and a full
+`state_update`. `chunk_completed` reports the sampled prompt and camera state,
+media counts, wall latency, and CUDA timings for denoising, cache commit, video
+decode, and audio decode. The rollout automatically starts fresh from the same
+image after 512 chunks while retaining the prompt, seed, field of view, camera
+state, and pause mode.
+
+## Inference performance
+
+Unmasked transformer attention uses FlashAttention 4 on Hopper and Blackwell
+GPUs. Masked text attention and UCPE camera attention use the upstream PyTorch
+SDPA path. Startup compares both backends on a representative attention shape
+and rejects non-finite or numerically inconsistent output.
+
+`inference.warmup_chunks` controls full throwaway audio-video turns during model
+load. The default single turn initializes the first-chunk path without adding a
+long multi-chunk startup. `inference.profile_cuda` controls per-stage CUDA
+timings, and `inference.attention_benchmark` controls the startup backend check.
+The B200 configuration decodes each visible video window directly to avoid
+spatial tile overhead. Set `inference.video_decode_tiling` to `true` when serving
+on a GPU that cannot hold the full VAE decode.
+
+The `main_video` track advertises a 24-frame buffer so Runtime applies
+backpressure at the model's native chunk boundary. The video track is paced at
+24 FPS alongside the 48 kHz `main_audio` track. Recording combines both tracks
+into synchronized H.264/AAC clips.

--- a/models/echo-wm/README.md
+++ b/models/echo-wm/README.md
@@ -102,18 +102,14 @@ revision:
 
 ## Interaction contract
 
-A session starts in running mode and waits for an image. `set_image` accepts a
-JPEG, PNG, WebP, or BMP upload plus an optional prompt and seed. A blank prompt
+A session starts in continuous mode and waits for an image. `set_image` accepts
+a JPEG, PNG, WebP, or BMP upload plus an optional prompt and seed. A blank prompt
 uses the image-neutral `inference.default_upload_prompt` from `echo_wm.yaml`,
 independent of every previously selected image. `random_image` selects one of
 the pinned upstream causal examples with its paired prompt. Selecting an image
 starts a fresh rollout without reloading model weights.
 
-When the session is running, image selection begins continuous generation. When
-the session is paused, image selection preserves the pause state and queues two
-preview chunks so a client can display the new world before another command.
-`set_paused(true)` stops before the next unqueued chunk, and `step` queues one
-chunk while remaining paused.
+Image selection begins continuous generation from the first native chunk.
 
 `set_camera_motion` updates Echo-WM's four native pure-camera inputs atomically:
 
@@ -129,15 +125,15 @@ pointer, touch, or gamepad controls.
 
 Echo-WM fixes its text cross-attention KV for one rollout. `set_prompt` therefore
 starts a fresh rollout from the selected image so chunk one is conditioned by
-the acknowledged prompt; paused mode queues that first chunk as a preview.
-`reset` also starts from the selected image and can retain or replace the seed.
+the acknowledged prompt. `reset` also starts from the selected image and can
+retain or replace the seed.
 
 Every successful mutation emits a specific model message and a full
 `state_update`. `chunk_completed` reports the sampled prompt and camera state,
 media counts, wall latency, and CUDA timings for denoising, cache commit, video
 decode, and audio decode. The rollout automatically starts fresh from the same
 image after 512 chunks while retaining the prompt, seed, field of view, camera
-state, and pause mode.
+state, and continuous playback.
 
 ## Inference performance
 

--- a/models/echo-wm/demo/.env.example
+++ b/models/echo-wm/demo/.env.example
@@ -1,0 +1,24 @@
+# The app runs with no configuration at all: it connects to a model container on
+# http://localhost:8080, which is where `reactor run` serves. Every variable
+# below is read on the server, per request.
+
+# Where the container serves, when you passed `reactor run --port` a different
+# port. Defaults to http://localhost:8080.
+# REACTOR_LOCAL_URL=http://localhost:18080
+
+# ── If you deploy this model yourself ────────────────────────────────────────
+#
+# This example is not published on the Reactor platform, so there is nothing to
+# connect an API key to until you have deployed the workspace to your own
+# account. Once you have, setting a key switches the app from talking to a local
+# container to creating sessions through the Reactor API. The key is read on the
+# server and exchanged for a short-lived token scoped to the one model, so it
+# never reaches the browser.
+#
+# REACTOR_API_KEY=rk_your_api_key_here
+
+# The name you deployed under — `model.name` in the reactor.yaml you deployed.
+# REACTOR_MODEL_NAME=echo-wm-flash
+
+# A different Reactor API. Defaults to https://api.reactor.inc.
+# REACTOR_API_URL=https://api.reactor.inc

--- a/models/echo-wm/demo/.gitignore
+++ b/models/echo-wm/demo/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+next-env.d.ts
+*.tsbuildinfo
+
+.env
+.env.local
+.env*.local
+!.env.example

--- a/models/echo-wm/demo/README.md
+++ b/models/echo-wm/demo/README.md
@@ -1,0 +1,109 @@
+# Echo-WM Flash demo frontend
+
+A small [Next.js](https://nextjs.org) app for driving the Echo-WM Flash
+example: choose a starting image, write a prompt, steer the camera, and receive
+synchronized generated video and audio over WebRTC.
+
+It follows the AlayaWorld demo structure and uses
+[`@reactor-team/js-sdk`](https://www.npmjs.com/package/@reactor-team/js-sdk)
+with a typed client derived from this model's schema. Connection settings come
+from the environment described in [`.env.example`](./.env.example).
+
+## Run it
+
+Start the model from the example root:
+
+```sh
+cd models/echo-wm
+reactor build
+reactor run --gpus device=0 -e HF_TOKEN
+```
+
+Then start the app:
+
+```sh
+cd demo
+pnpm install
+pnpm dev
+```
+
+Open [http://localhost:3000](http://localhost:3000), select **Connect**, choose
+a starting image, and drive the world. Generated sound plays through the same
+video element.
+
+The default model URL is `http://localhost:8080`. Set a different URL when the
+model uses another port:
+
+```sh
+cp .env.example .env
+# REACTOR_LOCAL_URL=http://localhost:18091
+```
+
+## Controls
+
+Each axis is a velocity from -1 to 1. Echo-WM holds the value until another
+camera command arrives and samples all four axes together at the next chunk
+boundary.
+
+| Keys      | Axis      | Effect                |
+| --------- | --------- | --------------------- |
+| `W` / `S` | `forward` | Move forward and back |
+| `A` / `D` | `strafe`  | Move left and right   |
+| `I` / `K` | `pitch`   | Look up and down      |
+| `J` / `L` | `yaw`     | Turn left and right   |
+
+The on-screen pad sends the same atomic camera command, so touch and keyboard
+input share one state. The field-of-view control covers Echo-WM's supported
+30–120 degree range.
+
+## How it works
+
+The app wraps the SDK's `ReactorProvider` and reads the model through the typed
+hooks:
+
+```tsx
+const model = useEchoWmFlash();
+
+await model.setCameraMotion({
+  forward: 1,
+  strafe: 0,
+  pitch: 0,
+  yaw: 0,
+});
+await model.setPrompt({ prompt: "a storm rolls in with distant thunder" });
+
+const reference = await model.uploadFile(file);
+await model.setImage({ image: reference });
+```
+
+An upload without a newly entered prompt applies the backend's image-neutral
+default for the new scene. `ReactorView` combines the `main_video` and
+`main_audio` receive tracks in one playback element.
+
+The model broadcasts a complete state snapshot after each observable change.
+The UI uses that snapshot as its source of truth for camera meters, prompt,
+pause state, and chunk progress:
+
+```tsx
+useEchoWmFlashStateUpdate((state) => {
+  state.forward;
+  state.queued_steps;
+  state.next_chunk;
+});
+```
+
+The schema-derived client lives in [`lib/echo_wm/`](./lib/echo_wm).
+
+## Layout
+
+| Path                          | What it holds                                     |
+| ----------------------------- | ------------------------------------------------- |
+| `app/page.tsx`                | Resolves environment-backed connection settings   |
+| `app/api/token/`              | Mints a scoped token for a hosted deployment      |
+| `components/App.tsx`          | Configures the SDK connection                     |
+| `components/Workspace.tsx`    | Subscribes to state and lays out the demo         |
+| `components/CameraBar.tsx`    | Four-axis camera and field-of-view controls       |
+| `components/ScenePanel.tsx`   | Random scene, upload, and prompt controls         |
+| `components/RolloutPanel.tsx` | Pause, step, seed, reset, and chunk state         |
+| `lib/controls.ts`             | Keyboard bindings and atomic velocity calculation |
+| `lib/echo_wm/`                | Schema-derived typed client and React hooks       |

--- a/models/echo-wm/demo/README.md
+++ b/models/echo-wm/demo/README.md
@@ -82,12 +82,12 @@ default for the new scene. `ReactorView` combines the `main_video` and
 
 The model broadcasts a complete state snapshot after each observable change.
 The UI uses that snapshot as its source of truth for camera meters, prompt,
-pause state, and chunk progress:
+generation state, and chunk progress:
 
 ```tsx
 useEchoWmFlashStateUpdate((state) => {
   state.forward;
-  state.queued_steps;
+  state.generating;
   state.next_chunk;
 });
 ```
@@ -104,6 +104,6 @@ The schema-derived client lives in [`lib/echo_wm/`](./lib/echo_wm).
 | `components/Workspace.tsx`    | Subscribes to state and lays out the demo         |
 | `components/CameraBar.tsx`    | Four-axis camera and field-of-view controls       |
 | `components/ScenePanel.tsx`   | Random scene, upload, and prompt controls         |
-| `components/RolloutPanel.tsx` | Pause, step, seed, reset, and chunk state         |
+| `components/RolloutPanel.tsx` | Seed, reset, progress, and generation state       |
 | `lib/controls.ts`             | Keyboard bindings and atomic velocity calculation |
 | `lib/echo_wm/`                | Schema-derived typed client and React hooks       |

--- a/models/echo-wm/demo/app/api/token/route.ts
+++ b/models/echo-wm/demo/app/api/token/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+
+import { readConfig } from "@/lib/config";
+
+const TOKEN_LIFETIME_SECONDS = 60 * 60;
+const MAX_SESSIONS = 10;
+/** Expire the browser's cached copy before the token itself expires. */
+const CACHE_SKEW_SECONDS = 60;
+const DEFAULT_API_URL = "https://api.reactor.inc";
+
+/**
+ * Exchange the server's API key for a short-lived session token.
+ *
+ * The token is scoped to this one model and to sessions it created itself, so
+ * handing it to the browser grants nothing else on the account. Only hosted mode
+ * calls this route; in local mode there is no token to mint.
+ */
+export async function GET() {
+  const apiKey = process.env.REACTOR_API_KEY?.trim();
+  if (!apiKey) {
+    return NextResponse.json(
+      {
+        error:
+          "REACTOR_API_KEY is not set. Leave it unset to connect to a local `reactor run` container instead.",
+      },
+      { status: 500 },
+    );
+  }
+
+  const { modelName, apiUrl } = readConfig();
+  const response = await fetch(`${apiUrl ?? DEFAULT_API_URL}/tokens`, {
+    method: "POST",
+    headers: {
+      "Reactor-API-Key": apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      expires_after: TOKEN_LIFETIME_SECONDS,
+      authorization_details: [
+        {
+          type: "session",
+          resources: { models: { match: [modelName] } },
+          constraints: { max_sessions: MAX_SESSIONS },
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    return NextResponse.json(
+      {
+        error:
+          `Reactor API rejected the token request (${response.status}). ${detail}`.trim(),
+      },
+      { status: 502 },
+    );
+  }
+
+  const { jwt, expires_at } = (await response.json()) as {
+    jwt: string;
+    expires_at: number;
+  };
+  const maxAge = Math.max(
+    0,
+    expires_at - Math.floor(Date.now() / 1000) - CACHE_SKEW_SECONDS,
+  );
+
+  return NextResponse.json(
+    { jwt },
+    { headers: { "Cache-Control": `private, max-age=${maxAge}` } },
+  );
+}

--- a/models/echo-wm/demo/app/globals.css
+++ b/models/echo-wm/demo/app/globals.css
@@ -1,0 +1,51 @@
+@import "tailwindcss";
+
+@theme {
+  --color-canvas: #0b0c0e;
+  --color-panel: #14161a;
+  --color-panel-raised: #1c1f25;
+  --color-edge: #272b33;
+  --color-ink: #f2f4f7;
+  --color-ink-dim: #9aa3af;
+  --color-ink-faint: #666e7a;
+  --color-live: #4ade80;
+  --color-pending: #fbbf24;
+  --color-alert: #f87171;
+  --color-accent: #7dd3fc;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  background: var(--color-canvas);
+  color: var(--color-ink);
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Range inputs are the one control the demo styles by hand, so the seed and
+   axis readouts look the same in every browser. */
+input[type="range"] {
+  appearance: none;
+  height: 2px;
+  background: var(--color-edge);
+  border-radius: 999px;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--color-ink);
+}
+
+input[type="range"]::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--color-ink);
+}

--- a/models/echo-wm/demo/app/layout.tsx
+++ b/models/echo-wm/demo/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Echo-WM Flash — audiovisual world model",
+  description:
+    "Drive an audiovisual world in real time: pick a starting image, write a prompt, and steer four camera axes from the keyboard.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body className="antialiased">{children}</body>
+    </html>
+  );
+}

--- a/models/echo-wm/demo/app/page.tsx
+++ b/models/echo-wm/demo/app/page.tsx
@@ -1,0 +1,18 @@
+import { App } from "@/components/App";
+import { readConfig } from "@/lib/config";
+
+/**
+ * Read the environment per request rather than at build time, so the same build
+ * can be pointed at a different container or a hosted model by changing the
+ * environment alone.
+ */
+export const dynamic = "force-dynamic";
+
+/**
+ * Resolve the connection settings on the server and hand the browser only what
+ * it needs. Reading the environment here keeps `REACTOR_API_KEY` server-side
+ * while the mode it selects is still visible in the UI.
+ */
+export default function Page() {
+  return <App config={readConfig()} />;
+}

--- a/models/echo-wm/demo/components/App.tsx
+++ b/models/echo-wm/demo/components/App.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { ReactorProvider } from "@reactor-team/js-sdk";
+
+import { EchoWmFlashTracks } from "@/lib/echo_wm/client";
+import type { DemoConfig } from "@/lib/config";
+
+import { Toasts } from "./Toasts";
+import { Workspace } from "./Workspace";
+
+/**
+ * Fetch a session token from this app's own server.
+ *
+ * The SDK takes a resolver rather than a string so it can ask for a fresh token
+ * on every request it makes, including uploads and stream renegotiation.
+ */
+async function fetchToken(): Promise<string> {
+  const response = await fetch("/api/token");
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? `Token request failed: ${response.status}`);
+  }
+  const { jwt } = (await response.json()) as { jwt: string };
+  return jwt;
+}
+
+/**
+ * Configure the connection and hand the rest of the app a live session.
+ *
+ * The provider comes from the SDK rather than the generated client so the model
+ * name stays configurable: this example is meant to run against a container you
+ * started yourself, where the name is whatever you deployed it under.
+ */
+export function App({ config }: { config: DemoConfig }) {
+  const local = config.mode === "local";
+
+  return (
+    <>
+      <ReactorProvider
+        modelName={config.modelName}
+        modelTracks={[...EchoWmFlashTracks]}
+        local={local}
+        {...(config.apiUrl ? { apiUrl: config.apiUrl } : {})}
+        {...(local ? {} : { getJwt: fetchToken })}
+        connectOptions={{ autoConnect: false }}
+      >
+        <Workspace config={config} />
+      </ReactorProvider>
+      <Toasts />
+    </>
+  );
+}

--- a/models/echo-wm/demo/components/CameraBar.tsx
+++ b/models/echo-wm/demo/components/CameraBar.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  type Axis,
+  BINDING_BY_CODE,
+  type Motion,
+  PAD_ROWS,
+} from "@/lib/controls";
+import type { Model, WorldState } from "@/lib/model";
+
+import { useCameraKeys } from "./useCameraKeys";
+import { AxisMeter, Button, cx } from "./ui";
+
+const METERS: {
+  axis: Axis;
+  label: string;
+  negative: string;
+  positive: string;
+}[] = [
+  { axis: "forward", label: "forward", negative: "back", positive: "fwd" },
+  { axis: "strafe", label: "strafe", negative: "left", positive: "right" },
+  { axis: "pitch", label: "pitch", negative: "down", positive: "up" },
+  { axis: "yaw", label: "yaw", negative: "left", positive: "right" },
+];
+
+function FovControl({ model, value }: { model: Model; value: number }) {
+  const [draft, setDraft] = useState(value);
+  useEffect(() => setDraft(value), [value]);
+  const commit = () => void model.setFov({ fov_degrees: draft });
+
+  return (
+    <label className="block min-w-48 text-[10px] text-ink-faint">
+      <span className="flex justify-between">
+        <span>field of view</span>
+        <span>{draft.toFixed(0)}°</span>
+      </span>
+      <input
+        type="range"
+        min={30}
+        max={120}
+        step={1}
+        value={draft}
+        onChange={(event) => setDraft(Number(event.target.value))}
+        onPointerUp={commit}
+        onKeyUp={commit}
+        onBlur={commit}
+        className="mt-1 w-full accent-[var(--color-accent)]"
+      />
+    </label>
+  );
+}
+
+/**
+ * Echo-WM's four camera axes, kept under the video where their effect is visible.
+ *
+ * The meters read from the model's own snapshot rather than from local key
+ * state, so they show the velocity the next chunk will actually use — including
+ * the zeroes the model applies on its own when playback pauses.
+ */
+export function CameraBar({
+  model,
+  world,
+  enabled,
+}: {
+  model: Model;
+  world: WorldState | null;
+  enabled: boolean;
+}) {
+  const onMotion = useCallback(
+    (motion: Motion) => {
+      void model.setCameraMotion(motion);
+    },
+    [model],
+  );
+
+  const { pressed, press, release, releaseAll } = useCameraKeys({
+    enabled,
+    onMotion,
+  });
+
+  return (
+    <div
+      className={cx(
+        "shrink-0 border-t border-edge bg-panel px-4 py-3 transition-opacity",
+        !enabled && "pointer-events-none opacity-40",
+      )}
+    >
+      <div className="flex flex-wrap items-start gap-x-8 gap-y-4">
+        <div>
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-dim">
+            Camera
+          </p>
+          <div className="space-y-1.5">
+            {PAD_ROWS.map((row, index) => (
+              <div key={index} className="flex gap-1.5">
+                {row.map((code) => {
+                  const binding = BINDING_BY_CODE[code];
+                  const down = pressed.has(code);
+                  return (
+                    <button
+                      key={code}
+                      type="button"
+                      title={binding.action}
+                      onPointerDown={(event) => {
+                        event.preventDefault();
+                        press(code);
+                      }}
+                      onPointerUp={() => release(code)}
+                      onPointerLeave={() => release(code)}
+                      onPointerCancel={() => release(code)}
+                      className={cx(
+                        "flex w-[4.5rem] flex-col items-center gap-0.5 rounded-md border px-1 py-1 text-[10px] transition-colors select-none",
+                        down
+                          ? "border-accent bg-accent/15 text-accent"
+                          : "border-edge bg-panel-raised text-ink-dim hover:border-ink-faint",
+                      )}
+                    >
+                      <span className="font-semibold">{binding.key}</span>
+                      <span className="text-[9px] text-ink-faint">
+                        {binding.action}
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid min-w-[18rem] flex-1 grid-cols-1 gap-x-6 gap-y-2 sm:grid-cols-2 xl:grid-cols-4">
+          {METERS.map((meter) => (
+            <AxisMeter
+              key={meter.axis}
+              label={meter.label}
+              negative={meter.negative}
+              positive={meter.positive}
+              value={world?.[meter.axis] ?? 0}
+            />
+          ))}
+        </div>
+
+        <div className="flex min-w-48 flex-col gap-2">
+          <FovControl model={model} value={world?.fov_degrees ?? 70} />
+          <Button
+            onClick={() => {
+              releaseAll();
+              void model.releaseCamera();
+            }}
+          >
+            Neutral camera
+          </Button>
+        </div>
+
+        <p className="max-w-xs text-[11px] leading-relaxed text-ink-faint">
+          {enabled
+            ? "Held keys are sent as one four-axis command. Echo-WM samples it when the next 24-frame chunk starts."
+            : "Choose a starting image to unlock the controls."}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/models/echo-wm/demo/components/CameraBar.tsx
+++ b/models/echo-wm/demo/components/CameraBar.tsx
@@ -56,8 +56,7 @@ function FovControl({ model, value }: { model: Model; value: number }) {
  * Echo-WM's four camera axes, kept under the video where their effect is visible.
  *
  * The meters read from the model's own snapshot rather than from local key
- * state, so they show the velocity the next chunk will actually use — including
- * the zeroes the model applies on its own when playback pauses.
+ * state, so they show the velocity the next chunk will actually use.
  */
 export function CameraBar({
   model,

--- a/models/echo-wm/demo/components/Header.tsx
+++ b/models/echo-wm/demo/components/Header.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import type { DemoConfig } from "@/lib/config";
+
+import { Button, Dot, Pill } from "./ui";
+
+/** How the SDK's connection status reads in the UI. */
+const STATUS_LABEL: Record<string, string> = {
+  disconnected: "Not connected",
+  connecting: "Connecting",
+  waiting: "Waiting for a worker",
+  ready: "Live",
+  error: "Connection failed",
+};
+
+export function Header({
+  config,
+  status,
+  onConnect,
+  onDisconnect,
+}: {
+  config: DemoConfig;
+  status: string;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}) {
+  const busy = status === "connecting" || status === "waiting";
+  const local = config.mode === "local";
+
+  return (
+    <header className="flex shrink-0 flex-wrap items-center gap-3 border-b border-edge px-4 py-3">
+      <h1 className="text-sm font-semibold tracking-tight">Echo-WM Flash</h1>
+
+      <Pill
+        title={
+          local
+            ? "Local mode ignores the model name: the container you started is the only model there is."
+            : "The session is created for this model name. It has to match the name you deployed the model under."
+        }
+      >
+        <span className="text-ink-faint">model</span>
+        <code className="text-ink-dim">{config.modelName}</code>
+      </Pill>
+
+      <Pill tone={local ? "neutral" : "live"}>
+        {local ? `local · ${config.apiUrl}` : "hosted · API key"}
+      </Pill>
+
+      <div className="ml-auto flex items-center gap-3">
+        <span className="flex items-center gap-2 text-xs text-ink-dim">
+          <Dot
+            tone={
+              status === "ready"
+                ? "live"
+                : status === "error"
+                  ? "alert"
+                  : busy
+                    ? "pending"
+                    : "idle"
+            }
+            pulse={busy}
+          />
+          {STATUS_LABEL[status] ?? status}
+        </span>
+        {status === "ready" ? (
+          <Button onClick={onDisconnect}>Disconnect</Button>
+        ) : (
+          <Button tone="primary" onClick={onConnect} disabled={busy}>
+            {busy ? "Connecting…" : "Connect"}
+          </Button>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/models/echo-wm/demo/components/RolloutPanel.tsx
+++ b/models/echo-wm/demo/components/RolloutPanel.tsx
@@ -9,9 +9,8 @@ import { Button, Dot, Panel, StatRow } from "./ui";
 /**
  * Playback and the life of the current world.
  *
- * Each chunk is 24 frames and one second of synchronized audio-video, and costs real GPU
- * time — so pausing, stepping one chunk at a time, and restarting from the same
- * image with a chosen seed are all first-class controls rather than debug aids.
+ * Each turn generates one second of synchronized audio-video. The panel exposes
+ * rollout progress and deterministic restart controls while playback continues.
  */
 export function RolloutPanel({
   model,
@@ -24,7 +23,6 @@ export function RolloutPanel({
 }) {
   const [seed, setSeed] = useState("");
 
-  const paused = world?.paused ?? false;
   const completed = world?.completed_chunks ?? 0;
   const max = world?.max_chunks ?? 0;
   const progress = max > 0 ? Math.min(100, (completed / max) * 100) : 0;
@@ -34,30 +32,12 @@ export function RolloutPanel({
       title="Playback"
       hint={
         enabled
-          ? "Pausing also releases every camera axis, so the world stops where you left it."
+          ? "Echo-WM continuously generates native audio-video chunks from the selected scene."
           : "Available once the world has a starting image."
       }
       disabled={!enabled}
     >
       <div className="flex gap-2">
-        <Button
-          full
-          tone={paused ? "primary" : "default"}
-          onClick={() => void model.setPaused({ paused: !paused })}
-        >
-          {paused ? "Resume" : "Pause"}
-        </Button>
-        <Button
-          full
-          disabled={!paused}
-          title="Generate exactly one 24-frame audio-video chunk"
-          onClick={() => void model.step()}
-        >
-          Step once
-        </Button>
-      </div>
-
-      <div className="mt-3 flex gap-2">
         <input
           value={seed}
           onChange={(event) =>
@@ -98,18 +78,14 @@ export function RolloutPanel({
           value={
             <span className="inline-flex items-center gap-1.5">
               <Dot
-                tone={world?.generating ? "live" : paused ? "idle" : "pending"}
+                tone={world?.generating ? "live" : "pending"}
                 pulse={world?.generating}
               />
               {world?.generating
                 ? "generating"
                 : world?.reset_queued
                   ? "restarting"
-                  : paused
-                    ? world?.queued_steps
-                      ? `${world.queued_steps} queued`
-                      : "paused"
-                    : "waiting"}
+                  : "waiting"}
             </span>
           }
         />

--- a/models/echo-wm/demo/components/RolloutPanel.tsx
+++ b/models/echo-wm/demo/components/RolloutPanel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+
+import type { Model, WorldState } from "@/lib/model";
+
+import { Button, Dot, Panel, StatRow } from "./ui";
+
+/**
+ * Playback and the life of the current world.
+ *
+ * Each chunk is 24 frames and one second of synchronized audio-video, and costs real GPU
+ * time — so pausing, stepping one chunk at a time, and restarting from the same
+ * image with a chosen seed are all first-class controls rather than debug aids.
+ */
+export function RolloutPanel({
+  model,
+  world,
+  enabled,
+}: {
+  model: Model;
+  world: WorldState | null;
+  enabled: boolean;
+}) {
+  const [seed, setSeed] = useState("");
+
+  const paused = world?.paused ?? false;
+  const completed = world?.completed_chunks ?? 0;
+  const max = world?.max_chunks ?? 0;
+  const progress = max > 0 ? Math.min(100, (completed / max) * 100) : 0;
+
+  return (
+    <Panel
+      title="Playback"
+      hint={
+        enabled
+          ? "Pausing also releases every camera axis, so the world stops where you left it."
+          : "Available once the world has a starting image."
+      }
+      disabled={!enabled}
+    >
+      <div className="flex gap-2">
+        <Button
+          full
+          tone={paused ? "primary" : "default"}
+          onClick={() => void model.setPaused({ paused: !paused })}
+        >
+          {paused ? "Resume" : "Pause"}
+        </Button>
+        <Button
+          full
+          disabled={!paused}
+          title="Generate exactly one 24-frame audio-video chunk"
+          onClick={() => void model.step()}
+        >
+          Step once
+        </Button>
+      </div>
+
+      <div className="mt-3 flex gap-2">
+        <input
+          value={seed}
+          onChange={(event) =>
+            setSeed(event.target.value.replace(/[^0-9]/g, ""))
+          }
+          inputMode="numeric"
+          placeholder="seed (optional)"
+          className="h-8 min-w-0 flex-1 rounded-md border border-edge bg-panel-raised px-2.5 text-xs tabular-nums text-ink placeholder:text-ink-faint focus:border-ink-faint focus:outline-none"
+        />
+        <Button
+          tone="danger"
+          title="Rebuild the world from the same image and prompt"
+          onClick={() => {
+            void model.reset(seed ? { seed: Number(seed) } : { seed: -1 });
+            setSeed("");
+          }}
+        >
+          Restart world
+        </Button>
+      </div>
+
+      <div className="mt-3 border-t border-edge pt-2">
+        <StatRow
+          label="Chunks"
+          value={max > 0 ? `${completed} / ${max}` : String(completed)}
+          title="The world restarts by itself once it reaches the chunk limit."
+        />
+        <div className="h-1 overflow-hidden rounded-full bg-panel-raised">
+          <div
+            className="h-full rounded-full bg-ink-faint transition-[width] duration-300"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <StatRow label="Next chunk" value={world?.next_chunk ?? "—"} />
+        <StatRow label="Seed" value={world?.seed ?? "—"} />
+        <StatRow
+          label="State"
+          value={
+            <span className="inline-flex items-center gap-1.5">
+              <Dot
+                tone={world?.generating ? "live" : paused ? "idle" : "pending"}
+                pulse={world?.generating}
+              />
+              {world?.generating
+                ? "generating"
+                : world?.reset_queued
+                  ? "restarting"
+                  : paused
+                    ? world?.queued_steps
+                      ? `${world.queued_steps} queued`
+                      : "paused"
+                    : "waiting"}
+            </span>
+          }
+        />
+      </div>
+    </Panel>
+  );
+}

--- a/models/echo-wm/demo/components/ScenePanel.tsx
+++ b/models/echo-wm/demo/components/ScenePanel.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import type { Model, WorldState } from "@/lib/model";
+
+import { notify } from "./Toasts";
+import { Button, Panel, StatRow } from "./ui";
+
+/**
+ * Pick what the world starts from, and steer it with text once it is running.
+ *
+ * Choosing an image or changing the prompt starts a fresh Echo-WM rollout.
+ */
+export function ScenePanel({
+  model,
+  world,
+  connected,
+}: {
+  model: Model;
+  world: WorldState | null;
+  connected: boolean;
+}) {
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useState("");
+  const [dirty, setDirty] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  // Follow the model's prompt until the user starts writing their own, so the
+  // box shows what is actually queued rather than a stale copy.
+  const modelPrompt = world?.prompt ?? "";
+  useEffect(() => {
+    if (!dirty) setDraft(modelPrompt);
+  }, [modelPrompt, dirty]);
+
+  const hasImage = Boolean(world?.image_name);
+  const trimmed = draft.trim();
+
+  const upload = async (file: File) => {
+    setUploading(true);
+    try {
+      const reference = await model.uploadFile(file);
+      await model.setImage(
+        dirty && trimmed
+          ? { image: reference, prompt: trimmed }
+          : { image: reference },
+      );
+      setDirty(false);
+    } catch (error) {
+      notify("error", error instanceof Error ? error.message : "Upload failed");
+    } finally {
+      setUploading(false);
+      if (fileInput.current) fileInput.current.value = "";
+    }
+  };
+
+  return (
+    <Panel
+      title="Scene"
+      hint={
+        connected
+          ? "A new image restarts the world. Echo-WM prepares it for the 1280×704 stream."
+          : "Connect first."
+      }
+      disabled={!connected}
+    >
+      <div className="flex gap-2">
+        <Button full onClick={() => void model.randomImage()}>
+          Random scene
+        </Button>
+        <Button
+          full
+          onClick={() => fileInput.current?.click()}
+          disabled={uploading}
+        >
+          {uploading ? "Uploading…" : "Upload image"}
+        </Button>
+      </div>
+      <input
+        ref={fileInput}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/bmp"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.target.files?.[0];
+          if (file) void upload(file);
+        }}
+      />
+
+      <label className="mt-4 block text-[11px] text-ink-faint">
+        Prompt
+        <textarea
+          value={draft}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setDirty(true);
+          }}
+          rows={3}
+          placeholder="Optional for uploads; describe visuals, motion, and sound"
+          className="mt-1 w-full resize-none rounded-md border border-edge bg-panel-raised px-2.5 py-2 text-xs text-ink placeholder:text-ink-faint focus:border-ink-faint focus:outline-none"
+        />
+      </label>
+      <Button
+        full
+        tone="primary"
+        disabled={!hasImage || !trimmed || trimmed === modelPrompt}
+        onClick={() => {
+          void model.setPrompt({ prompt: trimmed });
+          setDirty(false);
+        }}
+      >
+        {hasImage ? "Start with prompt" : "Choose an image first"}
+      </Button>
+
+      <div className="mt-3 border-t border-edge pt-2">
+        <StatRow label="Image" value={world?.image_name ?? "none"} />
+        <StatRow
+          label="Source"
+          value={
+            world?.image_source === "built_in"
+              ? "built-in"
+              : (world?.image_source ?? "—")
+          }
+        />
+        {world?.active_prompt ? (
+          <p
+            className="mt-1 line-clamp-2 text-[11px] leading-relaxed text-ink-faint"
+            title={world.active_prompt}
+          >
+            <span className="text-ink-dim">Generating now: </span>
+            {world.active_prompt}
+          </p>
+        ) : null}
+      </div>
+    </Panel>
+  );
+}

--- a/models/echo-wm/demo/components/Stage.tsx
+++ b/models/echo-wm/demo/components/Stage.tsx
@@ -90,7 +90,6 @@ export function Stage({
             />
             chunk {world?.completed_chunks ?? 0}
           </span>
-          {world?.paused ? <span className="text-pending">paused</span> : null}
           <span>video + 48 kHz audio</span>
         </div>
       ) : null}

--- a/models/echo-wm/demo/components/Stage.tsx
+++ b/models/echo-wm/demo/components/Stage.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { EchoWmFlashMainVideoView } from "@/lib/echo_wm/client.react";
+import type { DemoConfig } from "@/lib/config";
+import type { WorldState } from "@/lib/model";
+
+import { Dot } from "./ui";
+
+/** What to say over the video when there is nothing to watch yet. */
+function placeholder(
+  status: string,
+  config: DemoConfig,
+  world: WorldState | null,
+): { title: string; detail: string } | null {
+  if (status === "ready") {
+    if (!world?.image_name) {
+      return {
+        title: "Choose a starting image",
+        detail:
+          "Pick a built-in scene or upload your own. The world is generated from that first frame.",
+      };
+    }
+    return null;
+  }
+  if (status === "connecting" || status === "waiting") {
+    return {
+      title: "Opening a session",
+      detail:
+        config.mode === "local"
+          ? "A local container serves one session at a time, so this waits for any earlier session to close."
+          : "The first frames arrive once the model has a scene to generate from.",
+    };
+  }
+  if (status === "error") {
+    return {
+      title: "Could not connect",
+      detail:
+        config.mode === "local"
+          ? `Check that a container is serving on ${config.apiUrl}, the port passed to \`reactor run --port\`. A session left open by an earlier page also refuses a new one for about a minute.`
+          : "Check the API key and that the model name matches a deployed model.",
+    };
+  }
+  return {
+    title: "Not connected",
+    detail:
+      config.mode === "local"
+        ? `Connect to the model container on ${config.apiUrl}.`
+        : `Connect to ${config.modelName}.`,
+  };
+}
+
+export function Stage({
+  config,
+  status,
+  world,
+}: {
+  config: DemoConfig;
+  status: string;
+  world: WorldState | null;
+}) {
+  const overlay = placeholder(status, config, world);
+  const live = status === "ready" && Boolean(world?.image_name);
+
+  return (
+    <div className="relative min-h-0 min-w-0 flex-1 bg-black">
+      <EchoWmFlashMainVideoView
+        className="absolute inset-0 size-full"
+        audioTrack="main_audio"
+        muted={false}
+        videoObjectFit="contain"
+      />
+
+      {overlay ? (
+        <div className="absolute inset-0 flex items-center justify-center p-8">
+          <div className="max-w-sm text-center">
+            <p className="text-sm font-medium text-ink-dim">{overlay.title}</p>
+            <p className="mt-2 text-xs leading-relaxed text-ink-faint">
+              {overlay.detail}
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {live ? (
+        <div className="pointer-events-none absolute bottom-3 left-3 flex items-center gap-3 rounded-md border border-white/10 bg-black/50 px-2.5 py-1.5 text-[11px] text-white/70 backdrop-blur">
+          <span className="flex items-center gap-1.5">
+            <Dot
+              tone={world?.generating ? "live" : "idle"}
+              pulse={world?.generating}
+            />
+            chunk {world?.completed_chunks ?? 0}
+          </span>
+          {world?.paused ? <span className="text-pending">paused</span> : null}
+          <span>video + 48 kHz audio</span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/models/echo-wm/demo/components/Steps.tsx
+++ b/models/echo-wm/demo/components/Steps.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { cx } from "./ui";
+
+/**
+ * The three things that have to happen before the world can be driven, and
+ * which one is next. A session opens with no scene chosen, so without this the
+ * disabled controls below have no explanation.
+ */
+export function Steps({
+  connected,
+  hasImage,
+}: {
+  connected: boolean;
+  hasImage: boolean;
+}) {
+  const steps = [
+    { title: "Connect", detail: "Open a session with the model." },
+    {
+      title: "Choose a starting image",
+      detail: "A built-in scene, or upload your own.",
+    },
+    {
+      title: "Drive the world",
+      detail: "Steer with the keyboard and listen as the world responds.",
+    },
+  ];
+  const current = !connected ? 0 : !hasImage ? 1 : 2;
+
+  return (
+    <ol className="rounded-lg border border-edge bg-panel p-4">
+      {steps.map((step, index) => {
+        const done = index < current;
+        const active = index === current;
+        return (
+          <li
+            key={step.title}
+            className={cx(
+              "flex gap-3 py-1.5",
+              !done && !active && "opacity-40",
+            )}
+          >
+            <span
+              className={cx(
+                "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full border text-[10px] font-semibold",
+                done && "border-live/40 bg-live/10 text-live",
+                active && "border-ink bg-ink text-canvas",
+                !done && !active && "border-edge text-ink-faint",
+              )}
+            >
+              {done ? "✓" : index + 1}
+            </span>
+            <span className="min-w-0">
+              <span
+                className={cx(
+                  "block text-xs font-medium",
+                  active ? "text-ink" : "text-ink-dim",
+                )}
+              >
+                {step.title}
+              </span>
+              {active ? (
+                <span className="block text-[11px] leading-relaxed text-ink-faint">
+                  {step.detail}
+                </span>
+              ) : null}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/models/echo-wm/demo/components/Toasts.tsx
+++ b/models/echo-wm/demo/components/Toasts.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { cx } from "./ui";
+
+export type ToastTone = "info" | "error";
+
+interface Toast {
+  id: number;
+  tone: ToastTone;
+  text: string;
+}
+
+type Listener = (toast: Toast) => void;
+
+const listeners = new Set<Listener>();
+let nextId = 1;
+
+/** Show a short-lived message. Safe to call from anywhere in the tree. */
+export function notify(tone: ToastTone, text: string): void {
+  const toast = { id: nextId++, tone, text };
+  for (const listener of listeners) listener(toast);
+}
+
+export function Toasts() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  useEffect(() => {
+    const listener: Listener = (toast) => {
+      setToasts((current) => [...current, toast]);
+      const lifetime = toast.tone === "error" ? 8000 : 4000;
+      window.setTimeout(
+        () => setToasts((current) => current.filter((t) => t.id !== toast.id)),
+        lifetime,
+      );
+    };
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  if (toasts.length === 0) return null;
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 left-1/2 z-50 flex w-[min(28rem,calc(100vw-2rem))] -translate-x-1/2 flex-col gap-2">
+      {toasts.map((toast) => (
+        <div
+          key={toast.id}
+          className={cx(
+            "rounded-md border px-3 py-2 text-xs shadow-lg backdrop-blur",
+            toast.tone === "error"
+              ? "border-alert/40 bg-alert/10 text-alert"
+              : "border-edge bg-panel/90 text-ink-dim",
+          )}
+        >
+          {toast.text}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/models/echo-wm/demo/components/Workspace.tsx
+++ b/models/echo-wm/demo/components/Workspace.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useReactorMessage } from "@reactor-team/js-sdk";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  useEchoWmFlash,
+  useEchoWmFlashAutomaticResetQueued,
+  useEchoWmFlashImageSelected,
+  useEchoWmFlashStateUpdate,
+} from "@/lib/echo_wm/client.react";
+import type { DemoConfig } from "@/lib/config";
+import type { WorldState } from "@/lib/model";
+
+import { CameraBar } from "./CameraBar";
+import { Header } from "./Header";
+import { RolloutPanel } from "./RolloutPanel";
+import { ScenePanel } from "./ScenePanel";
+import { Stage } from "./Stage";
+import { Steps } from "./Steps";
+import { notify } from "./Toasts";
+
+/**
+ * Put a readable sentence in front of the failures a reader is likely to hit.
+ *
+ * A container serves one session at a time and holds a closed one open for about
+ * a minute in case the client comes back, so leaving the page without
+ * disconnecting is the most common reason a reconnect is refused.
+ */
+function explain(message: string): string {
+  if (message.includes("orphaned")) {
+    return "An earlier session is still closing. The model accepts one session at a time and releases a dropped one after about a minute — try again shortly, and use Disconnect to leave straight away.";
+  }
+  return message;
+}
+
+export function Workspace({ config }: { config: DemoConfig }) {
+  const model = useEchoWmFlash();
+  const { status, lastError } = model;
+  const [world, setWorld] = useState<WorldState | null>(null);
+
+  // The model broadcasts a complete snapshot whenever anything observable
+  // changes, and sends one to every viewer as it joins. Treating that snapshot
+  // as the only source of truth keeps the UI honest about what the model will
+  // actually do next, rather than guessing from the commands this tab sent.
+  useEchoWmFlashStateUpdate(setWorld);
+
+  useEchoWmFlashImageSelected((message) => {
+    notify(
+      "info",
+      message.source === "built_in"
+        ? `Loaded built-in scene ${message.filename}`
+        : `Loaded ${message.filename}`,
+    );
+  });
+
+  useEchoWmFlashAutomaticResetQueued((message) => {
+    notify(
+      "info",
+      `Rollout limit reached after ${message.completed_chunks} chunks — restarting from the same image.`,
+    );
+  });
+
+  // A rejected command comes back correlated to the request that caused it, not
+  // as one of the model's own messages, so it arrives here without a `type`.
+  useReactorMessage((raw: unknown) => {
+    const error = (raw as { error?: { code?: string; message?: string } })
+      ?.error;
+    if (error?.message || error?.code) {
+      notify("error", error.message || `Command rejected (${error.code})`);
+    }
+  });
+
+  const previousStatus = useRef(status);
+  useEffect(() => {
+    if (previousStatus.current !== status && status === "disconnected") {
+      setWorld(null);
+    }
+    previousStatus.current = status;
+  }, [status]);
+
+  useEffect(() => {
+    if (lastError) notify("error", explain(lastError.message));
+  }, [lastError]);
+
+  const connected = status === "ready";
+  const hasImage = Boolean(world?.image_name);
+
+  const connect = useCallback(() => {
+    void model.connect().catch((error: unknown) => {
+      notify(
+        "error",
+        error instanceof Error ? error.message : "Could not connect",
+      );
+    });
+  }, [model]);
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden">
+      <Header
+        config={config}
+        status={status}
+        onConnect={connect}
+        onDisconnect={() => void model.disconnect()}
+      />
+
+      <main className="flex min-h-0 flex-1 flex-col-reverse lg:flex-row">
+        <aside className="flex w-full shrink-0 flex-col gap-3 overflow-y-auto border-edge p-3 lg:w-[24rem] lg:border-r">
+          <Steps connected={connected} hasImage={hasImage} />
+          <ScenePanel model={model} world={world} connected={connected} />
+          <RolloutPanel model={model} world={world} enabled={hasImage} />
+        </aside>
+
+        <section className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <Stage config={config} status={status} world={world} />
+          <CameraBar model={model} world={world} enabled={hasImage} />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/models/echo-wm/demo/components/ui.tsx
+++ b/models/echo-wm/demo/components/ui.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+export function cx(...parts: (string | false | null | undefined)[]): string {
+  return parts.filter(Boolean).join(" ");
+}
+
+export function Panel({
+  title,
+  hint,
+  children,
+  disabled,
+}: {
+  title: string;
+  hint?: ReactNode;
+  children: ReactNode;
+  disabled?: boolean;
+}) {
+  return (
+    <section
+      className={cx(
+        "rounded-lg border border-edge bg-panel p-4 transition-opacity",
+        disabled && "pointer-events-none opacity-40",
+      )}
+    >
+      <header className="mb-3">
+        <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-ink-dim">
+          {title}
+        </h2>
+        {hint ? (
+          <p className="mt-1 text-[11px] leading-relaxed text-ink-faint">
+            {hint}
+          </p>
+        ) : null}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+type ButtonTone = "default" | "primary" | "danger";
+
+export function Button({
+  children,
+  onClick,
+  disabled,
+  tone = "default",
+  full,
+  title,
+}: {
+  children: ReactNode;
+  onClick?: () => void;
+  disabled?: boolean;
+  tone?: ButtonTone;
+  full?: boolean;
+  title?: string;
+}) {
+  const tones: Record<ButtonTone, string> = {
+    default:
+      "border-edge bg-panel-raised text-ink hover:border-ink-faint hover:bg-edge",
+    primary:
+      "border-transparent bg-ink text-canvas hover:bg-white disabled:bg-ink-faint",
+    danger:
+      "border-edge bg-panel-raised text-alert hover:border-alert hover:bg-edge",
+  };
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      disabled={disabled}
+      className={cx(
+        "inline-flex h-8 items-center justify-center gap-2 rounded-md border px-3 text-xs font-medium transition-colors",
+        "disabled:cursor-not-allowed disabled:opacity-40",
+        tones[tone],
+        full && "w-full",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function Pill({
+  children,
+  tone = "neutral",
+  title,
+}: {
+  children: ReactNode;
+  tone?: "neutral" | "live" | "pending" | "alert";
+  title?: string;
+}) {
+  const tones = {
+    neutral: "border-edge text-ink-dim",
+    live: "border-live/40 text-live",
+    pending: "border-pending/40 text-pending",
+    alert: "border-alert/40 text-alert",
+  } as const;
+  return (
+    <span
+      title={title}
+      className={cx(
+        "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium",
+        tones[tone],
+      )}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function Dot({
+  tone,
+  pulse,
+}: {
+  tone: "idle" | "live" | "pending" | "alert";
+  pulse?: boolean;
+}) {
+  const tones = {
+    idle: "bg-ink-faint",
+    live: "bg-live",
+    pending: "bg-pending",
+    alert: "bg-alert",
+  } as const;
+  return (
+    <span
+      className={cx(
+        "inline-block size-1.5 shrink-0 rounded-full",
+        tones[tone],
+        pulse && "animate-pulse",
+      )}
+    />
+  );
+}
+
+export function StatRow({
+  label,
+  value,
+  title,
+}: {
+  label: string;
+  value: ReactNode;
+  title?: string;
+}) {
+  return (
+    <div
+      className="flex items-baseline justify-between gap-3 py-1"
+      title={title}
+    >
+      <span className="text-[11px] text-ink-faint">{label}</span>
+      <span className="truncate text-right text-xs tabular-nums text-ink-dim">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+/** A signed -1..1 velocity drawn as a bar that fills from the centre. */
+export function AxisMeter({
+  label,
+  negative,
+  positive,
+  value,
+}: {
+  label: string;
+  negative: string;
+  positive: string;
+  value: number;
+}) {
+  const magnitude = Math.abs(value) * 50;
+  return (
+    <div>
+      <div className="flex items-baseline justify-between text-[10px] text-ink-faint">
+        <span>{negative}</span>
+        <span className="font-medium uppercase tracking-[0.1em] text-ink-dim">
+          {label}
+        </span>
+        <span>{positive}</span>
+      </div>
+      <div className="relative mt-1 h-1.5 overflow-hidden rounded-full bg-panel-raised">
+        <div className="absolute left-1/2 top-0 h-full w-px bg-edge" />
+        <div
+          className="absolute top-0 h-full rounded-full bg-accent transition-[width,left] duration-100"
+          style={
+            value >= 0
+              ? { left: "50%", width: `${magnitude}%` }
+              : { left: `${50 - magnitude}%`, width: `${magnitude}%` }
+          }
+        />
+      </div>
+    </div>
+  );
+}

--- a/models/echo-wm/demo/components/useCameraKeys.ts
+++ b/models/echo-wm/demo/components/useCameraKeys.ts
@@ -1,0 +1,109 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import {
+  BINDING_BY_CODE,
+  type Motion,
+  NEUTRAL_MOTION,
+  changedAxes,
+  isTypingTarget,
+  motionFrom,
+} from "@/lib/controls";
+
+interface Options {
+  /** Keys are ignored until the model has a world to steer. */
+  enabled: boolean;
+  /** Called with one atomic four-axis update when held keys change. */
+  onMotion: (motion: Motion) => void;
+}
+
+/**
+ * Track which movement keys are down and push one atomic motion command.
+ *
+ * The model holds a velocity until it is replaced, so a key press and a key
+ * release are one command each and holding a key sends nothing. `press` and
+ * `release` are exposed so the on-screen pad drives the same key set as the
+ * keyboard, and both light up the same way.
+ */
+export function useCameraKeys({ enabled, onMotion }: Options) {
+  const [pressed, setPressed] = useState<ReadonlySet<string>>(new Set());
+  const pressedRef = useRef<Set<string>>(new Set());
+  const motionRef = useRef<Motion>({ ...NEUTRAL_MOTION });
+  const onMotionRef = useRef(onMotion);
+
+  useEffect(() => {
+    onMotionRef.current = onMotion;
+  });
+
+  const commit = useCallback(() => {
+    const next = motionFrom(pressedRef.current);
+    if (changedAxes(motionRef.current, next).length > 0) {
+      onMotionRef.current(next);
+    }
+    motionRef.current = next;
+    setPressed(new Set(pressedRef.current));
+  }, []);
+
+  const press = useCallback(
+    (code: string) => {
+      if (pressedRef.current.has(code)) return;
+      pressedRef.current.add(code);
+      commit();
+    },
+    [commit],
+  );
+
+  const release = useCallback(
+    (code: string) => {
+      if (!pressedRef.current.delete(code)) return;
+      commit();
+    },
+    [commit],
+  );
+
+  const releaseAll = useCallback(() => {
+    if (pressedRef.current.size === 0) return;
+    pressedRef.current.clear();
+    commit();
+  }, [commit]);
+
+  useEffect(() => {
+    if (!enabled) {
+      releaseAll();
+      return;
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.repeat || isTypingTarget(event.target)) return;
+      if (!BINDING_BY_CODE[event.code]) return;
+      event.preventDefault();
+      press(event.code);
+    };
+    const onKeyUp = (event: KeyboardEvent) => {
+      if (!BINDING_BY_CODE[event.code]) return;
+      event.preventDefault();
+      release(event.code);
+    };
+    // A window that loses focus keeps no key state, so the model would keep
+    // moving on a velocity the user can no longer cancel.
+    const onBlur = () => releaseAll();
+
+    window.addEventListener("keydown", onKeyDown);
+    window.addEventListener("keyup", onKeyUp);
+    window.addEventListener("blur", onBlur);
+    document.addEventListener("visibilitychange", onBlur);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown);
+      window.removeEventListener("keyup", onKeyUp);
+      window.removeEventListener("blur", onBlur);
+      document.removeEventListener("visibilitychange", onBlur);
+      releaseAll();
+    };
+  }, [enabled, press, release, releaseAll]);
+
+  return useMemo(
+    () => ({ pressed, press, release, releaseAll }),
+    [pressed, press, release, releaseAll],
+  );
+}

--- a/models/echo-wm/demo/lib/config.ts
+++ b/models/echo-wm/demo/lib/config.ts
@@ -1,0 +1,49 @@
+/**
+ * The two ways this app can reach the model.
+ *
+ * `local` talks straight to a container started with `reactor run`: no account,
+ * no API key, no session token. `hosted` goes through the Reactor API, which
+ * mints a short-lived session token for the browser.
+ */
+export type Mode = "local" | "hosted";
+
+export interface DemoConfig {
+  mode: Mode;
+  /** Model name sent when a hosted session is created. */
+  modelName: string;
+  /** Base URL the SDK connects to, or `undefined` to accept the SDK default. */
+  apiUrl?: string;
+}
+
+/** Matches `model.name` in the example's reactor.yaml. */
+const DEFAULT_MODEL_NAME = "echo-wm-flash";
+
+/** Where `reactor run` serves when `--port` is not passed. */
+const DEFAULT_LOCAL_URL = "http://localhost:8080";
+
+/**
+ * Read the environment once, on the server.
+ *
+ * `REACTOR_API_KEY` is the switch: with a key the app creates hosted sessions,
+ * without one it connects to a local container. The key itself never leaves the
+ * server — only the resolved mode, model name, and base URL are handed to the
+ * browser.
+ */
+export function readConfig(): DemoConfig {
+  const modelName =
+    process.env.REACTOR_MODEL_NAME?.trim() || DEFAULT_MODEL_NAME;
+
+  if (process.env.REACTOR_API_KEY?.trim()) {
+    return {
+      mode: "hosted",
+      modelName,
+      apiUrl: process.env.REACTOR_API_URL?.trim() || undefined,
+    };
+  }
+
+  return {
+    mode: "local",
+    modelName,
+    apiUrl: process.env.REACTOR_LOCAL_URL?.trim() || DEFAULT_LOCAL_URL,
+  };
+}

--- a/models/echo-wm/demo/lib/controls.ts
+++ b/models/echo-wm/demo/lib/controls.ts
@@ -1,0 +1,97 @@
+/**
+ * Keyboard bindings for Echo-WM's four pure-camera axes.
+ *
+ * Each axis takes a velocity between -1 and 1 that the model holds until a new
+ * value arrives, so a key press is a single command and a key release is a
+ * single command back to zero. Nothing is sent while a key is simply held down.
+ */
+
+export const AXES = ["forward", "strafe", "pitch", "yaw"] as const;
+
+export type Axis = (typeof AXES)[number];
+
+/** The four velocities sent together through `set_camera_motion`. */
+export type Motion = Record<Axis, number>;
+
+export const NEUTRAL_MOTION: Motion = {
+  forward: 0,
+  strafe: 0,
+  pitch: 0,
+  yaw: 0,
+};
+
+export interface Binding {
+  /** `KeyboardEvent.code`, so the layout is independent of keyboard language. */
+  code: string;
+  axis: Axis;
+  /** Velocity applied while the key is down. */
+  value: 1 | -1;
+  /** Key name shown in the on-screen pad. */
+  key: string;
+  /** What the key does, in the model's terms. */
+  action: string;
+}
+
+/**
+ * Movement on the left hand, looking on the right hand.
+ *
+ * W/A/S/D translate and I/J/K/L rotate, which keeps looking around on the
+ * keyboard rather than the mouse: the model samples one velocity per chunk, so
+ * mouse deltas would be averaged away rather than felt.
+ */
+export const BINDINGS: readonly Binding[] = [
+  { code: "KeyW", axis: "forward", value: 1, key: "W", action: "Forward" },
+  { code: "KeyS", axis: "forward", value: -1, key: "S", action: "Back" },
+  { code: "KeyA", axis: "strafe", value: -1, key: "A", action: "Left" },
+  { code: "KeyD", axis: "strafe", value: 1, key: "D", action: "Right" },
+  { code: "KeyI", axis: "pitch", value: 1, key: "I", action: "Look up" },
+  { code: "KeyK", axis: "pitch", value: -1, key: "K", action: "Look down" },
+  { code: "KeyJ", axis: "yaw", value: -1, key: "J", action: "Turn left" },
+  { code: "KeyL", axis: "yaw", value: 1, key: "L", action: "Turn right" },
+];
+
+export const BINDING_BY_CODE: Record<string, Binding> = Object.fromEntries(
+  BINDINGS.map((binding) => [binding.code, binding]),
+);
+
+/** The original demo pad layout, reduced to Echo-WM's native controls. */
+export const PAD_ROWS: readonly (readonly string[])[] = [
+  ["KeyW", "KeyS", "KeyA", "KeyD"],
+  ["KeyI", "KeyK", "KeyJ", "KeyL"],
+];
+
+/**
+ * Resolve the four velocities from the set of keys currently down.
+ *
+ * Opposite keys on one axis cancel, which keeps the axis at zero instead of
+ * letting whichever key was pressed last win.
+ */
+export function motionFrom(pressed: ReadonlySet<string>): Motion {
+  const motion: Motion = { ...NEUTRAL_MOTION };
+  for (const code of pressed) {
+    const binding = BINDING_BY_CODE[code];
+    if (binding) motion[binding.axis] += binding.value;
+  }
+  for (const axis of AXES) {
+    motion[axis] = Math.max(-1, Math.min(1, motion[axis]));
+  }
+  return motion;
+}
+
+/** The axes whose velocity changed, so only those are sent. */
+export function changedAxes(from: Motion, to: Motion): Axis[] {
+  return AXES.filter((axis) => from[axis] !== to[axis]);
+}
+
+/** True while a text field has focus and keystrokes belong to it. */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null;
+  if (!element) return false;
+  const tag = element.tagName;
+  return (
+    tag === "INPUT" ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    element.isContentEditable
+  );
+}

--- a/models/echo-wm/demo/lib/echo_wm/README.md
+++ b/models/echo-wm/demo/lib/echo_wm/README.md
@@ -1,0 +1,29 @@
+# Schema-derived model client
+
+`client.ts` and `client.react.tsx` mirror the model contract served by
+`/schema`. Command parameters, model messages, and the `main_video` and
+`main_audio` receive tracks are represented as TypeScript types.
+
+`client.ts` contains the standalone client surface. `client.react.tsx`
+contains `useEchoWmFlash()`, one hook per message, and the audiovisual
+`EchoWmFlashMainVideoView` component. Both use
+`@reactor-team/js-sdk` directly.
+
+The app wraps the SDK's `ReactorProvider` rather than the model-specific
+provider so `REACTOR_MODEL_NAME` can select the deployed model without changing
+source code.
+
+## Keeping it in sync
+
+After changing the Python schema, start the model and save the served contract:
+
+```sh
+curl -fsS http://localhost:8080/schema -o /tmp/echo-wm-schema.json
+```
+
+Update both client files to match that contract, then verify the frontend:
+
+```sh
+pnpm typecheck
+pnpm build
+```

--- a/models/echo-wm/demo/lib/echo_wm/client.react.tsx
+++ b/models/echo-wm/demo/lib/echo_wm/client.react.tsx
@@ -23,7 +23,6 @@ import {
   type EchoWmFlashImageSelectedMessage,
   type EchoWmFlashMessage,
   type EchoWmFlashOptions,
-  type EchoWmFlashPauseChangedMessage,
   type EchoWmFlashPromptQueuedMessage,
   type EchoWmFlashRecvTrackName,
   type EchoWmFlashResetParams,
@@ -31,10 +30,8 @@ import {
   type EchoWmFlashSetCameraMotionParams,
   type EchoWmFlashSetFovParams,
   type EchoWmFlashSetImageParams,
-  type EchoWmFlashSetPausedParams,
   type EchoWmFlashSetPromptParams,
   type EchoWmFlashStateUpdateMessage,
-  type EchoWmFlashStepQueuedMessage,
 } from "./client";
 
 function unwrapMessage<T>(raw: unknown): T {
@@ -119,9 +116,6 @@ export function useEchoWmFlash() {
     releaseCamera: (): Promise<void> => sendCommand("release_camera", {}),
     setFov: (params: EchoWmFlashSetFovParams): Promise<void> =>
       sendCommand("set_fov", params),
-    setPaused: (params: EchoWmFlashSetPausedParams): Promise<void> =>
-      sendCommand("set_paused", params),
-    step: (): Promise<void> => sendCommand("step", {}),
     reset: (params: EchoWmFlashResetParams): Promise<void> =>
       sendCommand("reset", params),
   };
@@ -165,18 +159,6 @@ export function useEchoWmFlashCameraMotionChanged(
   handler: (message: EchoWmFlashCameraMotionChangedMessage) => void,
 ): void {
   useMessageType("camera_motion_changed", handler);
-}
-
-export function useEchoWmFlashPauseChanged(
-  handler: (message: EchoWmFlashPauseChangedMessage) => void,
-): void {
-  useMessageType("pause_changed", handler);
-}
-
-export function useEchoWmFlashStepQueued(
-  handler: (message: EchoWmFlashStepQueuedMessage) => void,
-): void {
-  useMessageType("step_queued", handler);
 }
 
 export function useEchoWmFlashRolloutResetQueued(

--- a/models/echo-wm/demo/lib/echo_wm/client.react.tsx
+++ b/models/echo-wm/demo/lib/echo_wm/client.react.tsx
@@ -1,0 +1,213 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+// Generated from the Echo-WM Flash Reactor schema.
+// Model: echo-wm-flash v0.0.0
+
+"use client";
+
+import {
+  ReactorProvider,
+  ReactorView,
+  type ReactorViewProps,
+  useReactor,
+  useReactorMessage,
+} from "@reactor-team/js-sdk";
+import type { ReactElement } from "react";
+
+import {
+  EchoWmFlashTracks,
+  MODEL_NAME,
+  type EchoWmFlashAutomaticResetQueuedMessage,
+  type EchoWmFlashCameraMotionChangedMessage,
+  type EchoWmFlashChunkCompletedMessage,
+  type EchoWmFlashImageSelectedMessage,
+  type EchoWmFlashMessage,
+  type EchoWmFlashOptions,
+  type EchoWmFlashPauseChangedMessage,
+  type EchoWmFlashPromptQueuedMessage,
+  type EchoWmFlashRecvTrackName,
+  type EchoWmFlashResetParams,
+  type EchoWmFlashRolloutResetQueuedMessage,
+  type EchoWmFlashSetCameraMotionParams,
+  type EchoWmFlashSetFovParams,
+  type EchoWmFlashSetImageParams,
+  type EchoWmFlashSetPausedParams,
+  type EchoWmFlashSetPromptParams,
+  type EchoWmFlashStateUpdateMessage,
+  type EchoWmFlashStepQueuedMessage,
+} from "./client";
+
+function unwrapMessage<T>(raw: unknown): T {
+  const envelope = raw as { type?: string; data?: Record<string, unknown> };
+  if (
+    envelope &&
+    typeof envelope === "object" &&
+    envelope.data &&
+    typeof envelope.data === "object"
+  ) {
+    return { ...envelope.data, type: envelope.type } as T;
+  }
+  return raw as T;
+}
+
+export type EchoWmFlashProviderProps = Omit<
+  Parameters<typeof ReactorProvider>[0],
+  "modelName" | "modelTracks"
+>;
+
+export function EchoWmFlashProvider({
+  children,
+  ...rest
+}: EchoWmFlashProviderProps): ReactElement {
+  return (
+    <ReactorProvider
+      {...rest}
+      modelName={MODEL_NAME}
+      modelTracks={[...EchoWmFlashTracks]}
+    >
+      {children}
+    </ReactorProvider>
+  );
+}
+
+/** Return the SDK store and Echo-WM's schema-derived commands. */
+export function useEchoWmFlash() {
+  const connect = useReactor((state) => state.connect);
+  const connectOptions = useReactor((state) => state.connectOptions);
+  const disconnect = useReactor((state) => state.disconnect);
+  const downloadClipAsFile = useReactor((state) => state.downloadClipAsFile);
+  const jwtToken = useReactor((state) => state.jwtToken);
+  const lastError = useReactor((state) => state.lastError);
+  const publish = useReactor((state) => state.publish);
+  const reconnect = useReactor((state) => state.reconnect);
+  const requestClip = useReactor((state) => state.requestClip);
+  const requestRecording = useReactor((state) => state.requestRecording);
+  const sendCommand = useReactor((state) => state.sendCommand);
+  const sessionExpiration = useReactor((state) => state.sessionExpiration);
+  const sessionId = useReactor((state) => state.sessionId);
+  const status = useReactor((state) => state.status);
+  const tracks = useReactor((state) => state.tracks);
+  const unpublish = useReactor((state) => state.unpublish);
+  const uploadFile = useReactor((state) => state.uploadFile);
+
+  return {
+    connect,
+    connectOptions,
+    disconnect,
+    downloadClipAsFile,
+    jwtToken,
+    lastError,
+    publish,
+    reconnect,
+    requestClip,
+    requestRecording,
+    sendCommand,
+    sessionExpiration,
+    sessionId,
+    status,
+    tracks,
+    unpublish,
+    uploadFile,
+    setImage: (params: EchoWmFlashSetImageParams): Promise<void> =>
+      sendCommand("set_image", params),
+    randomImage: (): Promise<void> => sendCommand("random_image", {}),
+    setPrompt: (params: EchoWmFlashSetPromptParams): Promise<void> =>
+      sendCommand("set_prompt", params),
+    setCameraMotion: (
+      params: EchoWmFlashSetCameraMotionParams,
+    ): Promise<void> => sendCommand("set_camera_motion", params),
+    releaseCamera: (): Promise<void> => sendCommand("release_camera", {}),
+    setFov: (params: EchoWmFlashSetFovParams): Promise<void> =>
+      sendCommand("set_fov", params),
+    setPaused: (params: EchoWmFlashSetPausedParams): Promise<void> =>
+      sendCommand("set_paused", params),
+    step: (): Promise<void> => sendCommand("step", {}),
+    reset: (params: EchoWmFlashResetParams): Promise<void> =>
+      sendCommand("reset", params),
+  };
+}
+
+export function useEchoWmFlashMessage(
+  handler: (message: EchoWmFlashMessage) => void,
+): void {
+  useReactorMessage((raw: unknown) => handler(unwrapMessage(raw)));
+}
+
+function useMessageType<T extends EchoWmFlashMessage>(
+  type: T["type"],
+  handler: (message: T) => void,
+): void {
+  useReactorMessage((raw: unknown) => {
+    const message = unwrapMessage<EchoWmFlashMessage>(raw);
+    if (message.type === type) handler(message as T);
+  });
+}
+
+export function useEchoWmFlashStateUpdate(
+  handler: (message: EchoWmFlashStateUpdateMessage) => void,
+): void {
+  useMessageType("state_update", handler);
+}
+
+export function useEchoWmFlashImageSelected(
+  handler: (message: EchoWmFlashImageSelectedMessage) => void,
+): void {
+  useMessageType("image_selected", handler);
+}
+
+export function useEchoWmFlashPromptQueued(
+  handler: (message: EchoWmFlashPromptQueuedMessage) => void,
+): void {
+  useMessageType("prompt_queued", handler);
+}
+
+export function useEchoWmFlashCameraMotionChanged(
+  handler: (message: EchoWmFlashCameraMotionChangedMessage) => void,
+): void {
+  useMessageType("camera_motion_changed", handler);
+}
+
+export function useEchoWmFlashPauseChanged(
+  handler: (message: EchoWmFlashPauseChangedMessage) => void,
+): void {
+  useMessageType("pause_changed", handler);
+}
+
+export function useEchoWmFlashStepQueued(
+  handler: (message: EchoWmFlashStepQueuedMessage) => void,
+): void {
+  useMessageType("step_queued", handler);
+}
+
+export function useEchoWmFlashRolloutResetQueued(
+  handler: (message: EchoWmFlashRolloutResetQueuedMessage) => void,
+): void {
+  useMessageType("rollout_reset_queued", handler);
+}
+
+export function useEchoWmFlashChunkCompleted(
+  handler: (message: EchoWmFlashChunkCompletedMessage) => void,
+): void {
+  useMessageType("chunk_completed", handler);
+}
+
+export function useEchoWmFlashAutomaticResetQueued(
+  handler: (message: EchoWmFlashAutomaticResetQueuedMessage) => void,
+): void {
+  useMessageType("automatic_reset_queued", handler);
+}
+
+export function useEchoWmFlashTrack(name: EchoWmFlashRecvTrackName) {
+  return useReactor((state) => state.tracks[name]);
+}
+
+export type EchoWmFlashMainVideoViewProps = Omit<ReactorViewProps, "track">;
+
+/** Render Echo-WM video and optionally attach its generated audio track. */
+export function EchoWmFlashMainVideoView(
+  props: EchoWmFlashMainVideoViewProps,
+): ReactElement {
+  return <ReactorView {...props} track="main_video" />;
+}
+
+export type { EchoWmFlashOptions };

--- a/models/echo-wm/demo/lib/echo_wm/client.ts
+++ b/models/echo-wm/demo/lib/echo_wm/client.ts
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
+
+// Generated from the Echo-WM Flash Reactor schema.
+// Model: echo-wm-flash v0.0.0
+
+import { FileRef, Reactor } from "@reactor-team/js-sdk";
+
+export { FileRef };
+
+export const MODEL_NAME = "echo-wm-flash" as const;
+export const MODEL_VERSION = "v0.0.0" as const;
+
+/** Media tracks declared by the Echo-WM Flash schema. */
+export const EchoWmFlashTracks = [
+  { name: "main_video", kind: "video", direction: "recvonly" },
+  { name: "main_audio", kind: "audio", direction: "recvonly" },
+] as const;
+
+export type EchoWmFlashRecvTrackName = "main_video" | "main_audio";
+
+export interface EchoWmFlashSetImageParams {
+  image: FileRef;
+  prompt?: string;
+  seed?: number;
+}
+
+export interface EchoWmFlashSetPromptParams {
+  prompt?: string;
+}
+
+export interface EchoWmFlashSetCameraMotionParams {
+  forward?: number;
+  strafe?: number;
+  pitch?: number;
+  yaw?: number;
+}
+
+export interface EchoWmFlashSetFovParams {
+  fov_degrees?: number;
+}
+
+export interface EchoWmFlashSetPausedParams {
+  paused?: boolean;
+}
+
+export interface EchoWmFlashResetParams {
+  seed?: number;
+}
+
+export interface EchoWmFlashStateUpdateMessage {
+  type: "state_update";
+  image_source: "uploaded" | "built_in" | null;
+  image_name: string | null;
+  prompt: string | null;
+  active_prompt: string | null;
+  seed: number;
+  paused: boolean;
+  step_queued: boolean;
+  queued_steps: number;
+  reset_queued: boolean;
+  generating: boolean;
+  completed_chunks: number;
+  next_chunk: number | null;
+  max_chunks: number;
+  forward: number;
+  strafe: number;
+  pitch: number;
+  yaw: number;
+  fov_degrees: number;
+}
+
+export interface EchoWmFlashImageSelectedMessage {
+  type: "image_selected";
+  source: "uploaded" | "built_in";
+  filename: string;
+  prompt: string;
+  seed: number;
+  first_chunk_queued: boolean;
+  preview_chunks_queued: number;
+}
+
+export interface EchoWmFlashPromptQueuedMessage {
+  type: "prompt_queued";
+  prompt: string;
+  applies_to_chunk: number;
+}
+
+export interface EchoWmFlashCameraMotionChangedMessage {
+  type: "camera_motion_changed";
+  forward: number;
+  strafe: number;
+  pitch: number;
+  yaw: number;
+  fov_degrees: number;
+  applies_to_chunk: number | null;
+}
+
+export interface EchoWmFlashPauseChangedMessage {
+  type: "pause_changed";
+  paused: boolean;
+  next_chunk: number | null;
+}
+
+export interface EchoWmFlashStepQueuedMessage {
+  type: "step_queued";
+  applies_to_chunk: number;
+  expected_video_frames: number;
+}
+
+export interface EchoWmFlashRolloutResetQueuedMessage {
+  type: "rollout_reset_queued";
+  seed: number;
+  replaced_chunks: number;
+  first_chunk_queued: boolean;
+}
+
+export interface EchoWmFlashChunkCompletedMessage {
+  type: "chunk_completed";
+  chunk: number;
+  video_frames: number;
+  audio_samples: number;
+  generation_seconds: number;
+  denoise_seconds: number | null;
+  cache_commit_seconds: number | null;
+  video_decode_seconds: number | null;
+  audio_decode_seconds: number | null;
+  cuda_total_seconds: number | null;
+  prompt: string;
+  forward: number;
+  strafe: number;
+  pitch: number;
+  yaw: number;
+}
+
+export interface EchoWmFlashAutomaticResetQueuedMessage {
+  type: "automatic_reset_queued";
+  completed_chunks: number;
+  max_chunks: number;
+  seed: number;
+}
+
+export type EchoWmFlashMessage =
+  | EchoWmFlashStateUpdateMessage
+  | EchoWmFlashImageSelectedMessage
+  | EchoWmFlashPromptQueuedMessage
+  | EchoWmFlashCameraMotionChangedMessage
+  | EchoWmFlashPauseChangedMessage
+  | EchoWmFlashStepQueuedMessage
+  | EchoWmFlashRolloutResetQueuedMessage
+  | EchoWmFlashChunkCompletedMessage
+  | EchoWmFlashAutomaticResetQueuedMessage;
+
+export type EchoWmFlashOptions = Omit<
+  ConstructorParameters<typeof Reactor>[0],
+  "modelName" | "modelTracks"
+>;
+
+function unwrapMessage<T>(raw: unknown): T {
+  const envelope = raw as { type?: string; data?: Record<string, unknown> };
+  if (
+    envelope &&
+    typeof envelope === "object" &&
+    envelope.data &&
+    typeof envelope.data === "object"
+  ) {
+    return { ...envelope.data, type: envelope.type } as T;
+  }
+  return raw as T;
+}
+
+/** Strongly typed standalone client for Echo-WM Flash. */
+export class EchoWmFlashModel extends Reactor {
+  constructor(options?: EchoWmFlashOptions) {
+    super({
+      ...options,
+      modelName: MODEL_NAME,
+      modelTracks: [...EchoWmFlashTracks],
+    });
+  }
+
+  async setImage(params: EchoWmFlashSetImageParams): Promise<void> {
+    await this.sendCommand("set_image", params);
+  }
+
+  async randomImage(): Promise<void> {
+    await this.sendCommand("random_image", {});
+  }
+
+  async setPrompt(params: EchoWmFlashSetPromptParams): Promise<void> {
+    await this.sendCommand("set_prompt", params);
+  }
+
+  async setCameraMotion(
+    params: EchoWmFlashSetCameraMotionParams,
+  ): Promise<void> {
+    await this.sendCommand("set_camera_motion", params);
+  }
+
+  async releaseCamera(): Promise<void> {
+    await this.sendCommand("release_camera", {});
+  }
+
+  async setFov(params: EchoWmFlashSetFovParams): Promise<void> {
+    await this.sendCommand("set_fov", params);
+  }
+
+  async setPaused(params: EchoWmFlashSetPausedParams): Promise<void> {
+    await this.sendCommand("set_paused", params);
+  }
+
+  async step(): Promise<void> {
+    await this.sendCommand("step", {});
+  }
+
+  async reset(params: EchoWmFlashResetParams): Promise<void> {
+    await this.sendCommand("reset", params);
+  }
+
+  onMessage(handler: (message: EchoWmFlashMessage) => void): () => void {
+    const wrapped = (raw: unknown) => handler(unwrapMessage(raw));
+    this.on("message", wrapped);
+    return () => this.off("message", wrapped);
+  }
+
+  onMainVideo(
+    handler: (track: MediaStreamTrack, stream: MediaStream) => void,
+  ): () => void {
+    const wrapped = (
+      name: string,
+      track: MediaStreamTrack,
+      stream: MediaStream,
+    ) => {
+      if (name === "main_video") handler(track, stream);
+    };
+    this.on("trackReceived", wrapped);
+    return () => this.off("trackReceived", wrapped);
+  }
+
+  onMainAudio(
+    handler: (track: MediaStreamTrack, stream: MediaStream) => void,
+  ): () => void {
+    const wrapped = (
+      name: string,
+      track: MediaStreamTrack,
+      stream: MediaStream,
+    ) => {
+      if (name === "main_audio") handler(track, stream);
+    };
+    this.on("trackReceived", wrapped);
+    return () => this.off("trackReceived", wrapped);
+  }
+}

--- a/models/echo-wm/demo/lib/echo_wm/client.ts
+++ b/models/echo-wm/demo/lib/echo_wm/client.ts
@@ -39,10 +39,6 @@ export interface EchoWmFlashSetFovParams {
   fov_degrees?: number;
 }
 
-export interface EchoWmFlashSetPausedParams {
-  paused?: boolean;
-}
-
 export interface EchoWmFlashResetParams {
   seed?: number;
 }
@@ -95,18 +91,6 @@ export interface EchoWmFlashCameraMotionChangedMessage {
   applies_to_chunk: number | null;
 }
 
-export interface EchoWmFlashPauseChangedMessage {
-  type: "pause_changed";
-  paused: boolean;
-  next_chunk: number | null;
-}
-
-export interface EchoWmFlashStepQueuedMessage {
-  type: "step_queued";
-  applies_to_chunk: number;
-  expected_video_frames: number;
-}
-
 export interface EchoWmFlashRolloutResetQueuedMessage {
   type: "rollout_reset_queued";
   seed: number;
@@ -144,8 +128,6 @@ export type EchoWmFlashMessage =
   | EchoWmFlashImageSelectedMessage
   | EchoWmFlashPromptQueuedMessage
   | EchoWmFlashCameraMotionChangedMessage
-  | EchoWmFlashPauseChangedMessage
-  | EchoWmFlashStepQueuedMessage
   | EchoWmFlashRolloutResetQueuedMessage
   | EchoWmFlashChunkCompletedMessage
   | EchoWmFlashAutomaticResetQueuedMessage;
@@ -202,14 +184,6 @@ export class EchoWmFlashModel extends Reactor {
 
   async setFov(params: EchoWmFlashSetFovParams): Promise<void> {
     await this.sendCommand("set_fov", params);
-  }
-
-  async setPaused(params: EchoWmFlashSetPausedParams): Promise<void> {
-    await this.sendCommand("set_paused", params);
-  }
-
-  async step(): Promise<void> {
-    await this.sendCommand("step", {});
   }
 
   async reset(params: EchoWmFlashResetParams): Promise<void> {

--- a/models/echo-wm/demo/lib/model.ts
+++ b/models/echo-wm/demo/lib/model.ts
@@ -1,0 +1,8 @@
+import type { EchoWmFlashStateUpdateMessage } from "./echo_wm/client";
+import type { useEchoWmFlash } from "./echo_wm/client.react";
+
+/** The typed command surface the generated hook returns. */
+export type Model = ReturnType<typeof useEchoWmFlash>;
+
+/** The model's own snapshot of everything a client can observe. */
+export type WorldState = EchoWmFlashStateUpdateMessage;

--- a/models/echo-wm/demo/next.config.ts
+++ b/models/echo-wm/demo/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/models/echo-wm/demo/package.json
+++ b/models/echo-wm/demo/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "echo-wm-demo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@reactor-team/js-sdk": "2.12.3",
+    "hls.js": "^1.6.15",
+    "next": "15.5.18",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.14",
+    "@types/node": "^20.19.19",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.1",
+    "tailwindcss": "^4.1.14",
+    "typescript": "^5.9.3"
+  }
+}

--- a/models/echo-wm/demo/pnpm-lock.yaml
+++ b/models/echo-wm/demo/pnpm-lock.yaml
@@ -1,0 +1,1395 @@
+lockfileVersion: "9.0"
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      "@reactor-team/js-sdk":
+        specifier: 2.12.3
+        version: 2.12.3(hls.js@1.7.0)(react@19.1.0)(zustand@5.0.15(@types/react@19.2.18)(react@19.1.0))
+      hls.js:
+        specifier: ^1.6.15
+        version: 1.7.0
+      next:
+        specifier: 15.5.18
+        version: 15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
+    devDependencies:
+      "@tailwindcss/postcss":
+        specifier: ^4.1.14
+        version: 4.3.3
+      "@types/node":
+        specifier: ^20.19.19
+        version: 20.19.43
+      "@types/react":
+        specifier: ^19.2.2
+        version: 19.2.18
+      "@types/react-dom":
+        specifier: ^19.2.1
+        version: 19.2.4(@types/react@19.2.18)
+      tailwindcss:
+        specifier: ^4.1.14
+        version: 4.3.3
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+  "@alloc/quick-lru@5.2.0":
+    resolution:
+      {
+        integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==,
+      }
+    engines: { node: ">=10" }
+
+  "@emnapi/runtime@1.11.3":
+    resolution:
+      {
+        integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==,
+      }
+
+  "@img/colour@1.1.0":
+    resolution:
+      {
+        integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
+      }
+    engines: { node: ">=18" }
+
+  "@img/sharp-darwin-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@img/sharp-darwin-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [darwin]
+
+  "@img/sharp-libvips-darwin-arm64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==,
+      }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@img/sharp-libvips-darwin-x64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==,
+      }
+    cpu: [x64]
+    os: [darwin]
+
+  "@img/sharp-libvips-linux-arm64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-libvips-linux-arm@1.2.4":
+    resolution:
+      {
+        integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==,
+      }
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-libvips-linux-ppc64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==,
+      }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-libvips-linux-riscv64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-libvips-linux-s390x@1.2.4":
+    resolution:
+      {
+        integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==,
+      }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-libvips-linux-x64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==,
+      }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@img/sharp-libvips-linuxmusl-x64@1.2.4":
+    resolution:
+      {
+        integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==,
+      }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@img/sharp-linux-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-linux-arm@0.34.5":
+    resolution:
+      {
+        integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-linux-ppc64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-linux-riscv64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-linux-s390x@0.34.5":
+    resolution:
+      {
+        integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-linux-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-linuxmusl-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@img/sharp-linuxmusl-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@img/sharp-wasm32@0.34.5":
+    resolution:
+      {
+        integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [wasm32]
+
+  "@img/sharp-win32-arm64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [arm64]
+    os: [win32]
+
+  "@img/sharp-win32-ia32@0.34.5":
+    resolution:
+      {
+        integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [ia32]
+    os: [win32]
+
+  "@img/sharp-win32-x64@0.34.5":
+    resolution:
+      {
+        integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    cpu: [x64]
+    os: [win32]
+
+  "@jridgewell/gen-mapping@0.3.13":
+    resolution:
+      {
+        integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==,
+      }
+
+  "@jridgewell/remapping@2.3.5":
+    resolution:
+      {
+        integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==,
+      }
+
+  "@jridgewell/resolve-uri@3.1.2":
+    resolution:
+      {
+        integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==,
+      }
+    engines: { node: ">=6.0.0" }
+
+  "@jridgewell/sourcemap-codec@1.5.5":
+    resolution:
+      {
+        integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==,
+      }
+
+  "@jridgewell/trace-mapping@0.3.31":
+    resolution:
+      {
+        integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==,
+      }
+
+  "@next/env@15.5.18":
+    resolution:
+      {
+        integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==,
+      }
+
+  "@next/swc-darwin-arm64@15.5.18":
+    resolution:
+      {
+        integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@next/swc-darwin-x64@15.5.18":
+    resolution:
+      {
+        integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@next/swc-linux-arm64-gnu@15.5.18":
+    resolution:
+      {
+        integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@next/swc-linux-arm64-musl@15.5.18":
+    resolution:
+      {
+        integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@next/swc-linux-x64-gnu@15.5.18":
+    resolution:
+      {
+        integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@next/swc-linux-x64-musl@15.5.18":
+    resolution:
+      {
+        integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@next/swc-win32-arm64-msvc@15.5.18":
+    resolution:
+      {
+        integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@next/swc-win32-x64-msvc@15.5.18":
+    resolution:
+      {
+        integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==,
+      }
+    engines: { node: ">= 10" }
+    cpu: [x64]
+    os: [win32]
+
+  "@reactor-team/js-sdk@2.12.3":
+    resolution:
+      {
+        integrity: sha512-W1wussFAlKqrBPXyqVZHLg6dkDorjRVzu8/4aKdFdZtrPSbmN7uYIwcWK73chMGu8Chp/Xgc3QC2FVbDLEj7JA==,
+      }
+    engines: { node: ">=18" }
+    peerDependencies:
+      hls.js: ^1.6.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      zustand: ^5.0.6
+    peerDependenciesMeta:
+      hls.js:
+        optional: true
+
+  "@swc/helpers@0.5.15":
+    resolution:
+      {
+        integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==,
+      }
+
+  "@tailwindcss/node@4.3.3":
+    resolution:
+      {
+        integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==,
+      }
+
+  "@tailwindcss/oxide-android-arm64@4.3.3":
+    resolution:
+      {
+        integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [arm64]
+    os: [android]
+
+  "@tailwindcss/oxide-darwin-arm64@4.3.3":
+    resolution:
+      {
+        integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@tailwindcss/oxide-darwin-x64@4.3.3":
+    resolution:
+      {
+        integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@tailwindcss/oxide-freebsd-x64@4.3.3":
+    resolution:
+      {
+        integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [x64]
+    os: [freebsd]
+
+  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3":
+    resolution:
+      {
+        integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [arm]
+    os: [linux]
+
+  "@tailwindcss/oxide-linux-arm64-gnu@4.3.3":
+    resolution:
+      {
+        integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  "@tailwindcss/oxide-linux-arm64-musl@4.3.3":
+    resolution:
+      {
+        integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  "@tailwindcss/oxide-linux-x64-gnu@4.3.3":
+    resolution:
+      {
+        integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  "@tailwindcss/oxide-linux-x64-musl@4.3.3":
+    resolution:
+      {
+        integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  "@tailwindcss/oxide-wasm32-wasi@4.3.3":
+    resolution:
+      {
+        integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==,
+      }
+    engines: { node: ">=14.0.0" }
+    cpu: [wasm32]
+    bundledDependencies:
+      - "@napi-rs/wasm-runtime"
+      - "@emnapi/core"
+      - "@emnapi/runtime"
+      - "@tybys/wasm-util"
+      - "@emnapi/wasi-threads"
+      - tslib
+
+  "@tailwindcss/oxide-win32-arm64-msvc@4.3.3":
+    resolution:
+      {
+        integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@tailwindcss/oxide-win32-x64-msvc@4.3.3":
+    resolution:
+      {
+        integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==,
+      }
+    engines: { node: ">= 20" }
+    cpu: [x64]
+    os: [win32]
+
+  "@tailwindcss/oxide@4.3.3":
+    resolution:
+      {
+        integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==,
+      }
+    engines: { node: ">= 20" }
+
+  "@tailwindcss/postcss@4.3.3":
+    resolution:
+      {
+        integrity: sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==,
+      }
+
+  "@types/node@20.19.43":
+    resolution:
+      {
+        integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==,
+      }
+
+  "@types/react-dom@19.2.4":
+    resolution:
+      {
+        integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==,
+      }
+    peerDependencies:
+      "@types/react": ^19.2.0
+
+  "@types/react@19.2.18":
+    resolution:
+      {
+        integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==,
+      }
+
+  awaitqueue@3.3.1:
+    resolution:
+      {
+        integrity: sha512-kzMN6Bdfalok/JWZvwDfI704cIyCvHDi6Ez/bApGzNPjGHQhwJ07DzGd3DDzeXH2fjr9P5g8paESFUvYnbs7rA==,
+      }
+    engines: { node: ">=22" }
+
+  caniuse-lite@1.0.30001809:
+    resolution:
+      {
+        integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==,
+      }
+
+  client-only@0.0.1:
+    resolution:
+      {
+        integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==,
+      }
+
+  csstype@3.2.3:
+    resolution:
+      {
+        integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==,
+      }
+
+  debug@4.4.3:
+    resolution:
+      {
+        integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==,
+      }
+    engines: { node: ">=6.0" }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution:
+      {
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
+      }
+    engines: { node: ">=8" }
+
+  enhanced-resolve@5.24.5:
+    resolution:
+      {
+        integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==,
+      }
+    engines: { node: ">=10.13.0" }
+
+  graceful-fs@4.2.11:
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
+      }
+
+  hls.js@1.7.0:
+    resolution:
+      {
+        integrity: sha512-NnQpT6Z//+2IB2qovSUbKbrlXY1MOpi0JynZ9L2NNOuTJiNCyMSQj9k2laEj1v7CxU/Hb8oTWR98eT3mVpPQVQ==,
+      }
+
+  jiti@2.7.0:
+    resolution:
+      {
+        integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==,
+      }
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution:
+      {
+        integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution:
+      {
+        integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution:
+      {
+        integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution:
+      {
+        integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution:
+      {
+        integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution:
+      {
+        integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+
+  magic-string@0.30.21:
+    resolution:
+      {
+        integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
+      }
+
+  mp4box@2.4.1:
+    resolution:
+      {
+        integrity: sha512-0HGX7nXoDIX6FKLVl4a3wtYjBlwqsN3xuQC3GXzNtKp98FXUOhDSq623azsz8DG5ptd9ZXcXodDkgbdMZOjWvw==,
+      }
+    engines: { node: ">=20.8.1" }
+
+  ms@2.1.3:
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+
+  nanoid@3.3.18:
+    resolution:
+      {
+        integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
+  next@15.5.18:
+    resolution:
+      {
+        integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==,
+      }
+    engines: { node: ^18.18.0 || ^19.8.0 || >= 20.0.0 }
+    hasBin: true
+    peerDependencies:
+      "@opentelemetry/api": ^1.1.0
+      "@playwright/test": ^1.51.1
+      babel-plugin-react-compiler: "*"
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      "@opentelemetry/api":
+        optional: true
+      "@playwright/test":
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  picocolors@1.1.1:
+    resolution:
+      {
+        integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
+      }
+
+  postcss@8.4.31:
+    resolution:
+      {
+        integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  postcss@8.5.26:
+    resolution:
+      {
+        integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  react-dom@19.1.0:
+    resolution:
+      {
+        integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==,
+      }
+    peerDependencies:
+      react: ^19.1.0
+
+  react@19.1.0:
+    resolution:
+      {
+        integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  scheduler@0.26.0:
+    resolution:
+      {
+        integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==,
+      }
+
+  sdp-transform@3.0.0:
+    resolution:
+      {
+        integrity: sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==,
+      }
+    hasBin: true
+
+  semver@7.8.5:
+    resolution:
+      {
+        integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution:
+      {
+        integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==,
+      }
+    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+
+  source-map-js@1.2.1:
+    resolution:
+      {
+        integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  styled-jsx@5.1.6:
+    resolution:
+      {
+        integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==,
+      }
+    engines: { node: ">= 12.0.0" }
+    peerDependencies:
+      "@babel/core": "*"
+      babel-plugin-macros: "*"
+      react: ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+    peerDependenciesMeta:
+      "@babel/core":
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tailwindcss@4.3.3:
+    resolution:
+      {
+        integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==,
+      }
+
+  tapable@2.3.3:
+    resolution:
+      {
+        integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==,
+      }
+    engines: { node: ">=6" }
+
+  tslib@2.8.1:
+    resolution:
+      {
+        integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==,
+      }
+
+  typescript@5.9.3:
+    resolution:
+      {
+        integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==,
+      }
+    engines: { node: ">=14.17" }
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution:
+      {
+        integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==,
+      }
+
+  zod@4.4.3:
+    resolution:
+      {
+        integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
+      }
+
+  zustand@5.0.15:
+    resolution:
+      {
+        integrity: sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==,
+      }
+    engines: { node: ">=12.20.0" }
+    peerDependencies:
+      "@types/react": ">=18.0.0"
+      immer: ">=9.0.6"
+      react: ">=18.0.0"
+      use-sync-external-store: ">=1.2.0"
+    peerDependenciesMeta:
+      "@types/react":
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
+snapshots:
+  "@alloc/quick-lru@5.2.0": {}
+
+  "@emnapi/runtime@1.11.3":
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  "@img/colour@1.1.0":
+    optional: true
+
+  "@img/sharp-darwin-arm64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-darwin-arm64": 1.2.4
+    optional: true
+
+  "@img/sharp-darwin-x64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-darwin-x64": 1.2.4
+    optional: true
+
+  "@img/sharp-libvips-darwin-arm64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-darwin-x64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-arm64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-arm@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-ppc64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-riscv64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-s390x@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linux-x64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
+    optional: true
+
+  "@img/sharp-libvips-linuxmusl-x64@1.2.4":
+    optional: true
+
+  "@img/sharp-linux-arm64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm64": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-arm@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-ppc64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-ppc64": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-riscv64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-riscv64": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-s390x@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-s390x": 1.2.4
+    optional: true
+
+  "@img/sharp-linux-x64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-x64": 1.2.4
+    optional: true
+
+  "@img/sharp-linuxmusl-arm64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
+    optional: true
+
+  "@img/sharp-linuxmusl-x64@0.34.5":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-x64": 1.2.4
+    optional: true
+
+  "@img/sharp-wasm32@0.34.5":
+    dependencies:
+      "@emnapi/runtime": 1.11.3
+    optional: true
+
+  "@img/sharp-win32-arm64@0.34.5":
+    optional: true
+
+  "@img/sharp-win32-ia32@0.34.5":
+    optional: true
+
+  "@img/sharp-win32-x64@0.34.5":
+    optional: true
+
+  "@jridgewell/gen-mapping@0.3.13":
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.5
+      "@jridgewell/trace-mapping": 0.3.31
+
+  "@jridgewell/remapping@2.3.5":
+    dependencies:
+      "@jridgewell/gen-mapping": 0.3.13
+      "@jridgewell/trace-mapping": 0.3.31
+
+  "@jridgewell/resolve-uri@3.1.2": {}
+
+  "@jridgewell/sourcemap-codec@1.5.5": {}
+
+  "@jridgewell/trace-mapping@0.3.31":
+    dependencies:
+      "@jridgewell/resolve-uri": 3.1.2
+      "@jridgewell/sourcemap-codec": 1.5.5
+
+  "@next/env@15.5.18": {}
+
+  "@next/swc-darwin-arm64@15.5.18":
+    optional: true
+
+  "@next/swc-darwin-x64@15.5.18":
+    optional: true
+
+  "@next/swc-linux-arm64-gnu@15.5.18":
+    optional: true
+
+  "@next/swc-linux-arm64-musl@15.5.18":
+    optional: true
+
+  "@next/swc-linux-x64-gnu@15.5.18":
+    optional: true
+
+  "@next/swc-linux-x64-musl@15.5.18":
+    optional: true
+
+  "@next/swc-win32-arm64-msvc@15.5.18":
+    optional: true
+
+  "@next/swc-win32-x64-msvc@15.5.18":
+    optional: true
+
+  "@reactor-team/js-sdk@2.12.3(hls.js@1.7.0)(react@19.1.0)(zustand@5.0.15(@types/react@19.2.18)(react@19.1.0))":
+    dependencies:
+      awaitqueue: 3.3.1
+      mp4box: 2.4.1
+      react: 19.1.0
+      sdp-transform: 3.0.0
+      zod: 4.4.3
+      zustand: 5.0.15(@types/react@19.2.18)(react@19.1.0)
+    optionalDependencies:
+      hls.js: 1.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@swc/helpers@0.5.15":
+    dependencies:
+      tslib: 2.8.1
+
+  "@tailwindcss/node@4.3.3":
+    dependencies:
+      "@jridgewell/remapping": 2.3.5
+      enhanced-resolve: 5.24.5
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  "@tailwindcss/oxide-android-arm64@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-darwin-arm64@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-darwin-x64@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-freebsd-x64@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-linux-arm64-gnu@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-linux-arm64-musl@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-linux-x64-gnu@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-linux-x64-musl@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-wasm32-wasi@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-win32-arm64-msvc@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide-win32-x64-msvc@4.3.3":
+    optional: true
+
+  "@tailwindcss/oxide@4.3.3":
+    optionalDependencies:
+      "@tailwindcss/oxide-android-arm64": 4.3.3
+      "@tailwindcss/oxide-darwin-arm64": 4.3.3
+      "@tailwindcss/oxide-darwin-x64": 4.3.3
+      "@tailwindcss/oxide-freebsd-x64": 4.3.3
+      "@tailwindcss/oxide-linux-arm-gnueabihf": 4.3.3
+      "@tailwindcss/oxide-linux-arm64-gnu": 4.3.3
+      "@tailwindcss/oxide-linux-arm64-musl": 4.3.3
+      "@tailwindcss/oxide-linux-x64-gnu": 4.3.3
+      "@tailwindcss/oxide-linux-x64-musl": 4.3.3
+      "@tailwindcss/oxide-wasm32-wasi": 4.3.3
+      "@tailwindcss/oxide-win32-arm64-msvc": 4.3.3
+      "@tailwindcss/oxide-win32-x64-msvc": 4.3.3
+
+  "@tailwindcss/postcss@4.3.3":
+    dependencies:
+      "@alloc/quick-lru": 5.2.0
+      "@tailwindcss/node": 4.3.3
+      "@tailwindcss/oxide": 4.3.3
+      postcss: 8.5.26
+      tailwindcss: 4.3.3
+
+  "@types/node@20.19.43":
+    dependencies:
+      undici-types: 6.21.0
+
+  "@types/react-dom@19.2.4(@types/react@19.2.18)":
+    dependencies:
+      "@types/react": 19.2.18
+
+  "@types/react@19.2.18":
+    dependencies:
+      csstype: 3.2.3
+
+  awaitqueue@3.3.1:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  caniuse-lite@1.0.30001809: {}
+
+  client-only@0.0.1: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  enhanced-resolve@5.24.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  graceful-fs@4.2.11: {}
+
+  hls.js@1.7.0: {}
+
+  jiti@2.7.0: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      "@jridgewell/sourcemap-codec": 1.5.5
+
+  mp4box@2.4.1: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.18: {}
+
+  next@15.5.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      "@next/env": 15.5.18
+      "@swc/helpers": 0.5.15
+      caniuse-lite: 1.0.30001809
+      postcss: 8.4.31
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      styled-jsx: 5.1.6(react@19.1.0)
+    optionalDependencies:
+      "@next/swc-darwin-arm64": 15.5.18
+      "@next/swc-darwin-x64": 15.5.18
+      "@next/swc-linux-arm64-gnu": 15.5.18
+      "@next/swc-linux-arm64-musl": 15.5.18
+      "@next/swc-linux-x64-gnu": 15.5.18
+      "@next/swc-linux-x64-musl": 15.5.18
+      "@next/swc-win32-arm64-msvc": 15.5.18
+      "@next/swc-win32-x64-msvc": 15.5.18
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - "@babel/core"
+      - babel-plugin-macros
+
+  picocolors@1.1.1: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.1.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.26.0
+
+  react@19.1.0: {}
+
+  scheduler@0.26.0: {}
+
+  sdp-transform@3.0.0: {}
+
+  semver@7.8.5:
+    optional: true
+
+  sharp@0.34.5:
+    dependencies:
+      "@img/colour": 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      "@img/sharp-darwin-arm64": 0.34.5
+      "@img/sharp-darwin-x64": 0.34.5
+      "@img/sharp-libvips-darwin-arm64": 1.2.4
+      "@img/sharp-libvips-darwin-x64": 1.2.4
+      "@img/sharp-libvips-linux-arm": 1.2.4
+      "@img/sharp-libvips-linux-arm64": 1.2.4
+      "@img/sharp-libvips-linux-ppc64": 1.2.4
+      "@img/sharp-libvips-linux-riscv64": 1.2.4
+      "@img/sharp-libvips-linux-s390x": 1.2.4
+      "@img/sharp-libvips-linux-x64": 1.2.4
+      "@img/sharp-libvips-linuxmusl-arm64": 1.2.4
+      "@img/sharp-libvips-linuxmusl-x64": 1.2.4
+      "@img/sharp-linux-arm": 0.34.5
+      "@img/sharp-linux-arm64": 0.34.5
+      "@img/sharp-linux-ppc64": 0.34.5
+      "@img/sharp-linux-riscv64": 0.34.5
+      "@img/sharp-linux-s390x": 0.34.5
+      "@img/sharp-linux-x64": 0.34.5
+      "@img/sharp-linuxmusl-arm64": 0.34.5
+      "@img/sharp-linuxmusl-x64": 0.34.5
+      "@img/sharp-wasm32": 0.34.5
+      "@img/sharp-win32-arm64": 0.34.5
+      "@img/sharp-win32-ia32": 0.34.5
+      "@img/sharp-win32-x64": 0.34.5
+    optional: true
+
+  source-map-js@1.2.1: {}
+
+  styled-jsx@5.1.6(react@19.1.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.1.0
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  zod@4.4.3: {}
+
+  zustand@5.0.15(@types/react@19.2.18)(react@19.1.0):
+    optionalDependencies:
+      "@types/react": 19.2.18
+      react: 19.1.0

--- a/models/echo-wm/demo/pnpm-workspace.yaml
+++ b/models/echo-wm/demo/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+# This app installs on its own, so it can be copied out of the example and run
+# anywhere without inheriting a parent workspace.
+packages: []
+
+# `sharp` builds native image-optimisation binaries for Next.js. This app has no
+# images to optimise, so the build is declined rather than approved.
+allowBuilds:
+  sharp: false

--- a/models/echo-wm/demo/postcss.config.mjs
+++ b/models/echo-wm/demo/postcss.config.mjs
@@ -1,0 +1,5 @@
+const config = {
+  plugins: ["@tailwindcss/postcss"],
+};
+
+export default config;

--- a/models/echo-wm/demo/tsconfig.json
+++ b/models/echo-wm/demo/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/models/echo-wm/echo_wm.py
+++ b/models/echo-wm/echo_wm.py
@@ -152,7 +152,7 @@ class EchoWM(ReactorPipeline):
 
     @session_started
     def on_session_started(self) -> None:
-        """Initialize an empty paused world before the first viewer connects."""
+        """Initialize an empty continuous world before the first viewer connects."""
         config = self._require_loaded()
         self.state.prompt = ""
         self.state.paused = False
@@ -197,9 +197,9 @@ class EchoWM(ReactorPipeline):
     @event(
         name="set_image",
         description=(
-            "Select an uploaded first frame and queue a fresh audiovisual world. The command "
-            "preserves paused mode and queues two preview chunks while paused. Supply a prompt "
-            "or leave it blank to use the configured image-neutral default. Emits "
+            "Select an uploaded first frame and start a fresh audiovisual world with continuous "
+            "generation. Supply a prompt or leave it blank to use the configured image-neutral "
+            "default. Emits "
             "`image_selected` and broadcasts `state_update` on success, or `command_error` "
             "when the upload is invalid."
         ),
@@ -253,8 +253,8 @@ class EchoWM(ReactorPipeline):
         name="random_image",
         description=(
             "Select a different public Echo-WM example with its matching prompt, field of "
-            "view, and seed. The command preserves paused mode and queues two preview chunks "
-            "while paused. Emits `image_selected` and broadcasts `state_update` on success, "
+            "view, and seed, then start continuous generation from it. Emits `image_selected` "
+            "and broadcasts `state_update` on success, "
             "or `command_error` when no example is configured."
         ),
     )
@@ -291,8 +291,8 @@ class EchoWM(ReactorPipeline):
         name="set_prompt",
         description=(
             "Replace the text condition and queue a fresh rollout from the selected image. "
-            "The new prompt begins at chunk one; paused mode is preserved and one preview "
-            "chunk is queued while paused. Emits `prompt_queued` and broadcasts "
+            "The new prompt begins at chunk one and continuous generation resumes from the "
+            "fresh world. Emits `prompt_queued` and broadcasts "
             "`state_update` on success, or `command_error` before image selection or for empty "
             "text."
         ),
@@ -407,15 +407,7 @@ class EchoWM(ReactorPipeline):
         await self.send(self._state_update())
         return message
 
-    @event(
-        name="set_paused",
-        description=(
-            "Pause before the next chunk or resume continuous generation. The command releases "
-            "held camera motion and cancels a queued step without changing the selected image. "
-            "Emits `pause_changed` and broadcasts `state_update` on success, or "
-            "`command_error` when resuming before image selection."
-        ),
-    )
+    # Pause remains an internal control and is excluded from the public schema.
     async def set_paused(
         self,
         paused: bool = InputField(
@@ -433,15 +425,7 @@ class EchoWM(ReactorPipeline):
         await self.send(self._state_update())
         return message
 
-    @event(
-        name="step",
-        description=(
-            "Queue exactly one native synchronized audio-video chunk without leaving paused "
-            "mode. Requires a selected image and `paused=true`. Emits `step_queued` and "
-            "broadcasts `state_update` on success, or `command_error` when either precondition "
-            "is unmet."
-        ),
-    )
+    # Single-step generation remains internal and is excluded from the public schema.
     async def step(self) -> StepQueued:
         """Queue one paused causal block and report its rollout position."""
         self._require_selected()
@@ -462,9 +446,9 @@ class EchoWM(ReactorPipeline):
         name="reset",
         description=(
             "Queue a fresh bounded rollout from the selected image and current prompt. The "
-            "command preserves paused mode, releases camera motion, and queues one preview "
-            "chunk while paused. Emits `rollout_reset_queued` and broadcasts `state_update` on "
-            "success, or `command_error` before image selection."
+            "command releases camera motion and continues generation from chunk one. Emits "
+            "`rollout_reset_queued` and broadcasts `state_update` on success, or "
+            "`command_error` before image selection."
         ),
     )
     async def reset(

--- a/models/echo-wm/echo_wm.py
+++ b/models/echo-wm/echo_wm.py
@@ -1,0 +1,729 @@
+"""Serve one native Echo-WM Flash audio-video block per Reactor turn."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Literal, Protocol, cast
+
+import numpy as np
+from reactor_runtime import (
+    ClientInfo,
+    CommandError,
+    Idle,
+    InputField,
+    OutputStream,
+    ReactorPipeline,
+    UploadedFile,
+    connected,
+    disconnected,
+    event,
+    session_ended,
+    session_started,
+)
+from reactor_runtime.log import get_logger
+
+from echo_wm_assets import (
+    EchoWMConfig,
+    ExampleScene,
+    activate_source,
+    configure_cache_environment,
+    load_examples,
+    prepare_assets,
+    read_config,
+)
+from echo_wm_camera import CameraChunk, EchoCameraPlanner, MotionConfig
+from echo_wm_images import materialized_image, validate_uploaded_image
+from echo_wm_schema import (
+    AutomaticResetQueued,
+    CameraMotionChanged,
+    ChunkCompleted,
+    EchoWMOutput,
+    EchoWMState,
+    ImageSelected,
+    PauseChanged,
+    PromptQueued,
+    RolloutResetQueued,
+    StateUpdate,
+    StepQueued,
+)
+
+logger = get_logger(__name__)
+
+
+class _Backend(Protocol):
+    """Define the blocking upstream operations used by the Reactor loop."""
+
+    def reset(self, *, image: Path, prompt: str, seed: int, fov_degrees: float) -> None:
+        """Start a fresh bounded causal rollout."""
+
+    def generate_chunk(
+        self,
+        camera: CameraChunk,
+        *,
+        fov_degrees: float,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Generate one native synchronized audio-video block."""
+
+    @property
+    def last_profile(self) -> dict[str, float]:
+        """Return CUDA stage timings for the latest chunk."""
+
+    def end_session(self, *, release_cuda_cache: bool = True) -> None:
+        """Release rollout state while retaining model weights."""
+
+
+class EchoWM(ReactorPipeline):
+    """Generate a prompt-, image-, and pure-camera-controlled audiovisual world."""
+
+    state: EchoWMState
+    output: EchoWMOutput
+    # Keep the generated 48 kHz audio aligned with Echo-WM's native video time.
+    fps = 24
+    buffer_size = 24
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config: EchoWMConfig | None = None
+        self._backend: _Backend | None = None
+        self._planner: EchoCameraPlanner | None = None
+        self._examples: tuple[ExampleScene, ...] = ()
+        self._selected_image: Path | UploadedFile | None = None
+        self._image_source: Literal["uploaded", "built_in"] | None = None
+        self._image_name: str | None = None
+        self._active_prompt: str | None = None
+        self._seed = 0
+        self._chunk_index = 0
+        self._generating = False
+
+    def load(self, config_path: Path | None) -> None:
+        """Prepare public assets and load Echo-WM weights once at startup.
+
+        Args:
+            config_path: Path to ``echo_wm.yaml`` from ``reactor.yaml``.
+        """
+        config = read_config(config_path)
+        configure_cache_environment(config)
+        prepare_assets(config)
+        activate_source(config)
+        from echo_wm_backend import EchoWMBackend
+
+        self._config = config
+        self._examples = load_examples(config)
+        self._seed = config.seed
+        self._planner = EchoCameraPlanner(
+            MotionConfig(
+                fps=config.fps,
+                translation_speed=config.translation_speed,
+                rotation_speed_degrees=config.rotation_speed_degrees,
+                pitch_speed_degrees=config.pitch_speed_degrees,
+                pitch_limit_degrees=config.pitch_limit_degrees,
+            )
+        )
+        backend = EchoWMBackend(config)
+        self._backend = backend
+        benchmark = backend.attention_benchmark
+        if benchmark is not None:
+            logger.info(
+                "Echo-WM attention verification complete",
+                pytorch_milliseconds=round(benchmark.pytorch_milliseconds, 4),
+                flash_attention_4_milliseconds=round(
+                    benchmark.flash_attention_4_milliseconds, 4
+                ),
+                speedup=round(benchmark.speedup, 3),
+                max_absolute_error=round(benchmark.max_absolute_error, 6),
+                mean_absolute_error=round(benchmark.mean_absolute_error, 6),
+                normalized_root_mean_square_error=round(
+                    benchmark.normalized_root_mean_square_error, 6
+                ),
+            )
+        self._warmup()
+        logger.info(
+            "Echo-WM Flash ready",
+            source_revision=config.source_revision,
+            checkpoint_revision=config.checkpoint.revision,
+            frames_per_chunk=config.frames_per_chunk,
+            max_chunks=config.max_chunks,
+            attention_backend=config.attention_backend,
+            attention_modules=backend.attention_modules,
+        )
+
+    @session_started
+    def on_session_started(self) -> None:
+        """Initialize an empty paused world before the first viewer connects."""
+        config = self._require_loaded()
+        self.state.prompt = ""
+        self.state.paused = False
+        self.state._queued_steps = 0
+        self.state._reset_requested = False
+        self.state._fov_degrees = config.fov_degrees
+        self._clear_camera()
+        self._selected_image = None
+        self._image_source = None
+        self._image_name = None
+        self._active_prompt = None
+        self._seed = config.seed
+        self._chunk_index = 0
+        self._generating = False
+
+    @session_ended
+    def on_session_ended(self) -> None:
+        """Release causal state when the shared session ends."""
+        self._clear_camera()
+        self.state._queued_steps = 0
+        self.state._reset_requested = False
+        self._selected_image = None
+        self._image_source = None
+        self._image_name = None
+        self._active_prompt = None
+        self._chunk_index = 0
+        self._generating = False
+        if self._backend is not None:
+            self._backend.end_session()
+
+    @connected
+    async def on_connected(self, client: ClientInfo) -> None:
+        """Send the complete shared world state to one joining viewer."""
+        await client.send(self._state_update())
+
+    @disconnected
+    async def on_disconnected(self) -> None:
+        """Release held camera motion when a viewer disconnects."""
+        self._clear_camera()
+        await self.send(self._state_update())
+
+    @event(
+        name="set_image",
+        description=(
+            "Select an uploaded first frame and queue a fresh audiovisual world. The command "
+            "preserves paused mode and queues two preview chunks while paused. Supply a prompt "
+            "or leave it blank to use the configured image-neutral default. Emits "
+            "`image_selected` and broadcasts `state_update` on success, or `command_error` "
+            "when the upload is invalid."
+        ),
+    )
+    async def set_image(
+        self,
+        image: UploadedFile = InputField(  # noqa: B008 - schema field declaration
+            description=(
+                "JPEG, PNG, WebP, or BMP first frame, up to 25 MiB and 100 million pixels."
+            )
+        ),
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            description=(
+                "Scene, motion, sound, music, and speech description. An empty value uses the "
+                "configured image-neutral default for the new scene."
+            ),
+        ),
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description="Fresh-rollout seed, or -1 to retain the active seed.",
+        ),
+    ) -> ImageSelected:
+        """Validate an upload and select it as the next world anchor."""
+        validate_uploaded_image(image)
+        config = self._require_loaded()
+        normalized = prompt.strip() or config.default_upload_prompt
+        if seed >= 0:
+            self._seed = seed
+        self._selected_image = image
+        self._image_source = "uploaded"
+        self._image_name = image.name
+        self.state.prompt = normalized
+        self._request_reset(preview_steps=2)
+        preview_chunks = 2 if self.state.paused else 0
+        message = ImageSelected(
+            source="uploaded",
+            filename=image.name,
+            prompt=normalized,
+            seed=self._seed,
+            first_chunk_queued=preview_chunks > 0,
+            preview_chunks_queued=preview_chunks,
+        )
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="random_image",
+        description=(
+            "Select a different public Echo-WM example with its matching prompt, field of "
+            "view, and seed. The command preserves paused mode and queues two preview chunks "
+            "while paused. Emits `image_selected` and broadcasts `state_update` on success, "
+            "or `command_error` when no example is configured."
+        ),
+    )
+    async def random_image(self) -> ImageSelected:
+        """Select a different upstream example when possible."""
+        if not self._examples:
+            raise CommandError(
+                "image_unavailable", "No Echo-WM examples are configured."
+            )
+        candidates = [
+            scene for scene in self._examples if scene.image != self._selected_image
+        ]
+        scene = secrets.choice(candidates or list(self._examples))
+        self._selected_image = scene.image
+        self._image_source = "built_in"
+        self._image_name = scene.image.name
+        self.state.prompt = scene.prompt
+        self.state._fov_degrees = scene.fov_degrees
+        self._seed = scene.seed
+        self._request_reset(preview_steps=2)
+        preview_chunks = 2 if self.state.paused else 0
+        message = ImageSelected(
+            source="built_in",
+            filename=scene.image.name,
+            prompt=scene.prompt,
+            seed=scene.seed,
+            first_chunk_queued=preview_chunks > 0,
+            preview_chunks_queued=preview_chunks,
+        )
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="set_prompt",
+        description=(
+            "Replace the text condition and queue a fresh rollout from the selected image. "
+            "The new prompt begins at chunk one; paused mode is preserved and one preview "
+            "chunk is queued while paused. Emits `prompt_queued` and broadcasts "
+            "`state_update` on success, or `command_error` before image selection or for empty "
+            "text."
+        ),
+    )
+    async def set_prompt(
+        self,
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            description=(
+                "Non-empty scene, character, perspective, sound, music, and speech description."
+            ),
+        ),
+    ) -> PromptQueued:
+        """Queue a prompt-conditioned fresh rollout from the selected image."""
+        self._require_selected()
+        normalized = prompt.strip()
+        if not normalized:
+            raise CommandError(
+                "prompt_required", "Echo-WM requires a non-empty prompt."
+            )
+        self.state.prompt = normalized
+        self._request_reset(preview_steps=1)
+        message = PromptQueued(prompt=normalized, applies_to_chunk=1)
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="set_camera_motion",
+        description=(
+            "Set Echo-WM's four native held camera axes atomically. Values are sampled at the "
+            "next chunk boundary and remain active until changed or released. Emits "
+            "`camera_motion_changed` and broadcasts `state_update` on success, or "
+            "`command_error` before image selection."
+        ),
+    )
+    async def set_camera_motion(
+        self,
+        forward: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description="Backward (-1) to forward (1); zero is neutral.",
+        ),
+        strafe: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description="Left (-1) to right (1); zero is neutral.",
+        ),
+        pitch: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description="Look down (-1) to up (1); zero is neutral.",
+        ),
+        yaw: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description="Turn left (-1) to right (1); zero is neutral.",
+        ),
+    ) -> CameraMotionChanged:
+        """Set every native camera axis and report the complete held state."""
+        self._require_selected()
+        self.state._forward = forward
+        self.state._strafe = strafe
+        self.state._pitch = pitch
+        self.state._yaw = yaw
+        message = self._camera_changed()
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="release_camera",
+        description=(
+            "Return every held camera axis to neutral for forthcoming chunks. Emits "
+            "`camera_motion_changed` and broadcasts `state_update` on success, or "
+            "`command_error` before image selection."
+        ),
+    )
+    async def release_camera(self) -> CameraMotionChanged:
+        """Release native camera motion and report neutral state."""
+        self._require_selected()
+        self._clear_camera()
+        message = self._camera_changed()
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="set_fov",
+        description=(
+            "Set the horizontal camera field of view for forthcoming chunks. The value is "
+            "sampled at the next chunk boundary and remains active. Emits "
+            "`camera_motion_changed` and broadcasts `state_update` on success, or "
+            "`command_error` before image selection."
+        ),
+    )
+    async def set_fov(
+        self,
+        fov_degrees: float = InputField(
+            default=70.0,
+            ge=30.0,
+            le=120.0,
+            description="Horizontal field of view in degrees from 30 through 120.",
+        ),
+    ) -> CameraMotionChanged:
+        """Set and report the held camera field of view."""
+        self._require_selected()
+        self.state._fov_degrees = fov_degrees
+        message = self._camera_changed()
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="set_paused",
+        description=(
+            "Pause before the next chunk or resume continuous generation. The command releases "
+            "held camera motion and cancels a queued step without changing the selected image. "
+            "Emits `pause_changed` and broadcasts `state_update` on success, or "
+            "`command_error` when resuming before image selection."
+        ),
+    )
+    async def set_paused(
+        self,
+        paused: bool = InputField(
+            default=False,
+            description="True pauses before the next chunk; false resumes generation.",
+        ),
+    ) -> PauseChanged:
+        """Set playback state and release camera motion."""
+        if not paused:
+            self._require_selected()
+        self.state.paused = paused
+        self.state._queued_steps = 0
+        self._clear_camera()
+        message = PauseChanged(paused=paused, next_chunk=self._next_chunk())
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="step",
+        description=(
+            "Queue exactly one native synchronized audio-video chunk without leaving paused "
+            "mode. Requires a selected image and `paused=true`. Emits `step_queued` and "
+            "broadcasts `state_update` on success, or `command_error` when either precondition "
+            "is unmet."
+        ),
+    )
+    async def step(self) -> StepQueued:
+        """Queue one paused causal block and report its rollout position."""
+        self._require_selected()
+        if not self.state.paused:
+            raise CommandError("pause_required", "Pause Echo-WM before stepping.")
+        next_chunk = self._next_unqueued_chunk()
+        if next_chunk is None:
+            raise RuntimeError("Echo-WM selected image has no available next chunk")
+        self.state._queued_steps += 1
+        message = StepQueued(
+            applies_to_chunk=next_chunk,
+            expected_video_frames=25 if next_chunk == 1 else 24,
+        )
+        await self.send(self._state_update())
+        return message
+
+    @event(
+        name="reset",
+        description=(
+            "Queue a fresh bounded rollout from the selected image and current prompt. The "
+            "command preserves paused mode, releases camera motion, and queues one preview "
+            "chunk while paused. Emits `rollout_reset_queued` and broadcasts `state_update` on "
+            "success, or `command_error` before image selection."
+        ),
+    )
+    async def reset(
+        self,
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description="Fresh-rollout seed, or -1 to retain the active seed.",
+        ),
+    ) -> RolloutResetQueued:
+        """Queue a fresh rollout and report the state it replaces."""
+        self._require_selected()
+        if seed >= 0:
+            self._seed = seed
+        replaced = self._chunk_index
+        self._request_reset(preview_steps=1)
+        message = RolloutResetQueued(
+            seed=self._seed,
+            replaced_chunks=replaced,
+            first_chunk_queued=self.state.paused,
+        )
+        await self.send(self._state_update())
+        return message
+
+    async def inference(self) -> AsyncGenerator[EchoWMOutput | object, None]:
+        """Generate and emit one native causal audio-video block per turn."""
+        config = self._require_loaded()
+        backend = self._backend
+        planner = self._planner
+        if backend is None or planner is None:
+            raise RuntimeError("Echo-WM was not loaded")
+
+        while True:
+            if self.state._reset_requested:
+                selected = self._selected_image
+                if selected is None:
+                    yield Idle
+                    continue
+                prompt = self.state.prompt.strip()
+                if not prompt:
+                    raise RuntimeError("Echo-WM requires a prompt before reset")
+                self.state._reset_requested = False
+                self._generating = True
+                await self.send(self._state_update())
+                try:
+                    with materialized_image(selected, config.runtime_dir) as image:
+                        backend.reset(
+                            image=image,
+                            prompt=prompt,
+                            seed=self._seed,
+                            fov_degrees=self.state._fov_degrees,
+                        )
+                finally:
+                    self._generating = False
+                planner.reset()
+                self._chunk_index = 0
+                self._active_prompt = prompt
+                await self.send(self._state_update())
+
+            if self._selected_image is None:
+                yield Idle
+                continue
+            if self.state.paused and self.state._queued_steps == 0:
+                yield Idle
+                continue
+
+            if self.state._queued_steps > 0:
+                self.state._queued_steps -= 1
+            sampled_prompt = self._active_prompt
+            if sampled_prompt is None:
+                raise RuntimeError("Echo-WM rollout has no active prompt")
+            sampled_controls = {
+                "forward": self.state._forward,
+                "strafe": self.state._strafe,
+                "pitch": self.state._pitch,
+                "yaw": self.state._yaw,
+            }
+            sampled_fov = self.state._fov_degrees
+            camera = planner.plan_chunk(
+                **sampled_controls,
+                frame_count=config.frames_per_chunk,
+            )
+            self._generating = True
+            await self.send(self._state_update())
+            started = time.perf_counter()
+            try:
+                video, audio = backend.generate_chunk(
+                    camera,
+                    fov_degrees=sampled_fov,
+                )
+            finally:
+                self._generating = False
+            seconds = time.perf_counter() - started
+            profile = backend.last_profile
+            self._chunk_index += 1
+            logger.info(
+                "Echo-WM chunk complete",
+                chunk=self._chunk_index,
+                generation_seconds=round(seconds, 3),
+                **{name: round(value, 4) for name, value in profile.items()},
+            )
+            await self.send(
+                ChunkCompleted(
+                    chunk=self._chunk_index,
+                    video_frames=int(video.shape[0]),
+                    audio_samples=int(audio.shape[-1]),
+                    generation_seconds=round(seconds, 3),
+                    denoise_seconds=_profile_value(profile, "denoise_seconds"),
+                    cache_commit_seconds=_profile_value(
+                        profile, "cache_commit_seconds"
+                    ),
+                    video_decode_seconds=_profile_value(
+                        profile, "video_decode_seconds"
+                    ),
+                    audio_decode_seconds=_profile_value(
+                        profile, "audio_decode_seconds"
+                    ),
+                    cuda_total_seconds=_profile_value(profile, "cuda_total_seconds"),
+                    prompt=sampled_prompt,
+                    **sampled_controls,
+                )
+            )
+            if self._chunk_index >= config.max_chunks:
+                self.state._reset_requested = True
+                await self.send(
+                    AutomaticResetQueued(
+                        completed_chunks=self._chunk_index,
+                        max_chunks=config.max_chunks,
+                        seed=self._seed,
+                    )
+                )
+            await self.send(self._state_update())
+            yield EchoWMOutput(main_video=video, main_audio=audio)
+
+    def _warmup(self) -> None:
+        """Generate configured throwaway chunks before accepting a session."""
+        config = self._require_loaded()
+        backend = self._backend
+        planner = self._planner
+        if config.warmup_chunks == 0:
+            return
+        if backend is None or planner is None or not self._examples:
+            raise RuntimeError(
+                "Echo-WM warmup requires a backend, planner, and example"
+            )
+        scene = self._examples[0]
+        started = time.perf_counter()
+        logger.info("Echo-WM warming up", chunks=config.warmup_chunks)
+        try:
+            backend.reset(
+                image=scene.image,
+                prompt=scene.prompt,
+                seed=scene.seed,
+                fov_degrees=scene.fov_degrees,
+            )
+            planner.reset()
+            for _ in range(config.warmup_chunks):
+                camera = planner.plan_chunk(
+                    forward=0.0,
+                    strafe=0.0,
+                    pitch=0.0,
+                    yaw=0.0,
+                    frame_count=config.frames_per_chunk,
+                )
+                backend.generate_chunk(camera, fov_degrees=scene.fov_degrees)
+        finally:
+            backend.end_session(release_cuda_cache=False)
+            planner.reset()
+        logger.info(
+            "Echo-WM warmup complete",
+            chunks=config.warmup_chunks,
+            seconds=round(time.perf_counter() - started, 3),
+        )
+
+    def _request_reset(self, *, preview_steps: int) -> None:
+        """Queue a clean rollout and clear prior playout, controls, and progress."""
+        if preview_steps < 0:
+            raise ValueError("preview_steps must be zero or more")
+        cast(OutputStream, self.output).flush()
+        self._clear_camera()
+        self.state._queued_steps = preview_steps if self.state.paused else 0
+        self.state._reset_requested = True
+        self._chunk_index = 0
+
+    def _clear_camera(self) -> None:
+        """Return every native camera axis to neutral."""
+        self.state._forward = 0.0
+        self.state._strafe = 0.0
+        self.state._pitch = 0.0
+        self.state._yaw = 0.0
+
+    def _camera_changed(self) -> CameraMotionChanged:
+        """Return the complete held camera state after a mutation."""
+        return CameraMotionChanged(
+            forward=self.state._forward,
+            strafe=self.state._strafe,
+            pitch=self.state._pitch,
+            yaw=self.state._yaw,
+            fov_degrees=self.state._fov_degrees,
+            applies_to_chunk=self._next_chunk(),
+        )
+
+    def _require_loaded(self) -> EchoWMConfig:
+        """Return startup configuration or fail before model load completes."""
+        if self._config is None:
+            raise RuntimeError("Echo-WM was not loaded")
+        return self._config
+
+    def _require_selected(self) -> None:
+        """Reject commands that need a first-frame image before one is selected."""
+        if self._selected_image is None:
+            raise CommandError(
+                "image_required",
+                "Upload an image or select a random image before this command.",
+            )
+
+    def _next_chunk(self) -> int | None:
+        """Return the one-based chunk expected to consume newly accepted input."""
+        if self._selected_image is None:
+            return None
+        if self.state._reset_requested:
+            return 1
+        return self._chunk_index + 1 + int(self._generating)
+
+    def _next_unqueued_chunk(self) -> int | None:
+        """Return the chunk claimed by one additional paused step."""
+        if self._selected_image is None:
+            return None
+        if self.state._reset_requested:
+            return self.state._queued_steps + 1
+        return self._chunk_index + int(self._generating) + self.state._queued_steps + 1
+
+    def _state_update(self) -> StateUpdate:
+        """Return a complete client-visible snapshot of the shared world."""
+        config = self._config
+        return StateUpdate(
+            image_source=self._image_source,
+            image_name=self._image_name,
+            prompt=self.state.prompt or None,
+            active_prompt=self._active_prompt,
+            seed=self._seed,
+            paused=self.state.paused,
+            step_queued=self.state._queued_steps > 0,
+            queued_steps=self.state._queued_steps,
+            reset_queued=self.state._reset_requested,
+            generating=self._generating,
+            completed_chunks=self._chunk_index,
+            next_chunk=self._next_chunk(),
+            max_chunks=config.max_chunks if config is not None else 0,
+            forward=self.state._forward,
+            strafe=self.state._strafe,
+            pitch=self.state._pitch,
+            yaw=self.state._yaw,
+            fov_degrees=self.state._fov_degrees,
+        )
+
+
+def _profile_value(profile: dict[str, float], name: str) -> float | None:
+    """Return a rounded CUDA timing when profiling is enabled."""
+    value = profile.get(name)
+    return round(value, 4) if value is not None else None

--- a/models/echo-wm/echo_wm.yaml
+++ b/models/echo-wm/echo_wm.yaml
@@ -1,0 +1,47 @@
+source:
+  path: source/JoyAI-Echo
+  url: https://github.com/jd-opensource/JoyAI-Echo.git
+  revision: c7963031c4425a154a791a46606d3247b2201c2b
+
+assets:
+  cache_dir: cache/huggingface
+  checkpoint:
+    path: weights/echo-wm/echo-wm-flash.safetensors
+    repo_id: Echo-Team/Echo-WM
+    revision: 5f18c27bcc6e9395c120c055c92e294674e7ea91
+    filename: echo-wm-flash.safetensors
+  gemma:
+    path: weights/gemma-3-12b-it-qat-q4_0-unquantized
+    repo_id: google/gemma-3-12b-it-qat-q4_0-unquantized
+    revision: 68f7ee4fbd59087436ada77ed2d62f373fdd4482
+  runtime_dir: runtime
+
+inference:
+  width: 1280
+  height: 704
+  fps: 24
+  seed: 42
+  default_upload_prompt: >-
+    The scene continues naturally from the input image with coherent motion,
+    stable visual details, and matching ambient sound.
+  timesteps: [1000, 750, 500, 250]
+  video_local_attn_size: 19
+  video_sink_size: 7
+  video_chunk_size: 3
+  max_chunks: 512
+  video_decode_context_latents: 7
+  video_decode_tiling: false
+  attention_backend: flash_attention_4
+  attention_benchmark: true
+  warmup_chunks: 1
+  profile_cuda: true
+
+motion:
+  translation_speed: 0.05
+  rotation_speed_degrees: 0.4
+  pitch_speed_degrees: 0.2
+  pitch_limit_degrees: 40.0
+  fov_degrees: 70.0
+
+examples:
+  cases: ["0081", "0104", "0170"]

--- a/models/echo-wm/echo_wm_assets.py
+++ b/models/echo-wm/echo_wm_assets.py
@@ -1,0 +1,325 @@
+"""Resolve Echo-WM source, model assets, configuration, and built-in scenes."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from reactor_runtime import get_weights_path
+
+
+@dataclass(frozen=True)
+class ModelAsset:
+    """Describe one Hugging Face asset pinned to an immutable revision."""
+
+    path: Path
+    repo_id: str
+    revision: str
+    filename: str | None = None
+
+
+@dataclass(frozen=True)
+class ExampleScene:
+    """Describe one upstream image, prompt, field of view, and seed."""
+
+    name: str
+    image: Path
+    prompt: str
+    fov_degrees: float
+    seed: int
+
+
+@dataclass(frozen=True)
+class EchoWMConfig:
+    """Hold validated source, asset, inference, and interaction settings."""
+
+    source_path: Path
+    source_url: str
+    source_revision: str
+    checkpoint: ModelAsset
+    gemma: ModelAsset
+    cache_dir: Path
+    runtime_dir: Path
+    width: int
+    height: int
+    fps: float
+    seed: int
+    default_upload_prompt: str
+    timesteps: tuple[int, ...]
+    video_local_attn_size: int
+    video_sink_size: int
+    video_chunk_size: int
+    max_chunks: int
+    video_decode_context_latents: int
+    video_decode_tiling: bool
+    attention_backend: str
+    attention_benchmark: bool
+    warmup_chunks: int
+    profile_cuda: bool
+    translation_speed: float
+    rotation_speed_degrees: float
+    pitch_speed_degrees: float
+    pitch_limit_degrees: float
+    fov_degrees: float
+    example_names: tuple[str, ...]
+
+    @property
+    def wm_root(self) -> Path:
+        """Return the pinned upstream Echo-WM package root."""
+        return self.source_path / "echo_wm"
+
+    @property
+    def frames_per_chunk(self) -> int:
+        """Return decoded RGB frames produced by one causal latent block."""
+        return self.video_chunk_size * 8
+
+
+def _mapping(value: Any, name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise TypeError(f"{name} must be a mapping")
+    return value
+
+
+def _positive_int(value: Any, name: str) -> int:
+    result = int(value)
+    if result <= 0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _nonnegative_int(value: Any, name: str) -> int:
+    result = int(value)
+    if result < 0:
+        raise ValueError(f"{name} must be zero or more")
+    return result
+
+
+def _boolean(value: Any, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise TypeError(f"{name} must be a boolean")
+    return value
+
+
+def _asset(value: Any, name: str) -> ModelAsset:
+    raw = _mapping(value, name)
+    return ModelAsset(
+        path=_local_path(raw["path"]),
+        repo_id=str(raw["repo_id"]),
+        revision=str(raw["revision"]),
+        filename=str(raw["filename"]) if raw.get("filename") else None,
+    )
+
+
+def read_config(path: Path | None) -> EchoWMConfig:
+    """Read and validate the Echo-WM adapter configuration."""
+    if path is None:
+        raise ValueError("Echo-WM requires echo_wm.yaml")
+    document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    source = _mapping(document.get("source"), "source")
+    assets = _mapping(document.get("assets"), "assets")
+    inference = _mapping(document.get("inference"), "inference")
+    motion = _mapping(document.get("motion"), "motion")
+    examples = _mapping(document.get("examples"), "examples")
+    width = _positive_int(inference.get("width"), "inference.width")
+    height = _positive_int(inference.get("height"), "inference.height")
+    if width % 32 or height % 32:
+        raise ValueError("Echo-WM width and height must be divisible by 32")
+    video_chunk_size = _positive_int(
+        inference.get("video_chunk_size"), "inference.video_chunk_size"
+    )
+    if video_chunk_size != 3:
+        raise ValueError("Echo-WM Flash requires inference.video_chunk_size=3")
+    timesteps = tuple(int(value) for value in inference.get("timesteps", ()))
+    if timesteps != (1000, 750, 500, 250):
+        raise ValueError("Echo-WM Flash requires timesteps [1000, 750, 500, 250]")
+    attention_backend = str(inference.get("attention_backend", "pytorch"))
+    if attention_backend not in {"pytorch", "flash_attention_4"}:
+        raise ValueError(
+            "inference.attention_backend must be pytorch or flash_attention_4"
+        )
+    names = tuple(str(value) for value in examples.get("cases", ()))
+    if not names:
+        raise ValueError("examples.cases must contain at least one upstream case")
+    default_upload_prompt = str(inference.get("default_upload_prompt", "")).strip()
+    if not default_upload_prompt:
+        raise ValueError("inference.default_upload_prompt must be non-empty")
+    return EchoWMConfig(
+        source_path=_local_path(source["path"]),
+        source_url=str(source["url"]),
+        source_revision=str(source["revision"]),
+        checkpoint=_asset(assets.get("checkpoint"), "assets.checkpoint"),
+        gemma=_asset(assets.get("gemma"), "assets.gemma"),
+        cache_dir=_local_path(assets["cache_dir"]),
+        runtime_dir=_local_path(assets["runtime_dir"]),
+        width=width,
+        height=height,
+        fps=float(inference.get("fps", 24.0)),
+        seed=int(inference.get("seed", 42)),
+        default_upload_prompt=default_upload_prompt,
+        timesteps=timesteps,
+        video_local_attn_size=_positive_int(
+            inference.get("video_local_attn_size"),
+            "inference.video_local_attn_size",
+        ),
+        video_sink_size=_positive_int(
+            inference.get("video_sink_size"), "inference.video_sink_size"
+        ),
+        video_chunk_size=video_chunk_size,
+        max_chunks=_positive_int(inference.get("max_chunks"), "inference.max_chunks"),
+        video_decode_context_latents=_positive_int(
+            inference.get("video_decode_context_latents"),
+            "inference.video_decode_context_latents",
+        ),
+        video_decode_tiling=_boolean(
+            inference.get("video_decode_tiling", True),
+            "inference.video_decode_tiling",
+        ),
+        attention_backend=attention_backend,
+        attention_benchmark=_boolean(
+            inference.get("attention_benchmark", False),
+            "inference.attention_benchmark",
+        ),
+        warmup_chunks=_nonnegative_int(
+            inference.get("warmup_chunks", 0), "inference.warmup_chunks"
+        ),
+        profile_cuda=_boolean(
+            inference.get("profile_cuda", True), "inference.profile_cuda"
+        ),
+        translation_speed=float(motion.get("translation_speed", 0.05)),
+        rotation_speed_degrees=float(motion.get("rotation_speed_degrees", 0.4)),
+        pitch_speed_degrees=float(motion.get("pitch_speed_degrees", 0.2)),
+        pitch_limit_degrees=float(motion.get("pitch_limit_degrees", 40.0)),
+        fov_degrees=float(motion.get("fov_degrees", 70.0)),
+        example_names=names,
+    )
+
+
+def configure_cache_environment(config: EchoWMConfig) -> None:
+    """Keep model and compiled-kernel caches under the mounted weights root."""
+    runtime_cache = config.runtime_dir / "cache"
+    environment = {
+        "HF_HOME": config.cache_dir,
+        "XDG_CACHE_HOME": runtime_cache,
+        "TORCHINDUCTOR_CACHE_DIR": runtime_cache / "torchinductor",
+        "CUDA_CACHE_PATH": runtime_cache / "cuda",
+        "FLASH_ATTENTION_CUTE_DSL_CACHE_DIR": runtime_cache / "flash-attention-4",
+    }
+    for name, path in environment.items():
+        path.mkdir(parents=True, exist_ok=True)
+        os.environ.setdefault(name, str(path))
+    os.environ.setdefault("FLASH_ATTENTION_CUTE_DSL_CACHE_ENABLED", "1")
+
+
+def prepare_assets(config: EchoWMConfig) -> None:
+    """Clone or download missing public assets into configured NVMe paths."""
+    config.cache_dir.mkdir(parents=True, exist_ok=True)
+    config.runtime_dir.mkdir(parents=True, exist_ok=True)
+    if not (config.source_path / ".git").is_dir():
+        config.source_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "clone", config.source_url, str(config.source_path)],
+            check=True,
+        )
+    git = ["git", "-c", f"safe.directory={config.source_path}"]
+    subprocess.run(
+        [
+            *git,
+            "-C",
+            str(config.source_path),
+            "checkout",
+            "--detach",
+            config.source_revision,
+        ],
+        check=True,
+    )
+    actual_revision = subprocess.run(
+        [*git, "-C", str(config.source_path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if actual_revision != config.source_revision:
+        raise RuntimeError(
+            f"Echo-WM source revision is {actual_revision}; expected {config.source_revision}"
+        )
+    if not config.checkpoint.path.is_file():
+        from huggingface_hub import hf_hub_download
+
+        if config.checkpoint.filename is None:
+            raise ValueError("Echo-WM checkpoint filename is required")
+        config.checkpoint.path.parent.mkdir(parents=True, exist_ok=True)
+        hf_hub_download(
+            repo_id=config.checkpoint.repo_id,
+            revision=config.checkpoint.revision,
+            filename=config.checkpoint.filename,
+            local_dir=config.checkpoint.path.parent,
+            cache_dir=config.cache_dir,
+        )
+    if not (config.gemma.path / "model.safetensors.index.json").is_file():
+        from huggingface_hub import snapshot_download
+
+        config.gemma.path.mkdir(parents=True, exist_ok=True)
+        try:
+            snapshot_download(
+                repo_id=config.gemma.repo_id,
+                revision=config.gemma.revision,
+                local_dir=config.gemma.path,
+                cache_dir=config.cache_dir,
+            )
+        except Exception as error:
+            raise RuntimeError(
+                "Gemma 3 is gated; accept its public license and set HF_TOKEN before startup"
+            ) from error
+
+
+def load_examples(config: EchoWMConfig) -> tuple[ExampleScene, ...]:
+    """Load the configured upstream causal example metadata."""
+    root = config.wm_root / "examples" / "wm_causal_cases"
+    scenes: list[ExampleScene] = []
+    for name in config.example_names:
+        case_dir = root / name
+        image = case_dir / "input.jpg"
+        metadata_path = case_dir / "case.json"
+        if not image.is_file() or not metadata_path.is_file():
+            raise FileNotFoundError(
+                f"Echo-WM example {name} is incomplete under {case_dir}"
+            )
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        scenes.append(
+            ExampleScene(
+                name=name,
+                image=image,
+                prompt=str(metadata["prompt"]),
+                fov_degrees=float(metadata.get("fov_deg", config.fov_degrees)),
+                seed=int(metadata.get("seed", config.seed)),
+            )
+        )
+    return tuple(scenes)
+
+
+def activate_source(config: EchoWMConfig) -> None:
+    """Put the pinned upstream packages first on the import path."""
+    paths = (
+        config.wm_root,
+        config.wm_root / "ltx-core" / "src",
+        config.wm_root / "ltx-causal" / "src",
+        config.wm_root / "ltx-pipelines" / "src",
+    )
+    for path in reversed(paths):
+        resolved = str(path.resolve())
+        if resolved in sys.path:
+            sys.path.remove(resolved)
+        sys.path.insert(0, resolved)
+
+
+def _local_path(value: Any) -> Path:
+    """Resolve one configured path under Reactor's mounted weights root."""
+    path = Path(str(value)).expanduser()
+    candidate = path if path.is_absolute() else get_weights_path() / path
+    return Path(os.path.abspath(candidate))

--- a/models/echo-wm/echo_wm_attention.py
+++ b/models/echo-wm/echo_wm_attention.py
@@ -1,0 +1,179 @@
+"""Select and verify Echo-WM attention kernels without changing upstream code."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class AttentionBenchmark:
+    """Report representative SDPA and FlashAttention 4 measurements."""
+
+    pytorch_milliseconds: float
+    flash_attention_4_milliseconds: float
+    speedup: float
+    max_absolute_error: float
+    mean_absolute_error: float
+    normalized_root_mean_square_error: float
+
+
+class FlashAttention4:
+    """Use FlashAttention 4 for unmasked attention and SDPA for masked calls."""
+
+    def __init__(
+        self,
+        flash_attention: Any,
+        masked_fallback: Any,
+        torch_module: Any,
+    ) -> None:
+        self._flash_attention = flash_attention
+        self._masked_fallback = masked_fallback
+        self._torch = torch_module
+
+    def __call__(
+        self,
+        query: Any,
+        key: Any,
+        value: Any,
+        heads: int,
+        mask: Any | None = None,
+    ) -> Any:
+        """Return attention over flattened-head Echo-WM tensors."""
+        if mask is not None:
+            return self._masked_fallback(query, key, value, heads, mask)
+        batch, _, fused = query.shape
+        head_dim = fused // heads
+        query, key, value = (
+            tensor.view(batch, -1, heads, head_dim) for tensor in (query, key, value)
+        )
+        output = self._flash_attention(
+            query.to(self._torch.bfloat16),
+            key.to(self._torch.bfloat16),
+            value.to(self._torch.bfloat16),
+        )
+        if isinstance(output, tuple):
+            output = output[0]
+        return output.reshape(batch, -1, fused).to(value.dtype)
+
+
+def resolve_attention_backend(
+    backend: str,
+    *,
+    pytorch_attention: Any,
+    torch_module: Any,
+) -> Any:
+    """Return the configured Echo-WM attention callable.
+
+    Raises:
+        RuntimeError: FlashAttention 4 is selected but unavailable.
+    """
+    if backend == "pytorch":
+        return pytorch_attention
+    try:
+        from flash_attn.cute import flash_attn_func
+    except ImportError as error:
+        raise RuntimeError(
+            "inference.attention_backend is flash_attention_4 but flash-attn-4 "
+            "is unavailable; install requirements-flash-attn.txt or select pytorch"
+        ) from error
+    return FlashAttention4(flash_attn_func, pytorch_attention, torch_module)
+
+
+def set_attention_backend(
+    root: Any,
+    attention_function: Any,
+    attention_class: type[Any],
+) -> int:
+    """Assign one callable to every upstream transformer attention module."""
+    changed = 0
+    for module in root.modules():
+        if isinstance(module, attention_class):
+            module.attention_function = attention_function
+            changed += 1
+    if changed == 0:
+        raise RuntimeError("Echo-WM exposed no configurable attention modules")
+    return changed
+
+
+def benchmark_attention_backends(
+    *,
+    flash_attention: Any,
+    pytorch_attention: Any,
+    torch_module: Any,
+    query_tokens: int,
+    key_value_tokens: int,
+    heads: int = 32,
+    head_dim: int = 128,
+    warmup_iterations: int = 2,
+    measured_iterations: int = 5,
+) -> AttentionBenchmark:
+    """Verify and time both kernels on a representative video-attention shape.
+
+    Raises:
+        RuntimeError: Either kernel returns non-finite or materially different output.
+    """
+    device = torch_module.device("cuda")
+    generator = torch_module.Generator(device=device).manual_seed(0)
+    fused = heads * head_dim
+    query = torch_module.randn(
+        (1, query_tokens, fused),
+        device=device,
+        dtype=torch_module.bfloat16,
+        generator=generator,
+    )
+    key = torch_module.randn(
+        (1, key_value_tokens, fused),
+        device=device,
+        dtype=torch_module.bfloat16,
+        generator=generator,
+    )
+    value = torch_module.randn(
+        (1, key_value_tokens, fused),
+        device=device,
+        dtype=torch_module.bfloat16,
+        generator=generator,
+    )
+
+    reference = pytorch_attention(query, key, value, heads)
+    candidate = flash_attention(query, key, value, heads)
+    torch_module.cuda.synchronize(device)
+    if not bool(torch_module.isfinite(reference).all()) or not bool(
+        torch_module.isfinite(candidate).all()
+    ):
+        raise RuntimeError("Echo-WM attention verification produced non-finite values")
+
+    difference = (candidate.float() - reference.float()).abs()
+    max_error = float(difference.max())
+    mean_error = float(difference.mean())
+    reference_rms = reference.float().square().mean().sqrt().clamp_min(1e-12)
+    normalized_rmse = float(difference.square().mean().sqrt() / reference_rms)
+    if mean_error > 0.01 or normalized_rmse > 0.05:
+        raise RuntimeError(
+            "FlashAttention 4 differs materially from PyTorch SDPA: "
+            f"mean_absolute_error={mean_error:.6f}, normalized_rmse={normalized_rmse:.6f}"
+        )
+
+    def measure(attention: Any) -> float:
+        for _ in range(warmup_iterations):
+            attention(query, key, value, heads)
+        torch_module.cuda.synchronize(device)
+        start = torch_module.cuda.Event(enable_timing=True)
+        end = torch_module.cuda.Event(enable_timing=True)
+        start.record()
+        for _ in range(measured_iterations):
+            attention(query, key, value, heads)
+        end.record()
+        end.synchronize()
+        return float(start.elapsed_time(end)) / measured_iterations
+
+    pytorch_ms = measure(pytorch_attention)
+    flash_attention_4_ms = measure(flash_attention)
+    return AttentionBenchmark(
+        pytorch_milliseconds=pytorch_ms,
+        flash_attention_4_milliseconds=flash_attention_4_ms,
+        speedup=pytorch_ms / flash_attention_4_ms,
+        max_absolute_error=max_error,
+        mean_absolute_error=mean_error,
+        normalized_root_mean_square_error=normalized_rmse,
+    )

--- a/models/echo-wm/echo_wm_backend.py
+++ b/models/echo-wm/echo_wm_backend.py
@@ -1,0 +1,469 @@
+"""Advance Echo-WM Flash one native audio-video block per Reactor turn."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from helpers.action_camera import default_k_pix
+from helpers.action_condition import (
+    _INTERNAL_TRANSLATION_CALIBRATION,
+    action_config,
+)
+from ltx_causal import (
+    CausalCacheConfig,
+    CausalModelWrapper,
+    causal_audio_blocks,
+    causal_audio_frames,
+    causal_video_blocks,
+)
+from ltx_causal.rollout import (
+    _BlockForward,
+    _denoise_av_block,
+    _generate_audio_prefix,
+    _RolloutBuffers,
+)
+from ltx_causal.scheduling import resolve_causal_sigmas
+from ltx_core.components.noisers import GaussianNoiser
+from ltx_core.model.audio_vae import decode_audio
+from ltx_core.model.transformer.attention import Attention, PytorchAttention
+from ltx_core.model.video_vae import decode_video
+from ltx_core.model.video_vae.tiling import TilingConfig
+from ltx_core.tools import AudioLatentTools
+from ltx_core.types import AudioLatentShape, VideoLatentShape, VideoPixelShape
+from ltx_pipelines.utils import ModelLedger, combined_image_conditionings
+from ltx_pipelines.utils.args import ImageConditioningInput
+from ltx_pipelines.utils.helpers import create_noised_state, noise_video_state
+from ltx_pipelines.utils.types import PipelineComponents
+
+from echo_wm_assets import EchoWMConfig
+from echo_wm_attention import (
+    AttentionBenchmark,
+    benchmark_attention_backends,
+    resolve_attention_backend,
+    set_attention_backend,
+)
+from echo_wm_camera import CameraChunk
+
+
+class EchoWMBackend:
+    """Own upstream model components and one bounded causal rollout."""
+
+    def __init__(self, config: EchoWMConfig) -> None:
+        if not torch.cuda.is_available():
+            raise RuntimeError("Echo-WM Flash requires a CUDA accelerator")
+        self._config = config
+        self._device = torch.device("cuda")
+        self._dtype = torch.bfloat16
+        self._cache_config = CausalCacheConfig(
+            video_local_attn_size=config.video_local_attn_size,
+            video_sink_size=config.video_sink_size,
+            video_chunk_size=config.video_chunk_size,
+        )
+        self._cache_config.validate()
+        self._total_video_latents = 1 + config.video_chunk_size * config.max_chunks
+        self._total_pixel_frames = 1 + config.frames_per_chunk * config.max_chunks
+        self._patches_per_frame = (config.height // 32) * (config.width // 32)
+        self._video_blocks = causal_video_blocks(
+            self._total_video_latents, config.video_chunk_size
+        )
+        self._audio_blocks = causal_audio_blocks(
+            self._total_video_latents, config.video_chunk_size
+        )
+        self._audio_latents = causal_audio_frames(
+            self._total_video_latents, config.video_chunk_size
+        )
+        self._ledger = ModelLedger(
+            dtype=self._dtype,
+            device=self._device,
+            checkpoint_path=str(config.checkpoint.path),
+            gemma_root_path=str(config.gemma.path),
+        )
+        self._components = PipelineComponents(dtype=self._dtype, device=self._device)
+        self._text_encoder = self._ledger.text_encoder()
+        self._embeddings_processor = self._ledger.gemma_embeddings_processor()
+        self._video_encoder = self._ledger.video_encoder()
+        self._x0_model = self._ledger.transformer(
+            action_config=action_config(config.width, config.height)
+        )
+        pytorch_attention = PytorchAttention()
+        attention_function = resolve_attention_backend(
+            config.attention_backend,
+            pytorch_attention=pytorch_attention,
+            torch_module=torch,
+        )
+        self._attention_modules = set_attention_backend(
+            self._x0_model,
+            attention_function,
+            Attention,
+        )
+        self._attention_benchmark: AttentionBenchmark | None = None
+        if (
+            config.attention_benchmark
+            and config.attention_backend == "flash_attention_4"
+        ):
+            self._attention_benchmark = benchmark_attention_backends(
+                flash_attention=attention_function,
+                pytorch_attention=pytorch_attention,
+                torch_module=torch,
+                query_tokens=config.video_chunk_size * self._patches_per_frame,
+                key_value_tokens=config.video_local_attn_size * self._patches_per_frame,
+            )
+        self._wrapper = CausalModelWrapper(
+            self._x0_model.velocity_model,
+            patches_per_frame=self._patches_per_frame,
+            cache=self._cache_config,
+        )
+        self._video_decoder = self._ledger.video_decoder()
+        self._audio_decoder = self._ledger.audio_decoder()
+        self._vocoder = self._ledger.vocoder()
+        self._audio_sample_rate = int(self._vocoder.output_sampling_rate)
+        if self._audio_sample_rate != 48_000:
+            raise ValueError(
+                f"Echo-WM audio must be 48000 Hz, got {self._audio_sample_rate}"
+            )
+        self._sigmas = resolve_causal_sigmas(config.timesteps)
+        self._forward: _BlockForward | None = None
+        self._buffers: _RolloutBuffers | None = None
+        self._video_tools: Any = None
+        self._audio_tools: AudioLatentTools | None = None
+        self._action_cond: dict[str, torch.Tensor] | None = None
+        self._generator: torch.Generator | None = None
+        self._chunk_index = 0
+        self._seed = config.seed
+        self._last_profile: dict[str, float] = {}
+
+    @property
+    def audio_sample_rate(self) -> int:
+        """Return the generated PCM sample rate."""
+        return self._audio_sample_rate
+
+    @property
+    def chunk_index(self) -> int:
+        """Return completed chunks in the current rollout."""
+        return self._chunk_index
+
+    @property
+    def attention_modules(self) -> int:
+        """Return upstream attention modules using the configured callable."""
+        return self._attention_modules
+
+    @property
+    def attention_benchmark(self) -> AttentionBenchmark | None:
+        """Return startup SDPA/FA4 verification results when enabled."""
+        return self._attention_benchmark
+
+    @property
+    def last_profile(self) -> dict[str, float]:
+        """Return CUDA stage timings for the latest generated chunk."""
+        return dict(self._last_profile)
+
+    @torch.inference_mode()
+    def reset(self, *, image: Path, prompt: str, seed: int, fov_degrees: float) -> None:
+        """Initialize upstream conditioning, buffers, and bounded caches."""
+        self.end_session(release_cuda_cache=False)
+        config = self._config
+        encoded_prompt = self._encode_prompt(prompt)
+        output_shape = VideoPixelShape(
+            1,
+            self._total_pixel_frames,
+            config.height,
+            config.width,
+            config.fps,
+        )
+        conditionings = combined_image_conditionings(
+            [ImageConditioningInput(str(image), 0, 1.0)],
+            config.height,
+            config.width,
+            self._video_encoder,
+            self._dtype,
+            self._device,
+        )
+        generator = torch.Generator(device=self._device).manual_seed(seed)
+        noiser = GaussianNoiser(generator)
+        video_state, video_tools = noise_video_state(
+            output_shape,
+            noiser,
+            conditionings,
+            self._components,
+            self._dtype,
+            self._device,
+        )
+        audio_shape = AudioLatentShape(
+            batch=1,
+            channels=8,
+            frames=self._audio_latents,
+            mel_bins=16,
+        )
+        audio_tools = AudioLatentTools(self._components.audio_patchifier, audio_shape)
+        audio_state = create_noised_state(
+            audio_tools,
+            [],
+            noiser,
+            self._dtype,
+            self._device,
+        )
+        action_cond = self._empty_action_condition(fov_degrees)
+        buffers = _RolloutBuffers.create(
+            video_state.clean_latent,
+            audio_state.clean_latent,
+            self._patches_per_frame,
+            generator,
+        )
+        forward = _BlockForward.create(
+            wrapper=self._wrapper,
+            clean_video=video_state.clean_latent,
+            clean_audio=audio_state.clean_latent,
+            video_positions=video_state.positions,
+            audio_positions=audio_state.positions,
+            video_context=encoded_prompt.video_encoding,
+            audio_context=encoded_prompt.audio_encoding,
+            context_mask=encoded_prompt.attention_mask,
+            action_cond=action_cond,
+        )
+        _generate_audio_prefix(
+            forward,
+            buffers,
+            self._video_blocks[0],
+            self._audio_blocks[0],
+            self._sigmas,
+            generator,
+        )
+        self._forward = forward
+        self._buffers = buffers
+        self._video_tools = video_tools
+        self._audio_tools = audio_tools
+        self._action_cond = action_cond
+        self._generator = generator
+        self._chunk_index = 0
+        self._seed = seed
+        self._last_profile = {}
+
+    @torch.inference_mode()
+    def generate_chunk(
+        self,
+        camera: CameraChunk,
+        *,
+        fov_degrees: float,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Generate, cache, decode, and return one native audio-video block."""
+        forward = self._require_forward()
+        buffers = self._require_buffers()
+        generator = self._require_generator()
+        next_index = self._chunk_index + 1
+        if next_index >= len(self._video_blocks):
+            raise RuntimeError("Echo-WM rollout reached its configured chunk capacity")
+        video_block = self._video_blocks[next_index]
+        audio_block = self._audio_blocks[next_index]
+        self._update_camera(camera, video_block, fov_degrees)
+        events = (
+            [torch.cuda.Event(enable_timing=True) for _ in range(5)]
+            if self._config.profile_cuda
+            else []
+        )
+        if events:
+            events[0].record()
+        video_sample, audio_sample = _denoise_av_block(
+            forward,
+            buffers.initial_video,
+            buffers.initial_audio,
+            video_block,
+            audio_block,
+            self._sigmas,
+            generator,
+        )
+        if events:
+            events[1].record()
+        video_start, video_end = video_block
+        audio_start, audio_end = audio_block
+        buffers.video_output[
+            :,
+            video_start * self._patches_per_frame : video_end * self._patches_per_frame,
+        ] = video_sample
+        buffers.audio_output[:, audio_start:audio_end] = audio_sample
+        forward(video_sample, video_block, 0.0, audio_sample, audio_block, 0.0)
+        if events:
+            events[2].record()
+        video = self._decode_video(video_end)
+        if events:
+            events[3].record()
+        audio = self._decode_audio(audio_end, int(video.shape[0]))
+        if events:
+            events[4].record()
+            events[4].synchronize()
+            self._last_profile = {
+                "denoise_seconds": events[0].elapsed_time(events[1]) / 1000.0,
+                "cache_commit_seconds": events[1].elapsed_time(events[2]) / 1000.0,
+                "video_decode_seconds": events[2].elapsed_time(events[3]) / 1000.0,
+                "audio_decode_seconds": events[3].elapsed_time(events[4]) / 1000.0,
+                "cuda_total_seconds": events[0].elapsed_time(events[4]) / 1000.0,
+            }
+        else:
+            self._last_profile = {}
+        self._chunk_index = next_index
+        return video, audio
+
+    def end_session(self, *, release_cuda_cache: bool = True) -> None:
+        """Release rollout tensors while retaining loaded model components."""
+        self._forward = None
+        self._buffers = None
+        self._video_tools = None
+        self._audio_tools = None
+        self._action_cond = None
+        self._generator = None
+        self._chunk_index = 0
+        self._last_profile = {}
+        if release_cuda_cache:
+            torch.cuda.empty_cache()
+
+    def _encode_prompt(self, prompt: str) -> Any:
+        hidden_states, mask = self._text_encoder.encode(prompt)
+        result = self._embeddings_processor.process_hidden_states(hidden_states, mask)
+        if result.audio_encoding is None:
+            raise ValueError(
+                "Echo-WM Flash checkpoint did not provide audio text embeddings"
+            )
+        return result
+
+    def _empty_action_condition(self, fov_degrees: float) -> dict[str, torch.Tensor]:
+        viewmats = (
+            torch.eye(
+                4,
+                device=self._device,
+                dtype=torch.float32,
+            )
+            .reshape(1, 1, 4, 4)
+            .repeat(1, self._total_video_latents, 1, 1)
+        )
+        intrinsic = default_k_pix(
+            self._config.width,
+            self._config.height,
+            fov_degrees,
+        ).to(device=self._device, dtype=torch.float32)
+        intrinsics = intrinsic.reshape(1, 1, 3, 3).repeat(
+            1, self._total_video_latents, 1, 1
+        )
+        return {"ucpe_viewmats": viewmats, "ucpe_Ks": intrinsics}
+
+    def _update_camera(
+        self,
+        camera: CameraChunk,
+        video_block: tuple[int, int],
+        fov_degrees: float,
+    ) -> None:
+        action = self._action_cond
+        if action is None:
+            raise RuntimeError("Echo-WM rollout was not initialized")
+        start, end = video_block
+        expected = end - start
+        if camera.latent_poses.shape != (expected, 4, 4):
+            raise ValueError(
+                f"Echo-WM camera chunk must have shape {(expected, 4, 4)}, "
+                f"got {camera.latent_poses.shape}"
+            )
+        normalized = torch.from_numpy(camera.latent_poses).to(
+            device=self._device,
+            dtype=torch.float32,
+        )
+        normalized = normalized.clone()
+        normalized[:, :3, 3] /= _INTERNAL_TRANSLATION_CALIBRATION
+        action["ucpe_viewmats"][:, start:end].copy_(normalized.unsqueeze(0))
+        intrinsic = default_k_pix(
+            self._config.width,
+            self._config.height,
+            fov_degrees,
+        ).to(device=self._device, dtype=torch.float32)
+        action["ucpe_Ks"][:, start:end].copy_(
+            intrinsic.reshape(1, 1, 3, 3).expand(1, expected, -1, -1)
+        )
+
+    def _decode_video(self, video_end: int) -> np.ndarray:
+        buffers = self._require_buffers()
+        context = min(self._config.video_decode_context_latents, video_end)
+        start = video_end - context
+        token_start = start * self._patches_per_frame
+        token_end = video_end * self._patches_per_frame
+        shape = VideoLatentShape(
+            batch=1,
+            channels=128,
+            frames=context,
+            height=self._config.height // 32,
+            width=self._config.width // 32,
+        )
+        latent = self._components.video_patchifier.unpatchify(
+            buffers.video_output[:, token_start:token_end],
+            output_shape=shape,
+        )
+        decode_generator = torch.Generator(device=self._device).manual_seed(self._seed)
+        decoded = torch.cat(
+            list(
+                decode_video(
+                    latent,
+                    self._video_decoder,
+                    tiling_config=(
+                        TilingConfig.default()
+                        if self._config.video_decode_tiling
+                        else None
+                    ),
+                    generator=decode_generator,
+                )
+            ),
+            dim=0,
+        )
+        frame_count = 25 if self._chunk_index == 0 else self._config.frames_per_chunk
+        return np.ascontiguousarray(
+            decoded[-frame_count:].cpu().numpy(), dtype=np.uint8
+        )
+
+    def _decode_audio(self, audio_end: int, video_frames: int) -> np.ndarray:
+        buffers = self._require_buffers()
+        context = min(self._cache_config.audio_local_attn_size, audio_end)
+        start = audio_end - context
+        shape = AudioLatentShape(
+            batch=1,
+            channels=8,
+            frames=context,
+            mel_bins=16,
+        )
+        latent = self._components.audio_patchifier.unpatchify(
+            buffers.audio_output[:, start:audio_end],
+            output_shape=shape,
+        )
+        decoded = decode_audio(latent, self._audio_decoder, self._vocoder)
+        waveform = decoded.waveform.float().mean(dim=0)
+        expected_samples = round(
+            video_frames * self._audio_sample_rate / self._config.fps
+        )
+        if waveform.numel() < expected_samples:
+            waveform = torch.nn.functional.pad(
+                waveform,
+                (expected_samples - waveform.numel(), 0),
+            )
+        waveform = waveform[-expected_samples:]
+        pcm = (
+            waveform.clamp(-1.0, 1.0)
+            .mul(32767.0)
+            .round()
+            .to(torch.int16)
+            .reshape(1, -1)
+            .cpu()
+            .numpy()
+        )
+        return np.ascontiguousarray(pcm)
+
+    def _require_forward(self) -> _BlockForward:
+        if self._forward is None:
+            raise RuntimeError("Echo-WM rollout was not initialized")
+        return self._forward
+
+    def _require_buffers(self) -> _RolloutBuffers:
+        if self._buffers is None:
+            raise RuntimeError("Echo-WM rollout was not initialized")
+        return self._buffers
+
+    def _require_generator(self) -> torch.Generator:
+        if self._generator is None:
+            raise RuntimeError("Echo-WM rollout was not initialized")
+        return self._generator

--- a/models/echo-wm/echo_wm_camera.py
+++ b/models/echo-wm/echo_wm_camera.py
@@ -1,0 +1,159 @@
+"""Integrate Echo-WM's native pure-camera motion across interactive chunks."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class MotionConfig:
+    """Hold the native camera integration constants."""
+
+    fps: float
+    translation_speed: float
+    rotation_speed_degrees: float
+    pitch_speed_degrees: float
+    pitch_limit_degrees: float
+
+
+@dataclass(frozen=True)
+class CameraChunk:
+    """Carry the three camera poses aligned with one causal latent block."""
+
+    latent_poses: np.ndarray
+
+
+def _rotation_x(angle: float) -> np.ndarray:
+    cosine, sine = math.cos(angle), math.sin(angle)
+    return np.asarray(
+        [[1.0, 0.0, 0.0], [0.0, cosine, -sine], [0.0, sine, cosine]],
+        dtype=np.float64,
+    )
+
+
+def _rotation_y(angle: float) -> np.ndarray:
+    cosine, sine = math.cos(angle), math.sin(angle)
+    return np.asarray(
+        [[cosine, 0.0, sine], [0.0, 1.0, 0.0], [-sine, 0.0, cosine]],
+        dtype=np.float64,
+    )
+
+
+class EchoCameraPlanner:
+    """Preserve Echo-WM camera pose, inertia, and pitch across chunks."""
+
+    def __init__(self, config: MotionConfig) -> None:
+        if config.fps <= 0 or config.translation_speed <= 0:
+            raise ValueError("Echo-WM camera rates must be positive")
+        self._config = config
+        self.reset()
+
+    def reset(self) -> None:
+        """Return camera position, rotation, and inertia to upstream defaults."""
+        self._pose = np.eye(4, dtype=np.float64)
+        self._pitch = 0.0
+        self._velocity = np.zeros(4, dtype=np.float64)
+        self._active_axes: frozenset[str] = frozenset()
+
+    def plan_chunk(
+        self,
+        *,
+        forward: float,
+        strafe: float,
+        pitch: float,
+        yaw: float,
+        frame_count: int,
+    ) -> CameraChunk:
+        """Advance native camera integration and return latent-aligned poses."""
+        if frame_count <= 0 or frame_count % 8:
+            raise ValueError(
+                "Echo-WM camera chunks must be a positive multiple of 8 frames"
+            )
+        pixel_poses = [
+            self._advance_one_frame(
+                forward=forward,
+                strafe=strafe,
+                pitch=pitch,
+                yaw=yaw,
+            )
+            for _ in range(frame_count)
+        ]
+        indices = np.arange(7, frame_count, 8)
+        return CameraChunk(
+            latent_poses=np.ascontiguousarray(
+                np.stack(pixel_poses)[indices], dtype=np.float32
+            )
+        )
+
+    def _advance_one_frame(
+        self,
+        *,
+        forward: float,
+        strafe: float,
+        pitch: float,
+        yaw: float,
+    ) -> np.ndarray:
+        config = self._config
+        target = np.asarray(
+            [
+                forward * config.translation_speed,
+                strafe * config.translation_speed,
+                yaw * math.radians(config.rotation_speed_degrees),
+                pitch * math.radians(config.pitch_speed_degrees),
+            ],
+            dtype=np.float64,
+        )
+        active = frozenset(
+            name
+            for name, value in zip(
+                ("forward", "strafe", "yaw", "pitch"),
+                (forward, strafe, yaw, pitch),
+                strict=True,
+            )
+            if value != 0.0
+        )
+        sign_changed = any(
+            np.sign(target[index]) != np.sign(self._velocity[index])
+            and target[index] != 0.0
+            for index in range(4)
+        )
+        if active - self._active_axes or sign_changed:
+            self._velocity = target
+        else:
+            time_constant = 0.45 if np.any(target) else 1.0
+            blend = 1.0 - math.exp(-(1.0 / config.fps) / time_constant)
+            self._velocity += (target - self._velocity) * blend
+        self._active_axes = active
+
+        next_pitch = float(
+            np.clip(
+                self._pitch + self._velocity[3],
+                -math.radians(config.pitch_limit_degrees),
+                math.radians(config.pitch_limit_degrees),
+            )
+        )
+        pitch_step = next_pitch - self._pitch
+        self._pitch = next_pitch
+        rotation = (
+            _rotation_y(self._velocity[2])
+            @ self._pose[:3, :3]
+            @ _rotation_x(pitch_step)
+        )
+        forward_axis = rotation[:, 2].copy()
+        right_axis = rotation[:, 0].copy()
+        forward_axis[1] = 0.0
+        right_axis[1] = 0.0
+        forward_axis /= max(float(np.linalg.norm(forward_axis)), 1e-6)
+        right_axis /= max(float(np.linalg.norm(right_axis)), 1e-6)
+        pose = np.eye(4, dtype=np.float64)
+        pose[:3, :3] = rotation
+        pose[:3, 3] = (
+            self._pose[:3, 3]
+            + forward_axis * self._velocity[0]
+            + right_axis * self._velocity[1]
+        )
+        self._pose = pose
+        return pose.copy()

--- a/models/echo-wm/echo_wm_images.py
+++ b/models/echo-wm/echo_wm_images.py
@@ -1,0 +1,70 @@
+"""Validate and materialize Echo-WM first-frame images."""
+
+from __future__ import annotations
+
+import io
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+from reactor_runtime import CommandError, UploadedFile
+
+_MAX_UPLOAD_BYTES = 25 * 1024 * 1024
+_MAX_PIXELS = 100_000_000
+_FORMATS = {"BMP", "JPEG", "PNG", "WEBP"}
+
+
+def validate_uploaded_image(image: UploadedFile) -> None:
+    """Reject uploads that cannot serve as an Echo-WM first frame."""
+    if not image.mime_type.startswith("image/"):
+        raise CommandError("unsupported_media", f"{image.name} is not an image.")
+    if not image.data:
+        raise CommandError("invalid_image", f"{image.name} is empty.")
+    if image.size > _MAX_UPLOAD_BYTES:
+        raise CommandError("image_too_large", f"{image.name} exceeds 25 MiB.")
+    try:
+        with Image.open(io.BytesIO(image.data)) as decoded:
+            if decoded.format not in _FORMATS:
+                raise CommandError(
+                    "unsupported_media",
+                    f"{image.name} must be JPEG, PNG, WebP, or BMP.",
+                )
+            width, height = decoded.size
+            if width <= 0 or height <= 0 or width * height > _MAX_PIXELS:
+                raise CommandError(
+                    "image_too_large", f"{image.name} exceeds {_MAX_PIXELS} pixels."
+                )
+            decoded.verify()
+    except CommandError:
+        raise
+    except (
+        Image.DecompressionBombError,
+        UnidentifiedImageError,
+        OSError,
+        ValueError,
+    ) as error:
+        raise CommandError(
+            "invalid_image", f"{image.name} cannot be decoded."
+        ) from error
+
+
+@contextmanager
+def materialized_image(
+    value: Path | UploadedFile,
+    runtime_dir: Path,
+) -> Iterator[Path]:
+    """Yield a filesystem image path accepted by the upstream loader."""
+    if isinstance(value, Path):
+        yield value
+        return
+    suffix = Path(value.name).suffix.lower() or ".png"
+    with tempfile.NamedTemporaryFile(
+        prefix="echo-wm-upload-",
+        suffix=suffix,
+        dir=runtime_dir,
+    ) as temporary:
+        temporary.write(value.data)
+        temporary.flush()
+        yield Path(temporary.name)

--- a/models/echo-wm/echo_wm_schema.py
+++ b/models/echo-wm/echo_wm_schema.py
@@ -1,0 +1,226 @@
+"""Define Echo-WM's public Reactor state, media tracks, and messages."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from reactor_runtime import (
+    Audio,
+    InputField,
+    InputState,
+    MessageField,
+    ModelMessage,
+    Output,
+    Video,
+)
+
+
+class EchoAudio(Audio):
+    """Declare Echo-WM's 48 kHz generated audio track."""
+
+    sample_rate = 48_000
+
+
+class EchoWMOutput(Output):
+    """Carry one synchronized generated video-and-audio chunk."""
+
+    main_video: Video
+    main_audio: EchoAudio
+
+
+class EchoWMState(InputState):
+    """Expose shared scene, camera, and playback controls for one world."""
+
+    prompt: str = InputField(
+        default="",
+        max_length=4096,
+        description=(
+            "Scene, character, perspective, sound, music, and speech description. "
+            "Use `set_prompt` to replace it; a change starts a fresh world from the "
+            "selected image because one prompt conditions an entire rollout."
+        ),
+    )
+    paused: bool = InputField(
+        default=False,
+        description=(
+            "Whether automatic generation stops before the next chunk. Image selection "
+            "queues two preview chunks while this remains true."
+        ),
+    )
+    _forward: float = 0.0
+    _strafe: float = 0.0
+    _pitch: float = 0.0
+    _yaw: float = 0.0
+    _fov_degrees: float = 70.0
+    _queued_steps: int = 0
+    _reset_requested: bool = False
+
+
+class StateUpdate(ModelMessage):
+    """Emitted after connection, state mutation, reset, or chunk completion."""
+
+    image_source: Literal["uploaded", "built_in"] | None = MessageField(
+        description=(
+            'Source of the first frame: "uploaded", "built_in", or null before an '
+            "image is selected."
+        )
+    )
+    image_name: str | None = MessageField(
+        description="Selected first-frame filename, or null before image selection."
+    )
+    prompt: str | None = MessageField(
+        description="Prompt for the current or queued world, or null before image selection."
+    )
+    active_prompt: str | None = MessageField(
+        description="Prompt used by the latest completed chunk, or null before generation."
+    )
+    seed: int = MessageField(description="Random seed for the current or queued world.")
+    paused: bool = MessageField(
+        description="Whether generation will stop before the next unqueued chunk."
+    )
+    step_queued: bool = MessageField(
+        description="Whether at least one chunk is queued while paused."
+    )
+    queued_steps: int = MessageField(
+        description="Chunks waiting to generate while paused."
+    )
+    reset_queued: bool = MessageField(
+        description="Whether a fresh world will be initialized before the next chunk."
+    )
+    generating: bool = MessageField(
+        description="Whether image preparation or one audio-video chunk is in progress."
+    )
+    completed_chunks: int = MessageField(
+        description="Completed audio-video chunks since the latest world reset."
+    )
+    next_chunk: int | None = MessageField(
+        description="One-based chunk that accepted camera state will first affect."
+    )
+    max_chunks: int = MessageField(
+        description="Chunk count that automatically starts a fresh world from the same image."
+    )
+    forward: float = MessageField(
+        description="Active backward-to-forward camera motion."
+    )
+    strafe: float = MessageField(description="Active left-to-right camera motion.")
+    pitch: float = MessageField(description="Active downward-to-upward pitch motion.")
+    yaw: float = MessageField(description="Active left-to-right yaw motion.")
+    fov_degrees: float = MessageField(
+        description="Active horizontal field of view in degrees."
+    )
+
+
+class ImageSelected(ModelMessage):
+    """Emitted when an uploaded or built-in image queues a fresh world."""
+
+    source: Literal["uploaded", "built_in"] = MessageField(
+        description="Image source accepted by the command."
+    )
+    filename: str = MessageField(description="Selected first-frame filename.")
+    prompt: str = MessageField(description="Non-empty prompt for the fresh world.")
+    seed: int = MessageField(description="Random seed for the fresh world.")
+    first_chunk_queued: bool = MessageField(
+        description="Whether paused mode caused preview generation to be queued."
+    )
+    preview_chunks_queued: int = MessageField(
+        description="Preview chunks queued by this image selection."
+    )
+
+
+class PromptQueued(ModelMessage):
+    """Emitted when a prompt queues a fresh world from the selected image."""
+
+    prompt: str = MessageField(description="Trimmed prompt accepted by `set_prompt`.")
+    applies_to_chunk: int = MessageField(
+        description="One-based chunk affected by the prompt; always 1 after the reset."
+    )
+
+
+class CameraMotionChanged(ModelMessage):
+    """Emitted when camera motion or field of view changes."""
+
+    forward: float = MessageField(description="Active backward-to-forward motion.")
+    strafe: float = MessageField(description="Active left-to-right motion.")
+    pitch: float = MessageField(description="Active downward-to-upward pitch motion.")
+    yaw: float = MessageField(description="Active left-to-right yaw motion.")
+    fov_degrees: float = MessageField(description="Active horizontal field of view.")
+    applies_to_chunk: int | None = MessageField(
+        description="First chunk expected to sample these values, or null without an image."
+    )
+
+
+class PauseChanged(ModelMessage):
+    """Emitted when continuous generation pauses or resumes."""
+
+    paused: bool = MessageField(description="Pause state now in effect.")
+    next_chunk: int | None = MessageField(
+        description="Next available chunk, or null before an image is selected."
+    )
+
+
+class StepQueued(ModelMessage):
+    """Emitted when `step` queues exactly one paused audio-video chunk."""
+
+    applies_to_chunk: int = MessageField(
+        description="One-based chunk queued by `step`."
+    )
+    expected_video_frames: int = MessageField(
+        description="Expected RGB frames: 25 for chunk 1 and 24 for later chunks."
+    )
+
+
+class RolloutResetQueued(ModelMessage):
+    """Emitted when `reset` queues a fresh world from the selected image."""
+
+    seed: int = MessageField(description="Random seed for the fresh world.")
+    replaced_chunks: int = MessageField(
+        description="Completed chunks discarded by the reset."
+    )
+    first_chunk_queued: bool = MessageField(
+        description="Whether one paused preview chunk was queued."
+    )
+
+
+class ChunkCompleted(ModelMessage):
+    """Emitted once after one synchronized audio-video chunk finishes."""
+
+    chunk: int = MessageField(description="One-based chunk that completed.")
+    video_frames: int = MessageField(description="RGB frames carried by `main_video`.")
+    audio_samples: int = MessageField(
+        description="48 kHz mono samples carried by `main_audio`."
+    )
+    generation_seconds: float = MessageField(
+        description="Wall-clock seconds spent generating and decoding the chunk."
+    )
+    denoise_seconds: float | None = MessageField(
+        description="CUDA seconds spent in the four denoising transformer forwards."
+    )
+    cache_commit_seconds: float | None = MessageField(
+        description="CUDA seconds spent committing clean audio-video KV cache entries."
+    )
+    video_decode_seconds: float | None = MessageField(
+        description="CUDA seconds spent decoding the video latent block."
+    )
+    audio_decode_seconds: float | None = MessageField(
+        description="CUDA seconds spent decoding and vocoding the audio latent block."
+    )
+    cuda_total_seconds: float | None = MessageField(
+        description="Total CUDA seconds from denoising through synchronized media decode."
+    )
+    prompt: str = MessageField(description="Prompt sampled by the completed chunk.")
+    forward: float = MessageField(description="Forward motion sampled by the chunk.")
+    strafe: float = MessageField(description="Strafe motion sampled by the chunk.")
+    pitch: float = MessageField(description="Pitch motion sampled by the chunk.")
+    yaw: float = MessageField(description="Yaw motion sampled by the chunk.")
+
+
+class AutomaticResetQueued(ModelMessage):
+    """Emitted after the final chunk queues a fresh bounded rollout."""
+
+    completed_chunks: int = MessageField(
+        description="Chunks completed when the configured bound was reached."
+    )
+    max_chunks: int = MessageField(
+        description="Configured chunk bound that was reached."
+    )
+    seed: int = MessageField(description="Seed retained by the queued fresh world.")

--- a/models/echo-wm/echo_wm_schema.py
+++ b/models/echo-wm/echo_wm_schema.py
@@ -29,7 +29,7 @@ class EchoWMOutput(Output):
 
 
 class EchoWMState(InputState):
-    """Expose shared scene, camera, and playback controls for one world."""
+    """Expose shared scene and camera controls for one world."""
 
     prompt: str = InputField(
         default="",
@@ -40,13 +40,7 @@ class EchoWMState(InputState):
             "selected image because one prompt conditions an entire rollout."
         ),
     )
-    paused: bool = InputField(
-        default=False,
-        description=(
-            "Whether automatic generation stops before the next chunk. Image selection "
-            "queues two preview chunks while this remains true."
-        ),
-    )
+    _paused: bool = False
     _forward: float = 0.0
     _strafe: float = 0.0
     _pitch: float = 0.0
@@ -54,6 +48,16 @@ class EchoWMState(InputState):
     _fov_degrees: float = 70.0
     _queued_steps: int = 0
     _reset_requested: bool = False
+
+    @property
+    def paused(self) -> bool:
+        """Return whether continuous chunk generation is paused."""
+        return self._paused
+
+    @paused.setter
+    def paused(self, value: bool) -> None:
+        """Set whether continuous chunk generation is paused."""
+        self._paused = value
 
 
 class StateUpdate(ModelMessage):

--- a/models/echo-wm/reactor.yaml
+++ b/models/echo-wm/reactor.yaml
@@ -1,0 +1,59 @@
+# Reactor model specification for the Echo-WM Flash recipe.
+$schema: reactor/v1
+
+model:
+  name: echo-wm-flash
+  version: v0.0.1
+  description: |
+    Explore an autoregressive audiovisual world from an image, a prompt, and
+    Echo-WM's native pure-camera controls.
+  resources:
+    gpu:
+      type: NVIDIA_B200
+      count: 1
+    cpu:
+      request: "8"
+      limit: "16"
+    memory:
+      request: 64Gi
+      limit: 160Gi
+
+runtime:
+  import: echo_wm:EchoWM
+  config: echo_wm.yaml
+  # Source, checkpoints, downloads, uploads, and compiled kernels stay here.
+  weights_path: ~/.cache/reactor_registry/echo-wm-flash
+
+build:
+  runtime_version: "3.2.3"
+  python_requirements: requirements.txt
+  cuda_version: "12.8.1"
+  python_version: "3.12"
+  system_packages:
+    - build-essential
+    - ffmpeg
+    - git
+    - libgl1
+    - libglib2.0-0
+    - libsndfile1
+  runtime_env:
+    PYTORCH_ALLOC_CONF: expandable_segments:True
+  # CuTe declares protobuf<7, while Runtime 3.2.3 requires protobuf>=7.35.1.
+  # Both execute with 7.35.1, so restore Runtime's supported wire dependency.
+  run:
+    - pip install --no-cache-dir "flash-attn-4==4.0.0b26"
+    - pip install --no-cache-dir --no-deps "protobuf==7.35.1"
+
+recording:
+  enabled: true
+  chunk_seconds: 4
+  clip_max_seconds: 300
+  video_track: main_video
+  audio_track: main_audio
+  video:
+    codec: h264
+    preset: veryfast
+    crf: 23
+  audio:
+    codec: aac
+    bitrate_kbps: 192

--- a/models/echo-wm/requirements.txt
+++ b/models/echo-wm/requirements.txt
@@ -1,0 +1,22 @@
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+torch==2.9.1
+torchaudio==2.9.1
+torchvision==0.24.1
+transformers>=4.52,<5.0
+accelerate
+av
+einops
+huggingface-hub<1.0
+imageio
+imageio-ffmpeg
+numpy
+omegaconf
+opencv-python-headless
+pillow
+protobuf==7.35.1
+pyyaml
+safetensors
+scipy>=1.14
+sentencepiece
+tqdm

--- a/models/echo-wm/tests/test_echo_wm.py
+++ b/models/echo-wm/tests/test_echo_wm.py
@@ -31,9 +31,7 @@ def test_public_contract_is_atomic_and_audiovisual() -> None:
         "set_camera_motion",
         "set_fov",
         "set_image",
-        "set_paused",
         "set_prompt",
-        "step",
     }
     assert EchoWM.fps == 24
     assert EchoWM.buffer_size == 24
@@ -206,8 +204,8 @@ def test_inference_yields_one_synchronized_native_chunk(tmp_path: Path) -> None:
     assert model.state.paused is True
 
 
-def test_paused_image_reset_queues_two_preview_chunks() -> None:
-    """Queue two chunks for visual confirmation when an image changes while paused."""
+def test_rollout_reset_flushes_pending_media() -> None:
+    """Discard queued media when a fresh rollout replaces the active world."""
 
     class FakeOutput:
         def __init__(self) -> None:
@@ -218,13 +216,12 @@ def test_paused_image_reset_queues_two_preview_chunks() -> None:
 
     model = EchoWM()
     model.state = EchoWMState()
-    model.state.paused = True
     output = FakeOutput()
     model.output = cast(Any, output)
 
-    model._request_reset(preview_steps=2)
+    model._request_reset(preview_steps=0)
 
-    assert model.state._queued_steps == 2
+    assert model.state._queued_steps == 0
     assert model.state._reset_requested is True
     assert output.flushes == 1
 

--- a/models/echo-wm/tests/test_echo_wm.py
+++ b/models/echo-wm/tests/test_echo_wm.py
@@ -1,0 +1,277 @@
+"""Test Echo-WM's schema, camera fidelity, uploads, and chunk boundary."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+from reactor_runtime import CommandError, UploadedFile
+from reactor_runtime.interface.model.contract import ModelContract
+
+from echo_wm import EchoWM
+from echo_wm_assets import activate_source, read_config
+from echo_wm_attention import FlashAttention4, set_attention_backend
+from echo_wm_camera import EchoCameraPlanner, MotionConfig
+from echo_wm_images import validate_uploaded_image
+from echo_wm_schema import EchoWMOutput, EchoWMState
+
+
+def test_public_contract_is_atomic_and_audiovisual() -> None:
+    """Expose only explicit controls and both generated media tracks."""
+    contract = ModelContract.of(EchoWM)
+    assert set(contract.commands) == {
+        "random_image",
+        "release_camera",
+        "reset",
+        "set_camera_motion",
+        "set_fov",
+        "set_image",
+        "set_paused",
+        "set_prompt",
+        "step",
+    }
+    assert EchoWM.fps == 24
+    assert EchoWM.buffer_size == 24
+    assert EchoWMState().paused is False
+    assert set(EchoWMOutput.__tracks__) == {"main_video", "main_audio"}
+    assert EchoWMOutput.__tracks__["main_audio"].rate == 48_000
+
+
+def test_camera_chunks_match_upstream_integration() -> None:
+    """Match the released DSL across controls that change between chunks."""
+    config_path = Path(__file__).parents[1] / "echo_wm.yaml"
+    activate_source(read_config(config_path))
+    from helpers.action_camera import action_string_to_c2w
+
+    config = MotionConfig(
+        fps=24.0,
+        translation_speed=0.05,
+        rotation_speed_degrees=0.4,
+        pitch_speed_degrees=0.2,
+        pitch_limit_degrees=40.0,
+    )
+    planner = EchoCameraPlanner(config)
+    first = planner.plan_chunk(
+        forward=1.0,
+        strafe=0.0,
+        pitch=0.0,
+        yaw=-1.0,
+        frame_count=24,
+    )
+    second = planner.plan_chunk(
+        forward=0.0,
+        strafe=-1.0,
+        pitch=1.0,
+        yaw=0.0,
+        frame_count=24,
+    )
+    reference = action_string_to_c2w(
+        [["w", "j"]] * 24 + [["a", "i"]] * 24,
+        translation_speed=config.translation_speed,
+        rotation_speed_deg=config.rotation_speed_degrees,
+        pitch_speed_deg=config.pitch_speed_degrees,
+        pitch_limit_deg=config.pitch_limit_degrees,
+        fps=config.fps,
+    )
+    expected = reference[[8, 16, 24, 32, 40, 48]]
+    actual = np.concatenate([first.latent_poses, second.latent_poses])
+    np.testing.assert_allclose(actual, expected, atol=1e-6)
+
+
+def test_upload_validation_checks_bytes_and_codec(tmp_path: Path) -> None:
+    """Accept a real image and reject bytes disguised as an image."""
+    image_path = tmp_path / "anchor.png"
+    Image.new("RGB", (32, 32), (10, 20, 30)).save(image_path)
+    validate_uploaded_image(
+        UploadedFile(
+            name=image_path.name,
+            mime_type="image/png",
+            data=image_path.read_bytes(),
+        )
+    )
+    with pytest.raises(CommandError):
+        validate_uploaded_image(
+            UploadedFile(
+                name="fake.png",
+                mime_type="image/png",
+                data=b"not an image",
+            )
+        )
+
+
+def test_blank_upload_prompt_uses_configured_default(tmp_path: Path) -> None:
+    """Use the configured image-neutral default for a blank upload prompt."""
+    image_path = tmp_path / "anchor.png"
+    Image.new("RGB", (32, 32), (10, 20, 30)).save(image_path)
+    config = read_config(Path(__file__).parents[1] / "echo_wm.yaml")
+    model = EchoWM()
+    model.state = EchoWMState()
+    model.state.prompt = "Prompt paired with the previously selected image."
+    model._config = config
+    model._seed = config.seed
+
+    message = asyncio.run(
+        model.set_image(
+            UploadedFile(
+                name=image_path.name,
+                mime_type="image/png",
+                data=image_path.read_bytes(),
+            ),
+            prompt="   ",
+            seed=-1,
+        )
+    )
+
+    assert model.state.prompt == config.default_upload_prompt
+    assert message.prompt == config.default_upload_prompt
+    assert "previously selected" not in message.prompt
+
+
+def test_inference_yields_one_synchronized_native_chunk(tmp_path: Path) -> None:
+    """Bind one backend call to one batched audio-video Reactor output."""
+
+    class FakeBackend:
+        def __init__(self) -> None:
+            self.reset_calls = 0
+            self.chunk_calls = 0
+
+        def reset(self, **_: object) -> None:
+            self.reset_calls += 1
+
+        def generate_chunk(
+            self, *_: object, **__: object
+        ) -> tuple[np.ndarray, np.ndarray]:
+            self.chunk_calls += 1
+            return (
+                np.zeros((25, 704, 1280, 3), dtype=np.uint8),
+                np.zeros((1, 50_000), dtype=np.int16),
+            )
+
+        @property
+        def last_profile(self) -> dict[str, float]:
+            return {
+                "denoise_seconds": 0.1,
+                "cache_commit_seconds": 0.02,
+                "video_decode_seconds": 0.03,
+                "audio_decode_seconds": 0.04,
+                "cuda_total_seconds": 0.19,
+            }
+
+        def end_session(self, *, release_cuda_cache: bool = True) -> None:
+            return
+
+    config_path = Path(__file__).parents[1] / "echo_wm.yaml"
+    config = read_config(config_path)
+    model = EchoWM()
+    model.state = EchoWMState()
+    model._config = config
+    model._backend = FakeBackend()
+    model._planner = EchoCameraPlanner(
+        MotionConfig(
+            fps=config.fps,
+            translation_speed=config.translation_speed,
+            rotation_speed_degrees=config.rotation_speed_degrees,
+            pitch_speed_degrees=config.pitch_speed_degrees,
+            pitch_limit_degrees=config.pitch_limit_degrees,
+        )
+    )
+    model._selected_image = tmp_path / "anchor.png"
+    model.state.prompt = "A quiet room with distant music."
+    model.state._reset_requested = True
+    model.state.paused = True
+    model.state._queued_steps = 2
+    model._seed = 42
+
+    async def generate() -> tuple[EchoWMOutput, EchoWMOutput]:
+        outputs = model.inference()
+        first = await anext(outputs)
+        second = await anext(outputs)
+        assert isinstance(first, EchoWMOutput)
+        assert isinstance(second, EchoWMOutput)
+        return first, second
+
+    output, _ = asyncio.run(generate())
+    video = cast(np.ndarray, output.main_video)
+    audio = cast(np.ndarray, output.main_audio)
+    assert video.shape == (25, 704, 1280, 3)
+    assert audio.shape == (1, 50_000)
+    assert model._backend.reset_calls == 1
+    assert model._backend.chunk_calls == 2
+    assert model.state._queued_steps == 0
+    assert model.state.paused is True
+
+
+def test_paused_image_reset_queues_two_preview_chunks() -> None:
+    """Queue two chunks for visual confirmation when an image changes while paused."""
+
+    class FakeOutput:
+        def __init__(self) -> None:
+            self.flushes = 0
+
+        def flush(self) -> None:
+            self.flushes += 1
+
+    model = EchoWM()
+    model.state = EchoWMState()
+    model.state.paused = True
+    output = FakeOutput()
+    model.output = cast(Any, output)
+
+    model._request_reset(preview_steps=2)
+
+    assert model.state._queued_steps == 2
+    assert model.state._reset_requested is True
+    assert output.flushes == 1
+
+
+def test_flash_attention_4_preserves_masked_upstream_path() -> None:
+    """Use FA4 only where its unmasked call represents upstream semantics."""
+    calls: list[str] = []
+
+    def flash(query: torch.Tensor, *_: torch.Tensor) -> torch.Tensor:
+        calls.append("flash")
+        return query
+
+    def fallback(*_: object) -> torch.Tensor:
+        calls.append("pytorch")
+        return torch.ones((1, 2, 8), dtype=torch.bfloat16)
+
+    attention = FlashAttention4(flash, fallback, torch)
+    query = torch.arange(16, dtype=torch.bfloat16).reshape(1, 2, 8)
+    key = torch.zeros((1, 3, 8), dtype=torch.bfloat16)
+    value = torch.zeros((1, 3, 8), dtype=torch.bfloat16)
+    unmasked = attention(query, key, value, heads=2)
+    masked = attention(query, key, value, heads=2, mask=torch.ones((2, 3)))
+
+    torch.testing.assert_close(unmasked, query)
+    torch.testing.assert_close(masked, torch.ones_like(query))
+    assert calls == ["flash", "pytorch"]
+
+
+def test_attention_backend_changes_only_upstream_attention_modules() -> None:
+    """Patch each selected attention module and leave unrelated modules intact."""
+
+    class Selected(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.attention_function: object = "before"
+
+    root = torch.nn.Sequential(Selected(), torch.nn.Linear(2, 2), Selected())
+    callable_backend = object()
+    changed = set_attention_backend(root, callable_backend, Selected)
+
+    assert changed == 2
+    assert cast(Selected, root[0]).attention_function is callable_backend
+    assert cast(Selected, root[2]).attention_function is callable_backend
+
+
+def test_video_decode_tiling_is_disabled_for_b200() -> None:
+    """Decode each visible chunk directly when the requested B200 has ample memory."""
+    config = read_config(Path(__file__).parents[1] / "echo_wm.yaml")
+
+    assert config.video_decode_tiling is False


### PR DESCRIPTION
## Why

  Echo-WM is an autoregressive audiovisual world model that benefits from Reactor’s interactive, chunk-based serving
  model. This integration makes its native image, prompt, camera, video, and audio capabilities directly playable
  through Reactor.

  ## What Changed

  This PR adapts Echo-WM’s causal inference loop to Reactor while preserving its bounded video and audio KV caches
  across turns. Each action generates one synchronized audiovisual chunk, with support for image uploads, prompts, four-
  axis camera motion, field-of-view control, pause, step, reset, and automatic long-session rollover.

  It also introduces an interactive example with keyboard and touch controls, scene selection, image
  upload, prompt editing, rollout controls, model messages, and synchronized video/audio playback.

  Inference is optimized for B200 serving with FlashAttention 4, startup warmup and validation, persistent model assets,
  and direct full-window VAE decoding. The reactor.yaml workspace defines the complete Runtime 3.2.3 build, deployment
  resources, recording configuration, and persistent weight storage.