### PR TITLE
Add the FastH3 continuous video and audio channel

### DIFF
--- a/models/fasth3/.dockerignore
+++ b/models/fasth3/.dockerignore
@@ -1,0 +1,21 @@
+# Python caches and local environments
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.venv/
+venv/
+
+# Editor and operating-system state
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Source-control metadata and local model assets
+.git/
+.gitignore
+weights/
+

--- a/models/fasth3/README.md
+++ b/models/fasth3/README.md
@@ -1,0 +1,292 @@
+# FastH3
+
+An endless, prompt-driven video and audio channel. Set a prompt and the model
+streams 768p video with synchronized audio over WebRTC continuously, always
+building the next clip while the current one plays, so the stream never runs
+dry. Change the prompt live and the channel follows it.
+
+Reach for this when you want a *channel* rather than a file: a always-on
+backdrop, a live visual that responds to typed direction, a stream a room full
+of people watches together. If you want one finished clip returned to you, this
+is the wrong shape — the model never stops on its own.
+
+[FastH3 Preview v1](https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree)
+is MiniMax-H3 (35B) distilled by FastVideo with data-free DMD2 down to **four
+transformer forwards**, with 90% sparse video attention on Blackwell. It
+generates video and stereo audio jointly from text. Text-to-video-and-audio is
+the only task this checkpoint was distilled for; first/last-frame and reference
+conditioning are not.
+
+## Prerequisites
+
+- **Eight NVIDIA B200s.** Eight is load-bearing, not a performance preference:
+  sequence parallelism spans all of them, and a 15 s clip builds in 12.88 s on
+  eight against 15.5 s on four. Only the former is faster than the video plays,
+  which is the whole premise of a continuous channel.
+- **CUDA 13.** The VSA-H3 sparse kernel and the FA4 CuTe kernels are both cu130
+  builds, which is why this model's `build.cuda_version` differs from every
+  other model here.
+- **The weights bundle**, roughly 148 GB, placed under `runtime.weights_path`.
+  Nothing is downloaded at load — see below.
+
+## Weights
+
+One Hugging Face snapshot carries every component:
+
+```
+~/.cache/reactor_registry/fasth3/
+└── FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree/   # ~148 GB
+    ├── modular_model_index.json
+    ├── transformer/        # ~70 GB, the 35B DiT
+    ├── text_encoder/       # ~69 GB, Qwen3-VL
+    ├── vae/  audio_vae/
+    ├── scheduler/  audio_scheduler/
+    └── tokenizer/  processor/
+```
+
+FastVideo resolves each component as a subdirectory of `model_path` and ignores
+the repo ids inside `modular_model_index.json`, so the bundle loads fully
+offline — which is what `HF_HUB_OFFLINE=1` in the manifest relies on. `load()`
+checks every component directory up front, so an incomplete bundle stops
+startup rather than surfacing as a loader traceback on the first clip.
+
+## Run it
+
+```sh
+# Render the client-facing contract — no weights, no GPU.
+python -m reactor_runtime.schema --path . --out /tmp/schema.json
+
+# The CPU-only structural tests.
+PYTHONPATH=. python -m pytest tests/ -q
+
+# Build the image and serve (needs the weights and eight GPUs).
+reactor build
+reactor run
+```
+
+`load()` warms one throwaway clip per shape before the pod reports ready, so the
+first real clip streams at warm speed. Every distinct frame count and canvas is
+a separate one-time cost, which is why `inference.warmup_aspects` in
+[`fasth3.yaml`](./fasth3.yaml) is a deliberately short list.
+
+Before blaming the adapter for a slow channel, baseline the recipe itself with
+FastVideo's own `examples/inference/basic/basic_fasth3.py` at the same settings.
+Its median is the number this model should match; a gap is the adapter's fault,
+not the model's.
+
+## Tracks
+
+| Track | Direction | Kind | Rate | Payload |
+|---|---|---|---|---|
+| `main_video` | out | video | 24 fps, fixed | RGB frames at the session's canvas, e.g. 1344×768 |
+| `main_audio` | out | audio | 48 kHz | Mono, synchronized frame-for-frame with `main_video` |
+
+There are no inbound tracks: the model reads no camera and no microphone. The
+video size is fixed for the life of a channel — `set_canvas` chooses it and is
+only accepted while the channel is idle, so the track never changes size
+mid-stream.
+
+## Commands
+
+| Command | Parameters | Effect | Rejected with |
+|---|---|---|---|
+| `set_prompt` | `prompt` (≤ 800 chars) | Sets what the channel shows. Empty clears it. Replies `prompt_accepted`. | — |
+| `set_clip_seconds` | `seconds` (5.167–14.375) | Sets clip length; the value is snapped to what the model can produce and the effective one is returned in `clip_length_accepted`. | — |
+| `set_seed` | `seed` (≥ 0) | Seed the next channel starts from; each clip advances it by one. Replies `seed_accepted`. | — |
+| `set_canvas` | `aspect` (`16:9`, `1:1`, `9:16`, `4:3`) | Sets the video size for the session. Replies `canvas_accepted`. | `channel_running`, `unsupported_aspect` |
+| `start` | — | Begins the channel. Emits `channel_started`, then streams. | `already_running`, `missing_prompt` |
+| `pause` | — | Freezes playout. Replies `channel_paused`. | `not_running`, `already_paused` |
+| `resume` | — | Continues playout. Replies `channel_resumed`. | `not_paused` |
+| `stop` | — | Ends the channel, keeping every condition. Emits `channel_stopped`. | `not_running` |
+| `reset` | — | Returns every condition to its default and clears the stream. Replies `channel_reset`. | — |
+| `get_state` | — | Replies with the full `state_update` snapshot. | — |
+
+A rejected command has no effect. Rejections carry a stable `code` (the values
+above) plus a readable message, so a client can branch on the code.
+
+`stop` halts the stream within about a second. The clip already being built
+cannot be cancelled, so the model can take several more seconds to go fully
+idle; `state_update` reports `running: false` when it has.
+
+## Messages
+
+| Message | Reaches | When |
+|---|---|---|
+| `state_update` | everyone | On connect, and after every change. A complete snapshot — render from this alone. |
+| `prompt_accepted` | the caller | Reply to `set_prompt`. Carries where the prompt lands. |
+| `clip_length_accepted` | the caller | Reply to `set_clip_seconds`. Carries the snapped value. |
+| `seed_accepted` | the caller | Reply to `set_seed`. |
+| `canvas_accepted` | the caller | Reply to `set_canvas`. Carries the exact pixel size. |
+| `channel_started` | everyone | `start` accepted. No frames yet. |
+| `clip_started` | everyone | A clip begins streaming — this is where the picture and sound cut. |
+| `clip_complete` | everyone | A clip has been fully sent. |
+| `channel_paused` / `channel_resumed` | the caller | Replies to `pause` / `resume`. |
+| `channel_stopped` | everyone | The channel ended via `stop`. |
+| `channel_failed` | everyone | The channel ended early because something went wrong; the model returns to idle. |
+| `channel_reset` | the caller | Reply to `reset`. |
+
+Anywhere a prompt appears on the wire — `state_update.prompt`,
+`prompt_accepted.prompt` — **"not set" is `null`, never an empty string**, so a
+client can test one thing rather than two.
+
+## Session lifecycle
+
+```
+  session starts (no clients yet)
+    |
+    v
+  client connects            -> state_update (a full snapshot, to this client)
+    |
+  ┌──────────────────────────────────────────────────────────────┐
+  │ IDLE                                                         │
+  │ Valid: set_prompt, set_clip_seconds, set_seed, set_canvas,   │
+  │        reset, get_state, and start once a prompt is set      │
+  │ No frames on either track                                    │
+  └───────────────────────────┬──────────────────────────────────┘
+                              v  start
+  ┌──────────────────────────────────────────────────────────────┐
+  │ BUILDING THE FIRST CLIP                                      │
+  │ channel_started is emitted immediately; NO frames yet        │
+  │ Lasts several seconds — show progress, not a stalled player  │
+  └───────────────────────────┬──────────────────────────────────┘
+                              v
+  ┌──────────────────────────────────────────────────────────────┐
+  │ STREAMING                                                    │
+  │ Valid: set_prompt, set_clip_seconds, set_seed, pause/resume, │
+  │        stop, reset, get_state                                │
+  │ Messages: clip_started, clip_complete, state_update          │
+  │ Tracks: main_video + main_audio, continuously                │
+  └───────────────────────────┬──────────────────────────────────┘
+                              v  stop / reset / last client leaves
+                        (back to IDLE)
+```
+
+**Single session, shared state.** Several clients may watch one session, and
+they all see the same channel: a `set_prompt` or a `stop` from any client
+affects everyone, and every client receives every `state_update`. Generation is
+gated on having an audience — when the last client leaves the channel winds down
+at the next clip boundary, so nothing is generated with nobody watching.
+
+A prompt is required before `start`; everything else has a default.
+
+## What to expect from the timing
+
+Two numbers matter, and they are different things:
+
+- **Time to first frame.** Nothing streams until the first clip is fully built.
+  The channel deliberately opens with a *shorter* clip (`inference.ramp_seconds`),
+  which builds proportionally faster, so this is a few seconds rather than a
+  full clip build. `channel_started` fires immediately and carries
+  `first_clip_seconds`; treat it as the cue to show progress.
+- **Steady state.** From then on the model builds faster than the video plays,
+  so the stream should not stall. If the hardware cannot keep up, the symptom is
+  a brief freeze at a clip boundary, not a dropped or corrupted stream. `seam
+  late` in the log is the gate: it fires when a clip was not ready by the time
+  its predecessor ran out, and a clean multi-hour run should never print it. The
+  levers, in order, are longer clips, regional compile, and replicated rather
+  than sharded weights.
+
+Output is a strict 24 fps metronome and the audio is sample-clocked against the
+same rate, so the two tracks stay locked over hours. `pause` freezes the stream
+within about an eighth of a second; the model keeps building ahead while paused,
+so `resume` continues instantly rather than skipping forward to catch up.
+
+## Clip boundaries are hard cuts
+
+Every clip is generated independently. **The picture and the sound cut at each
+boundary** — there is no continuity of subject, framing, or voice from one clip
+to the next, even with the prompt unchanged. `clip_started` marks each cut, so a
+UI can anticipate it.
+
+This checkpoint has no continuation path, and inventing one is not an adapter's
+decision. It is why [`fasth3.yaml`](./fasth3.yaml) defaults to the longest clip
+the model supports, and why `runtime.recording` is left disabled: a recording
+would carry those cuts too.
+
+The geometry it accepts is narrow, and [`fasth3_clip_plan.py`](./fasth3_clip_plan.py)
+encodes it: 24 fps, a frame count of the form `17n + 5`, a duration between 5
+and 15 seconds, a short edge of 768, at most 768×1344 pixels, and both sides a
+multiple of 32. The duration cap has a sharp edge — 15.0 s is 360 frames, which
+aligns *up* to 362 (15.083 s) and is then rejected, so **the longest clip this
+model can make is 345 frames, 14.375 s**.
+
+## Changing the prompt mid-channel
+
+The model is always one clip ahead. When clip *k* is playing, clip *k+1* has
+already been built with the prompt as it stood earlier, so a prompt sent now
+first appears on clip *k+2*.
+
+You never have to work this out. Both `prompt_accepted` and `state_update` carry
+`prompt_effective_clip_index` (the clip this prompt will first appear on) and
+`prompt_effective_in_seconds` (how much already-built video plays before it).
+Render the second one directly — "new prompt in ~21 s". Shorter clips
+(`set_clip_seconds`) shorten this wait, at the cost of cutting more often.
+
+## Determinism
+
+`set_seed` fixes the seed the channel starts from, and each clip advances it by
+one, so the same seed with the same prompt, clip length and canvas reproduces
+the same sequence of clips. Reproduction is approximate rather than bit-exact:
+the deployment runs fused and compiled kernels that can reorder floating-point
+operations.
+
+## Notes on the code
+
+**`ReactorModel`, not `ReactorPipeline`.** The generator base is shaped for
+frame-per-step models, where a `yield` is the natural unit of work. Here the
+unit is a whole clip produced by one blocking call, so the generator would buy
+nothing and cost the usual workarounds — `pause` holding by yielding `Idle`,
+polling the handoff with `get_nowait()`, and session state living in a
+runtime-built `InputState`. Under `ReactorModel`, command handlers and lifecycle
+hooks run on background coroutines *concurrent* with `run()`, so:
+
+- session state is plain attributes reset in `_reset_session_state`, called from
+  `@session_started` (not `@connected`: a client rejoining mid-session keeps the
+  channel it joined);
+- one persistent worker thread serialises every clip and gives teardown a single
+  handle to wait on;
+- refusals and accepts answer immediately, even mid-build.
+
+**The lookahead is exactly one clip.** `_run_channel` submits clip *k+1* the
+moment clip *k* is dequeued, then paces clip *k* out at a strict 24 fps while
+*k+1* builds. The handoff is a `Queue(maxsize=1)`, which is what bounds it —
+deeper would only bury prompt changes further behind.
+
+**Refusals are broadcast, not raised.** A handler returns only the message its
+annotation names and reports failure by broadcasting `command_error`. A raised
+runtime `CommandError` has its failure frame withheld from v0 clients, so the
+broadcast is what reaches every SDK generation.
+
+**Nothing is vendored.** FastVideo is a published package, so the whole upstream
+tree arrives through `requirements.txt` and an upgrade is a one-line bump.
+
+## Layout
+
+| Path | What it is |
+|---|---|
+| `fasth3.py` | The `ReactorModel`: weight loading, commands, and the `run()` loop |
+| `fasth3_types.py` | Everything a client sees — output tracks and messages |
+| `fasth3_clip_plan.py` | Clip geometry: valid lengths, frame counts, canvases |
+| `fasth3_session_rules.py` | Which commands each session state accepts |
+| `fasth3.yaml` | `inference:` the generation recipe, `runtime:` weight layout and engine shape |
+| `reactor.yaml` | The manifest: identity, version, resources, runtime, image build |
+| `tests/` | Structural tests that need no GPU |
+
+## Open questions for bring-up
+
+- **Host memory.** Every rank loads its own text encoder, so CPU-offloading it
+  across eight ranks would want several hundred GB of host memory *and* pay a
+  transfer per clip. `fasth3.yaml` therefore keeps it resident on the GPU, which
+  the FSDP-sharded transformer leaves room for. Confirm against measured VRAM
+  before changing either flag, and re-size `resources.memory` in the manifest
+  from what real hardware uses — the values there are an opening estimate.
+- **Post-decode cost.** Asking FastVideo for frames in memory
+  (`return_frames=True`) also allocates a full fp32 mirror of the decoded video
+  and copies into it — several GB per clip that nothing reads, on top of the
+  uint8 conversion that is actually needed. The per-clip log line carries the
+  stage timings; if `PostDecodeFrameProcessStage` eats the channel's slack, the
+  fix belongs upstream in FastVideo rather than here.
+- **The dependency closure is not yet exact.** `requirements.txt` lists what the
+  model's own code needs and leaves torchvision/torchaudio to the cu130 index.
+  Regenerate it from a `pip freeze` of the first successfully built image so a
+  rebuild is byte-comparable.

--- a/models/fasth3/fasth3.py
+++ b/models/fasth3/fasth3.py
@@ -1,0 +1,1230 @@
+"""FastH3 as a Reactor platform model: an endless, prompt-driven A/V channel.
+
+FastH3 is MiniMax-H3 distilled to four transformer forwards, and on eight
+Blackwell GPUs it builds video faster than the video plays. This model turns
+that into a continuous stream: it always builds the next clip while the current
+one is on the wire, so `main_video` and `main_audio` never run dry.
+
+The unit of work is a whole clip, not a frame, which is why this subclasses
+``ReactorModel`` and owns its own ``run()`` loop rather than using
+``ReactorPipeline``. Command handlers then run on their own coroutines
+concurrent with ``run()``, so `pause` and `stop` answer immediately even while a
+clip is being built.
+
+Layout:
+  * ``fasth3_types.py``        — everything a client sees (tracks and messages).
+  * ``fasth3_clip_plan.py``    — clip geometry (lengths, frame counts, canvases).
+  * ``fasth3_session_rules.py`` — which commands each state accepts.
+  * ``fasth3.yaml``            — the generation recipe and the weight layout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import queue
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+from reactor_runtime import (
+    ClientInfo,
+    InputField,
+    ReactorModel,
+    connected,
+    event,
+    get_weights_path,
+    session_ended,
+    session_started,
+)
+from reactor_runtime.log import get_logger
+
+import fasth3_clip_plan as clip_plan
+import fasth3_session_rules as session_rules
+from fasth3_types import (
+    MAX_PROMPT_CHARS,
+    CanvasAccepted,
+    ChannelFailed,
+    ChannelPaused,
+    ChannelReset,
+    ChannelResumed,
+    ChannelStarted,
+    ChannelStopped,
+    ClipComplete,
+    ClipLengthAccepted,
+    ClipStarted,
+    CommandError,
+    FastH3Output,
+    PromptAccepted,
+    SeedAccepted,
+    StateUpdate,
+)
+
+logger = get_logger(__name__)
+
+FRAME_RATE = clip_plan.FPS
+
+# The clip-length range, rendered once so the command text and the schema's own
+# bounds can never disagree.
+_CLIP_RANGE = f"{clip_plan.MIN_SECONDS_PUBLISHED:g} and {clip_plan.MAX_SECONDS_PUBLISHED:g}"
+
+# WebRTC-native rate every clip's waveform is resampled to. The checkpoint's
+# audio decoder is 32 kHz; the wire is 48 kHz.
+OUTPUT_SAMPLE_RATE = 48_000
+NATIVE_SAMPLE_RATE = 32_000
+
+# Frames per emitted slice. The runtime recorder's feed queue cannot absorb
+# one-second bursts, and the emitter is a metronome either way, so smaller
+# slices cost nothing.
+EMIT_FRAMES = 3
+
+# How often the arm loop and the pause hold re-check. Both run on the event
+# loop, so this is a scheduling granularity, not a busy-wait.
+POLL_SECONDS = 0.05
+WORKER_POLL_SECONDS = 0.1
+
+# What the warm-up builds. Never reaches a client: warm-up output is discarded,
+# and its only job is to be a syntactically ordinary prompt.
+WARMUP_PROMPT = "A slow cinematic shot of sunlight moving across a quiet room."
+
+# The HF snapshot directory inside the weights bundle.
+DEFAULT_CHECKPOINT_DIR = "FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree"
+
+# Component directories the T2VA pipeline loads. An incomplete bundle must kill
+# startup, not surface as a loader traceback on the first clip.
+REQUIRED_COMPONENTS = (
+    "transformer",
+    "text_encoder",
+    "tokenizer",
+    "processor",
+    "vae",
+    "audio_vae",
+    "scheduler",
+    "audio_scheduler",
+)
+
+
+class _ChannelStopped(Exception):
+    """Internal: the generation worker noticed the channel should wind down."""
+
+
+class _Job:
+    """One unit of work for the generation worker, and its outcome.
+
+    The error is carried back rather than only logged: ``load()`` waits on the
+    warm-up through this, and a warm-up that failed silently would let the pod
+    report ready and then die on its first real clip.
+    """
+
+    __slots__ = ("done", "error", "fn")
+
+    def __init__(self, fn) -> None:
+        self.fn = fn
+        self.done = threading.Event()
+        self.error: BaseException | None = None
+
+
+def _require_weights(root: Path, model_path: Path) -> None:
+    """Fail startup loudly when the weights bundle is incomplete."""
+    problems: list[str] = []
+    if not model_path.is_dir():
+        problems.append(f"checkpoint directory is missing: {model_path}")
+    else:
+        index = model_path / "modular_model_index.json"
+        if not index.is_file():
+            problems.append(f"modular_model_index.json is missing: {index}")
+        for component in REQUIRED_COMPONENTS:
+            if not (model_path / component).is_dir():
+                problems.append(f"component directory is missing: {model_path / component}")
+    if problems:
+        raise FileNotFoundError(
+            f"FastH3 weights bundle under {root} is incomplete:\n  " + "\n  ".join(problems)
+        )
+
+
+class FastH3(ReactorModel):
+    """Stream an endless video-and-audio channel from a text prompt."""
+
+    # Pinned: `_emit_paced` is a strict 24 fps metronome and every emit omits
+    # `compute_time`, which is exactly the "unmeasured" path this rate tags.
+    # Measuring instead re-estimates the rate from observed timing, whose wobble
+    # both drops chunks while converging and drifts video against the
+    # sample-clocked audio.
+    fps = FRAME_RATE
+    # Two seconds of transport-side tolerance at 24 fps, so a clip that lands
+    # late dents the buffer instead of dropping frames.
+    buffer_size = 48
+
+    # ------------------------------------------------------------------ load
+
+    def load(self, config_path: Path | None) -> None:
+        """Build the eight-GPU generator and warm every clip shape.
+
+        Runs once at startup, before any session. The runtime marks the pod
+        ready only when this returns, so the warm-up below means a deployed pod
+        never serves a cold clip.
+
+        Args:
+            config_path: Path to ``fasth3.yaml``; its ``inference`` block is the
+                generation recipe and its ``runtime`` block holds the weight
+                layout and the engine shape.
+        """
+        document: dict[str, Any] = {}
+        if config_path is not None:
+            document = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        self.inference_cfg: dict[str, Any] = document.get("inference") or {}
+        runtime: dict[str, Any] = document.get("runtime") or {}
+        self.runtime_cfg = runtime
+
+        self.default_aspect = str(self.inference_cfg.get("aspect", "16:9"))
+        if self.default_aspect not in clip_plan.ASPECT_CHOICES:
+            raise ValueError(
+                f"inference.aspect must be one of {list(clip_plan.ASPECT_CHOICES)}, "
+                f"got {self.default_aspect!r}"
+            )
+        self.default_clip_frames = clip_plan.frames_for_seconds(
+            float(self.inference_cfg.get("clip_seconds", clip_plan.MAX_SECONDS))
+        )
+        # Time-to-first-frame ramp: the channel opens with these clip lengths
+        # before settling on the steady one. Each entry is a distinct shape the
+        # warm-up must cover, so keep the list short. An empty list means a
+        # uniform cadence from clip zero.
+        self.ramp_frames = clip_plan.parse_ramp(
+            self.inference_cfg.get("ramp_seconds", [clip_plan.MIN_SECONDS])
+        )
+        self.default_seed = int(self.inference_cfg.get("seed", 1000))
+        # Sigma-grid POINTS, not transformer forwards: the distilled schedule is
+        # five points and exactly four forwards.
+        self.num_inference_steps = int(self.inference_cfg.get("num_inference_steps", 5))
+
+        # Must happen before the generator is built: the engine spawns worker
+        # processes, which inherit os.environ, and these select the attention
+        # backend and the sparse kernel.
+        self._apply_profile_environment()
+        self._validate_profile_dependencies()
+
+        weights = get_weights_path()
+        self.model_path = weights / str(runtime.get("checkpoint_dir", DEFAULT_CHECKPOINT_DIR))
+        _require_weights(weights, self.model_path)
+
+        self.num_gpus = int(runtime.get("num_gpus", 8))
+        logger.info(
+            "building fasth3 generator",
+            model_path=str(self.model_path),
+            num_gpus=self.num_gpus,
+            clip_frames=self.default_clip_frames,
+            ramp=list(self.ramp_frames),
+        )
+
+        from fastvideo import VideoGenerator
+
+        self.generator = VideoGenerator.from_config(self._generator_config())
+
+        # Session-scoped state. A ReactorPipeline would get a fresh `self.state`
+        # per session from the runtime; a ReactorModel owns that itself, so the
+        # defaults live in one reset function called here (so a command racing
+        # ahead of `session_started` reads defaults, never another session's
+        # values) and again from the `@session_started` hook.
+        self._reset_session_state()
+
+        # One persistent worker thread runs every clip. The GPU work itself
+        # lives in the spawned engine processes; this thread exists to serialise
+        # submissions and to give teardown a single handle to wait on.
+        self._jobs: queue.Queue = queue.Queue()
+        self._worker = threading.Thread(
+            target=self._worker_loop, name="fasth3-generation", daemon=True
+        )
+        self._worker.start()
+        self._preload_native_imports()
+        self._run_on_worker(self._warmup)
+        logger.info("fasth3 loaded")
+
+    @staticmethod
+    def _preload_native_imports() -> None:
+        """Touch every deferred native import the emit path needs.
+
+        ``_to_wire_audio`` and ``_emit_paced`` import torch, torchaudio and
+        numpy lazily so that rendering the schema needs none of them. Lazy means
+        the first import happens on the first real clip — after load, after
+        warm-up, after the pod reports ready — where a linkage failure is a dead
+        session rather than a startup error. The resample below is a real call,
+        so it fails here or not at all.
+        """
+        import numpy  # noqa: F401
+        import torch
+        import torchaudio.functional as AF
+
+        AF.resample(torch.zeros(2, NATIVE_SAMPLE_RATE // 10), NATIVE_SAMPLE_RATE, OUTPUT_SAMPLE_RATE)
+
+    # --------------------------------------------------------------- profile
+
+    def _apply_profile_environment(self) -> None:
+        """Set the FastH3 profile environment, exactly as the reference CLI does.
+
+        Mirrors ``examples/inference/basic/basic_fasth3.py:profile_environment``.
+        Values are explicit even for disabled features, so a shell's inherited
+        experiment settings cannot silently change the profile a pod serves.
+        """
+        cfg = self.inference_cfg
+        vsa_kernel = str(cfg.get("vsa_kernel", "sm100a"))
+        fusions = "all" if bool(cfg.get("h3_fusions", True)) else "0"
+        environment: dict[str, str | None] = {
+            "FASTVIDEO_ATTENTION_BACKEND": "VIDEO_SPARSE_ATTN_H3",
+            "FASTVIDEO_VSA_SM100A": "1" if vsa_kernel == "sm100a" else "0",
+            "FASTVIDEO_VSA_CUTEDSL": "0",
+            # A non-empty path enables the diagnostic probe; it must stay unset.
+            "FASTVIDEO_H3_VSA_PROBE": None,
+            "FASTVIDEO_DISABLE_ATTENTION_COMPILE": "0",
+            "FASTVIDEO_FA4": "1" if bool(cfg.get("fa4", True)) else "0",
+            "FASTVIDEO_NVFP4_FA4": "0",
+            "FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN": "0",
+            "FASTVIDEO_MINIMAX_H3_FUSIONS": fusions,
+            "FASTVIDEO_INFERENCE_TORCH_COMPILE": (
+                "1" if bool(cfg.get("inference_torch_compile", True)) else "0"
+            ),
+            "FASTVIDEO_VAE_PARALLEL_DECODE": (
+                "1" if bool(cfg.get("vae_parallel_decode", True)) else "0"
+            ),
+            "FASTVIDEO_VAE_PARALLEL_ENCODE": "0",
+            "FASTVIDEO_VAE_PARALLEL_DECODE_STRATEGY": "gather",
+            "FASTVIDEO_ULYSSES_A2A": str(cfg.get("ulysses_a2a", "off")),
+            "FASTVIDEO_STAGE_LOGGING": "1",
+        }
+        for name, value in environment.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        logger.info("fasth3 profile", **{k: (v or "<unset>") for k, v in environment.items()})
+
+    def _validate_profile_dependencies(self) -> None:
+        """Fail before the 148 GB load when the selected fast route is absent."""
+        import importlib.util
+
+        cfg = self.inference_cfg
+        if bool(cfg.get("fa4", True)):
+            try:
+                present = importlib.util.find_spec("flash_attn.cute") is not None
+            except (ImportError, ModuleNotFoundError):
+                present = False
+            if not present:
+                raise RuntimeError(
+                    "FastH3's FA4 route needs the pinned flash-attn-4 package. Install it, "
+                    "or set inference.fa4: false in fasth3.yaml."
+                )
+        if str(cfg.get("vsa_kernel", "sm100a")) == "sm100a":
+            try:
+                from fastvideo_kernel import block_sparse_attn_sm100a
+            except ImportError:
+                present = False
+            else:
+                present = bool(getattr(block_sparse_attn_sm100a, "_HAS_VSA_SM100A", False))
+            if not present:
+                raise RuntimeError(
+                    "FastH3's sm100a route needs fastvideo-kernel built with the Blackwell VSA "
+                    "extension. Install a matching wheel, or set inference.vsa_kernel: triton."
+                )
+
+    def _generator_config(self):
+        """The engine shape, mirroring ``basic_fasth3.py:build_generator_config``."""
+        from fastvideo.api import (
+            CompileConfig,
+            ComponentConfig,
+            EngineConfig,
+            GeneratorConfig,
+            OffloadConfig,
+            ParallelismConfig,
+            PipelineSelection,
+        )
+
+        cfg = self.inference_cfg
+        runtime = self.runtime_cfg
+        num_gpus = int(runtime.get("num_gpus", 8))
+        # The checkpoint's own contract (fastvideo_inference.json) shards the
+        # transformer with FSDP. Sharding is what frees the VRAM to keep the
+        # text encoder resident, which is the deployment this model wants.
+        replicated_dit = bool(runtime.get("replicated_dit", False))
+        return GeneratorConfig(
+            model_path=str(self.model_path),
+            pipeline=PipelineSelection(
+                components=ComponentConfig(),
+                experimental={
+                    "attention_backend": "VIDEO_SPARSE_ATTN_H3",
+                    "VSA_sparsity": float(cfg.get("vsa_sparsity", 0.9)),
+                    "VSA_tile_size": int(cfg.get("vsa_tile_size", 64)),
+                    "inference_torch_compile": bool(cfg.get("inference_torch_compile", True)),
+                    "vae_parallel_decode": bool(cfg.get("vae_parallel_decode", True)),
+                    "vae_parallel_decode_strategy": "gather",
+                },
+            ),
+            engine=EngineConfig(
+                num_gpus=num_gpus,
+                use_fsdp_inference=num_gpus > 1 and not replicated_dit,
+                parallelism=ParallelismConfig(tp_size=1, sp_size=num_gpus),
+                offload=OffloadConfig(
+                    dit=False,
+                    dit_layerwise=False,
+                    text_encoder=bool(runtime.get("offload_text_encoder", False)),
+                    vae=bool(runtime.get("offload_vae", False)),
+                    pin_cpu_memory=bool(runtime.get("pin_cpu_memory", False)),
+                ),
+                compile=CompileConfig(
+                    enabled=False,
+                    mode=None,
+                    vae_enabled=bool(cfg.get("compile_vae", True)),
+                ),
+            ),
+        )
+
+    # ---------------------------------------------------------- gpu plumbing
+
+    def _worker_loop(self) -> None:
+        """Run submitted jobs, one at a time, forever.
+
+        The waiter is always released, even when the job died: a completion
+        event that never arrives is indistinguishable from a hang, and this
+        thread is the only one that will ever set it.
+        """
+        logger.info("generation worker ready")
+        while True:
+            job = self._jobs.get()
+            try:
+                job.fn()
+            except BaseException as error:  # noqa: BLE001 — handed to the waiter
+                job.error = error
+                logger.exception("generation worker job raised")
+            finally:
+                job.done.set()
+
+    def _submit(self, fn) -> _Job:
+        """Queue work on the generation worker and hand back its handle."""
+        job = _Job(fn)
+        self._jobs.put(job)
+        return job
+
+    def _run_on_worker(self, fn) -> None:
+        """Run work on the worker, block until it finishes, and re-raise its failure.
+
+        Used only by ``load()``. Blocking here is the point: the runtime marks
+        the pod ready when ``load()`` returns, so a failed warm-up has to stop
+        startup rather than being discovered by the first client.
+        """
+        job = self._submit(fn)
+        while not job.done.wait(timeout=WORKER_POLL_SECONDS):
+            pass
+        if job.error is not None:
+            raise job.error
+
+    # ------------------------------------------------------------- warm-up
+
+    def _warmup(self) -> None:
+        """Build one throwaway clip per shape, before the pod reports ready.
+
+        Every distinct frame count and canvas is a separate one-time cost —
+        regional compile, sparse-kernel autotune, allocator growth — and paying
+        it here means the first real clip streams at warm speed. Results are
+        discarded: `return_frames=False, save_video=False` skips the whole
+        post-decode path, so a warm-up costs generation time and nothing else.
+        """
+        aspects = self.inference_cfg.get("warmup_aspects") or [self.default_aspect]
+        shapes = list(dict.fromkeys([*self.ramp_frames, self.default_clip_frames]))
+        cold = [a for a in clip_plan.ASPECT_CHOICES if a not in aspects]
+        if cold:
+            logger.info(
+                "aspects left cold; their first clip pays a one-off compile stall", aspects=cold
+            )
+        for aspect in aspects:
+            height, width = clip_plan.canvas_for_choice(str(aspect))
+            for frames in shapes:
+                started = time.monotonic()
+                self.generator.generate(
+                    self._request(
+                        frames=frames,
+                        prompt=WARMUP_PROMPT,
+                        seed=self.default_seed,
+                        height=height,
+                        width=width,
+                        keep_output=False,
+                    )
+                )
+                logger.info(
+                    "warmed clip shape",
+                    aspect=aspect,
+                    frames=frames,
+                    height=height,
+                    width=width,
+                    seconds=round(time.monotonic() - started, 2),
+                )
+
+    # -------------------------------------------------------- session state
+
+    def _reset_session_state(self) -> None:
+        """Return every session-scoped field to its default.
+
+        The replacement for a runtime-built ``InputState``: the same fields with
+        the same defaults, as plain attributes. Called once at ``load()`` and at
+        every ``@session_started``, which is what keeps one session from ever
+        observing another's conditions.
+        """
+        # Client-settable conditions. The prompt starts empty on purpose: the
+        # channel is whatever the client asks for, so `start` waits for one
+        # rather than falling back to a stock scene nobody chose.
+        self._prompt: str = ""
+        self._clip_frames: int = self.default_clip_frames
+        self._seed: int = self.default_seed
+        self._aspect: str = self.default_aspect
+
+        # Channel lifecycle. `_started` arms the run loop; `_running` is true
+        # while a channel is live; `_do_reset` asks it to wind down; `_stop_only`
+        # marks that wind-down as a `stop` (conditions kept) rather than a reset.
+        self._started: bool = False
+        self._running: bool = False
+        self._do_reset: bool = False
+        self._stop_only: bool = False
+        self._paused: bool = False
+
+        # Progress, mirrored so a `state_update` is a complete snapshot.
+        self._clip_index: int = -1
+        self._clips_sent: int = 0
+        self._frames_sent: int = 0
+        self._seconds_sent: float = 0.0
+        self._clip_start_seconds: float = 0.0
+        self._current_clip_seconds: float = 0.0
+
+    def _canvas(self) -> tuple[int, int]:
+        """The `(height, width)` this session generates at."""
+        return clip_plan.canvas_for_choice(self._aspect)
+
+    def _frames_for_clip(self, index: int) -> int:
+        """Frame count for clip ``index``, ramp included."""
+        return clip_plan.clip_frames(index, self._clip_frames, self.ramp_frames)
+
+    def _prompt_effective(self) -> tuple[int, float]:
+        """Which clip the current prompt lands on, and how far away that is.
+
+        The channel always has one clip in flight, so a prompt set now applies to
+        the next clip *submitted* — never the one already being built.
+        """
+        if not self._running:
+            return 0, 0.0
+        if self._clip_index < 0:
+            # Clip 0 is being built with the prompt as it stood at `start`; a
+            # prompt set now is the first one that can land, on clip 1.
+            return 1, round(clip_plan.seconds_for_frames(self._frames_for_clip(0)), 2)
+        played = self._seconds_sent - self._clip_start_seconds
+        remaining = max(0.0, self._current_clip_seconds - played)
+        queued = clip_plan.seconds_for_frames(self._frames_for_clip(self._clip_index + 1))
+        return self._clip_index + 2, round(remaining + queued, 2)
+
+    def _snapshot(self) -> StateUpdate:
+        """Everything a client can observe, in one message.
+
+        The single source of the snapshot: `state_update` broadcasts it, a
+        joining client is greeted with it, and `get_state` answers with it. Built
+        once here so those three can never disagree.
+        """
+        height, width = self._canvas()
+        effective_index, effective_seconds = self._prompt_effective()
+        return StateUpdate(
+            prompt=self._prompt or None,
+            clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
+            clip_seconds_min=clip_plan.MIN_SECONDS_PUBLISHED,
+            clip_seconds_max=clip_plan.MAX_SECONDS_PUBLISHED,
+            seed=self._seed,
+            aspect=self._aspect,
+            width=width,
+            height=height,
+            ready=bool(self._prompt),
+            running=self._running,
+            paused=self._paused,
+            clip_index=self._clip_index,
+            clips_sent=self._clips_sent,
+            seconds_sent=round(self._seconds_sent, 2),
+            prompt_effective_clip_index=effective_index,
+            prompt_effective_in_seconds=effective_seconds,
+            valid_commands=session_rules.valid_commands(
+                running=self._running, paused=self._paused, ready=bool(self._prompt)
+            ),
+        )
+
+    async def _send_state_update(self) -> None:
+        """Broadcast the snapshot to every connected client."""
+        await self.send(self._snapshot())
+
+    async def _refuse(self, command: str, reason: str) -> None:
+        """Reject a command: tell every client, and leave its reply bodyless.
+
+        A handler returns only the message its annotation names, and reports
+        a failure by broadcasting `command_error` and returning without a
+        value. The runtime answers that with a correlated bodyless
+        acknowledgement, so an awaiting client resolves rather than hanging —
+        and unlike a raised runtime ``CommandError``, whose failure frame is
+        withheld from v0 clients, the broadcast reaches every SDK generation.
+
+        Logged as well, so refusals are visible server-side and not only in the
+        client's message.
+        """
+        logger.info("command refused", command=command, reason=reason)
+        await self.send(CommandError(command=command, reason=reason))
+
+    # ------------------------------------------------------------ lifecycle
+
+    @session_started
+    async def on_session_started(self) -> None:
+        """Clear every condition so a new session never inherits an old one."""
+        self._reset_session_state()
+
+    @session_ended
+    async def on_session_ended(self) -> None:
+        """Wind the channel down; the only hook guaranteed to fire on every path."""
+        self._started = False
+        self._do_reset = True
+
+    @connected
+    async def on_connect(self, client: ClientInfo) -> None:
+        """Greet the joining client with the full state, so it can render at once.
+
+        Addressed rather than broadcast: the clients already watching have this
+        state, and a late joiner needs it without replaying every command.
+        """
+        await client.send(self._snapshot())
+
+    # ------------------------------------------------------------- commands
+
+    @event(
+        name="set_prompt",
+        description=(
+            "Set what the channel shows. Required before `start`; an empty text "
+            "clears it again. Valid at any time: while idle it applies to the "
+            "next `start`, and while streaming it applies to a later clip, "
+            "because the model always builds one clip ahead. Emits "
+            "`prompt_accepted` and `state_update`, both of which report the clip "
+            "this prompt lands on and how much already-built video plays first."
+        ),
+    )
+    async def set_prompt(
+        self,
+        prompt: str = InputField(
+            default="",
+            max_length=MAX_PROMPT_CHARS,
+            description=(
+                "What the channel should show, up to 800 characters. Read when "
+                "the model starts building a clip, so a change reaches the "
+                "viewer a clip or two later rather than immediately. Blank text "
+                "clears it, and `start` is then rejected until one is set again."
+            ),
+        ),
+    ) -> PromptAccepted:
+        """Set the prompt used from the next clip the model starts."""
+        self._prompt = prompt.strip()
+        effective_index, effective_seconds = self._prompt_effective()
+        await self._send_state_update()
+        return PromptAccepted(
+            prompt=self._prompt or None,
+            effective_clip_index=effective_index,
+            effective_in_seconds=effective_seconds,
+        )
+
+    @event(
+        name="set_clip_seconds",
+        description=(
+            "Set how long each clip is. The value is snapped to the nearest "
+            "length the model can produce, so read the effective one back from "
+            "`clip_length_accepted`. Valid at any time; while streaming it "
+            "applies from the next clip the model starts. Longer clips cut less "
+            "often, shorter clips let a new prompt reach the viewer sooner. "
+            "Emits `clip_length_accepted` and `state_update`."
+        ),
+    )
+    async def set_clip_seconds(
+        self,
+        seconds: float = InputField(
+            default=clip_plan.MAX_SECONDS_PUBLISHED,
+            ge=clip_plan.MIN_SECONDS_PUBLISHED,
+            le=clip_plan.MAX_SECONDS_PUBLISHED,
+            description=(
+                f"Clip length in seconds, between {_CLIP_RANGE}. Snapped to the "
+                "nearest length the model can produce, so the value that takes "
+                "effect can differ slightly; `state_update.clip_seconds` always "
+                "carries the one in force."
+            ),
+        ),
+    ) -> ClipLengthAccepted:
+        """Set the steady-state clip length."""
+        self._clip_frames = clip_plan.frames_for_seconds(float(seconds))
+        await self._send_state_update()
+        return ClipLengthAccepted(
+            clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
+            frames=self._clip_frames,
+        )
+
+    @event(
+        name="set_seed",
+        description=(
+            "Set the seed the channel starts from; each clip advances it by "
+            "one, so a channel is reproducible end to end while its clips still "
+            "differ. Valid at any time; applies from the next clip the model "
+            "starts. Emits `seed_accepted` and `state_update`."
+        ),
+    )
+    async def set_seed(
+        self,
+        seed: int = InputField(
+            default=1000,
+            ge=0,
+            description=(
+                "Seed for the next channel. The clip at index `n` uses this "
+                "value plus `n`. Reproduction is close rather than exact: the "
+                "deployment runs fused kernels that can reorder arithmetic."
+            ),
+        ),
+    ) -> SeedAccepted:
+        """Set the seed the next channel run starts from."""
+        self._seed = int(seed)
+        await self._send_state_update()
+        return SeedAccepted(seed=self._seed)
+
+    @event(
+        name="set_canvas",
+        description=(
+            "Choose the aspect ratio of `main_video`. The video track keeps one "
+            "size for the whole channel, so this is only valid while nothing is "
+            "streaming — send it before `start` or after `stop`. Emits "
+            "`canvas_accepted`, carrying the exact pixel size, and "
+            "`state_update`, or `command_error` if a channel is streaming or the "
+            "ratio is not one this model offers."
+        ),
+    )
+    async def set_canvas(
+        self,
+        aspect: str = InputField(
+            default="16:9",
+            choices=list(clip_plan.ASPECT_CHOICES),
+            description=(
+                "Aspect ratio of `main_video`, fixed for the whole channel. "
+                "`canvas_accepted` and `state_update` report the width and "
+                "height in pixels it resolves to."
+            ),
+        ),
+    ) -> CanvasAccepted:
+        """Set the session's canvas; refused once a channel is live."""
+        if self._running:
+            await self._refuse(
+                "set_canvas",
+                "The video size is fixed for the life of a channel; send `stop` first.",
+            )
+            return None
+        try:
+            height, width = clip_plan.canvas_for_choice(aspect)
+        except ValueError as error:
+            await self._refuse("set_canvas", str(error))
+            return None
+        self._aspect = aspect
+        await self._send_state_update()
+        return CanvasAccepted(aspect=aspect, width=width, height=height)
+
+    @event(
+        name="start",
+        description=(
+            "Start the channel. Valid only while nothing is streaming, and only "
+            "once a prompt is set; everything else has a default. Emits "
+            "`channel_started` and `state_update` at once, then a `clip_started` "
+            "as each clip reaches the output tracks. The first clip has to be "
+            "built before anything can stream, so expect several seconds of no "
+            "video, or `command_error` if a channel is already streaming or no "
+            "prompt is set."
+        ),
+    )
+    async def start(self) -> None:
+        """Arm the channel loop; it begins on its next poll."""
+        if self._running:
+            await self._refuse(
+                "start", "A channel is already streaming; send `stop` to end it first."
+            )
+            return
+        if not self._prompt:
+            await self._refuse("start", "No prompt is set; send `set_prompt` first.")
+            return
+        self._started = True
+        self._do_reset = False
+        await self._send_state_update()
+
+    @event(
+        name="pause",
+        description=(
+            "Freeze the output stream on its current frame. Valid only while a "
+            "channel is streaming and not already paused. The model keeps "
+            "building ahead, so `resume` continues instantly. Emits "
+            "`channel_paused` and `state_update`, or `command_error` if no "
+            "channel is streaming or it is already paused."
+        ),
+    )
+    async def pause(self) -> ChannelPaused:
+        """Hold the stream; the channel itself is unaffected."""
+        if not self._running:
+            await self._refuse("pause", "No channel is streaming.")
+            return None
+        if self._paused:
+            await self._refuse("pause", "The stream is already paused.")
+            return None
+        self._paused = True
+        await self._send_state_update()
+        return ChannelPaused(seconds_sent=round(self._seconds_sent, 2))
+
+    @event(
+        name="resume",
+        description=(
+            "Continue a paused stream exactly where it froze, with no warm-up "
+            "and without skipping ahead to catch up. Valid only while paused. "
+            "Emits `channel_resumed` and `state_update`, or `command_error` if "
+            "the stream is not paused."
+        ),
+    )
+    async def resume(self) -> ChannelResumed:
+        """Release a paused stream."""
+        if not self._paused:
+            await self._refuse("resume", "The stream is not paused.")
+            return None
+        self._paused = False
+        await self._send_state_update()
+        return ChannelResumed(seconds_sent=round(self._seconds_sent, 2))
+
+    @event(
+        name="stop",
+        description=(
+            "End the channel, keeping every condition, so `start` begins a "
+            "fresh one with the same setup. Valid only while a channel is "
+            "streaming. The stream stops within about a second, but the clip "
+            "already being built cannot be cancelled, so `state_update.running` "
+            "can stay true for a few seconds longer. Emits `channel_stopped` "
+            "and `state_update`, or `command_error` if no channel is streaming."
+        ),
+    )
+    async def stop(self) -> None:
+        """Wind the channel down, keeping the conditions."""
+        if not self._running:
+            await self._refuse("stop", "No channel is streaming.")
+            return
+        self._started = False
+        self._stop_only = True
+        self._do_reset = True
+        self._paused = False
+        await self._send_state_update()
+
+    @event(
+        name="reset",
+        description=(
+            "Return every condition to its default and clear whatever is queued "
+            "on the output tracks. Stops the channel first if one is streaming. "
+            "Valid at any time. Emits `channel_reset` and `state_update`."
+        ),
+    )
+    async def reset(self) -> ChannelReset:
+        """Clear the session back to its defaults."""
+        was_running = self._running
+        self._started = False
+        self._stop_only = False
+        # Only ask a live channel to wind down; see `_wait_until_armed`.
+        self._do_reset = was_running
+        self._prompt = ""
+        self._clip_frames = self.default_clip_frames
+        self._seed = self.default_seed
+        self._aspect = self.default_aspect
+        self._paused = False
+        self.output.flush()
+        await self._send_state_update()
+        return ChannelReset(was_running=was_running)
+
+    @event(
+        name="get_state",
+        description=(
+            "Return a snapshot of everything the session exposes: the "
+            "conditions in force, the lifecycle flags, progress through the "
+            "channel, and the commands that are valid right now. The same "
+            "payload the model broadcasts as `state_update`, so a client can "
+            "render its whole interface from this one message. Valid at any "
+            "time."
+        ),
+    )
+    async def get_state(self) -> StateUpdate:
+        """Answer with the same snapshot `state_update` broadcasts."""
+        return self._snapshot()
+
+    # ------------------------------------------------------------- run loop
+
+    async def run(self) -> None:
+        """The model's control loop: wait for an audience, arm, stream, repeat.
+
+        Nothing here may raise: an exception out of ``run()`` is an
+        unrecoverable crash of the whole model loop, not the end of one session,
+        so ``_run_channel`` owns its own failure reporting.
+        """
+        while True:
+            await self.connected.wait()
+            if await self._wait_until_armed():
+                await self._run_channel()
+
+    async def _wait_until_armed(self) -> bool:
+        """Wait for `start`; False if the audience left first."""
+        while True:
+            # Deliberately not gated on `_do_reset`: `reset` while idle sets
+            # it and nothing would ever clear it, which would wedge this loop
+            # forever. `_run_channel` clears it as it starts, and `stop`/`reset`
+            # drop `_started`, so a stale flag cannot start a doomed channel.
+            if self._started and self._prompt:
+                return True
+            if not self.connected.is_set():
+                return False
+            await asyncio.sleep(POLL_SECONDS)
+
+    def _should_abort(self) -> bool:
+        """Whether the channel must wind down now.
+
+        `_do_reset` is `stop`/`reset`/session end; a lost audience is the other
+        reason. Every abort check — the worker, the emitter — reads this rather
+        than the flag alone.
+        """
+        return self._do_reset or not self.connected.is_set()
+
+    async def _run_channel(self) -> None:
+        """Stream clips back to back, always building one ahead."""
+        height, width = self._canvas()
+        self._running = True
+        self._do_reset = False
+        self._stop_only = False
+        self._paused = False
+        self._clip_index = -1
+        self._clips_sent = 0
+        self._frames_sent = 0
+        self._seconds_sent = 0.0
+        self._clip_start_seconds = 0.0
+        self._current_clip_seconds = 0.0
+        channel_started_at = time.monotonic()
+
+        # Depth 1 is the lookahead: the worker can be at most one finished clip
+        # ahead of the transport, which is exactly the backpressure that keeps
+        # a prompt change from being buried behind a deep queue.
+        results: queue.Queue = queue.Queue(maxsize=1)
+        pending: _Job | None = None
+        # Emission pacing carried across clips, so a clip seam costs no time.
+        pacer = {"clock_start": None, "frames_paced": 0}
+
+        def submit(index: int) -> _Job:
+            """Queue clip ``index``, capturing the conditions as they stand now."""
+            frames = self._frames_for_clip(index)
+            prompt = self._prompt
+            seed = self._seed + index
+
+            def job() -> None:
+                try:
+                    if self._should_abort():
+                        raise _ChannelStopped
+                    built = self._generate_clip(index, frames, prompt, seed, height, width)
+                    if self._should_abort():
+                        raise _ChannelStopped
+                    results.put(("clip", index, prompt, built))
+                except _ChannelStopped:
+                    results.put(("stopped", index, prompt, None))
+                except BaseException as error:  # noqa: BLE001 — reported to the client
+                    logger.exception("clip generation failed", clip=index)
+                    results.put(("error", index, prompt, error))
+
+            return self._submit(job)
+
+        try:
+            await self.send(
+                ChannelStarted(
+                    width=width,
+                    height=height,
+                    clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
+                    first_clip_seconds=round(
+                        clip_plan.seconds_for_frames(self._frames_for_clip(0)), 3
+                    ),
+                )
+            )
+            await self._send_state_update()
+
+            pending = submit(0)
+            while True:
+                kind, index, prompt, payload = await asyncio.to_thread(results.get)
+                if kind == "error":
+                    raise payload
+                if kind == "stopped":
+                    break
+
+                frames_list, samples = payload
+                if index == 0:
+                    logger.info(
+                        "first clip ready",
+                        ttff_s=round(time.monotonic() - channel_started_at, 2),
+                    )
+                # Submit the next clip BEFORE emitting this one, so it is built
+                # while this one plays. This is what makes the channel endless.
+                pending = submit(index + 1)
+
+                self._clip_index = index
+                self._current_clip_seconds = clip_plan.seconds_for_frames(len(frames_list))
+                self._clip_start_seconds = self._seconds_sent
+                await self.send(
+                    ClipStarted(
+                        clip_index=index,
+                        clip_seconds=round(self._current_clip_seconds, 3),
+                        prompt=prompt,
+                    )
+                )
+                await self._send_state_update()
+
+                await self._emit_paced(frames_list, samples, pacer)
+                if self._should_abort():
+                    break
+
+                self._clips_sent = index + 1
+                await self.send(
+                    ClipComplete(clip_index=index, seconds_sent=round(self._seconds_sent, 2))
+                )
+                await self._send_state_update()
+
+            if self._stop_only:
+                await self.send(
+                    ChannelStopped(
+                        seconds_sent=round(self._seconds_sent, 2), clips_sent=self._clips_sent
+                    )
+                )
+                logger.info(
+                    "channel stopped", clips=self._clips_sent, seconds=round(self._seconds_sent, 2)
+                )
+        except (Exception, SystemExit) as error:
+            logger.exception("channel failed")
+            # Disarm before reporting. `run()` re-enters the arm loop the moment
+            # this returns, and `_started` is what it gates on — leaving it set
+            # would restart the channel straight into the same failure, over and
+            # over, at eight GPUs a go. The client is told to `start` again.
+            self._started = False
+            try:
+                await self.send(
+                    ChannelFailed(reason=str(error), seconds_sent=round(self._seconds_sent, 2))
+                )
+            except Exception:  # noqa: BLE001 — reporting must not crash run()
+                logger.exception("failed to report the channel failure")
+        finally:
+            self._running = False
+            self._paused = False
+            self._stop_only = False
+            self._drain_until_finished(results, pending)
+            self._do_reset = False
+            try:
+                await self._send_state_update()
+            except Exception:  # noqa: BLE001 — teardown must not crash run()
+                logger.exception("failed to send the closing state update")
+
+    def _drain_until_finished(self, results: queue.Queue, pending: _Job | None) -> None:
+        """Ask the in-flight clip to stop and drain its handoff until it returns.
+
+        A clip cannot be cancelled once it is being built, so this waits it out —
+        blocking, not awaiting, because it also runs under cancellation. Draining
+        while it winds down is what keeps a blocked ``put`` from deadlocking, and
+        waiting is not optional: a job left blocked on a full queue would stall
+        every later channel behind it.
+        """
+        if pending is None or pending.done.is_set():
+            return
+        self._do_reset = True
+        deadline = 300
+        while not pending.done.is_set() and deadline > 0:
+            try:
+                while True:
+                    results.get_nowait()
+            except queue.Empty:
+                pass
+            if not self._worker.is_alive():
+                logger.error("generation worker is gone; no further channel can be served")
+                return
+            pending.done.wait(timeout=1)
+            deadline -= 1
+        if not pending.done.is_set():
+            logger.error("clip did not wind down within 300s; later channels will queue behind it")
+
+    # -------------------------------------------------------------- emitter
+
+    async def _emit_paced(self, frames_list, samples, pacer: dict) -> None:
+        """Emit one clip as paced slices on a 24 fps metronome.
+
+        - Paced by FRAMES, not slices: a clip's tail slice is short, and charging
+          it a full slot would open a hole in the cadence.
+        - The clock carries across clips through ``pacer``, so a seam costs no
+          time as long as the next clip was ready.
+        - Never burst to catch up: if a clip landed late, re-anchor instead. A
+          catch-up burst only overflows the transport queue. `seam late` is the
+          log line that says the channel is not keeping up.
+        - Emits omit ``compute_time``, so every slice is tagged at the pinned
+          24 fps — the rate the audio is already sample-clocked against.
+        - `pause` holds by awaiting a sleep; handlers dispatch on their own
+          coroutine, so this starves nothing.
+        """
+        import numpy as np
+
+        samples_per_frame = OUTPUT_SAMPLE_RATE / FRAME_RATE
+        total = len(frames_list)
+        for lo in range(0, total, EMIT_FRAMES):
+            while self._paused and not self._should_abort():
+                await asyncio.sleep(POLL_SECONDS)
+            if self._should_abort():
+                return
+            hi = min(lo + EMIT_FRAMES, total)
+            alo = round(lo * samples_per_frame)
+            ahi = round(hi * samples_per_frame)
+
+            now = asyncio.get_running_loop().time()
+            if pacer["clock_start"] is None:
+                pacer["clock_start"] = now
+            content_pos = pacer["frames_paced"] / FRAME_RATE
+            late = now - (pacer["clock_start"] + content_pos)
+            if lo == 0 and late > 0.05:
+                logger.info("seam late", clip=self._clip_index, late_s=round(late, 2))
+            pacer["clock_start"] = max(pacer["clock_start"], now - content_pos)
+            delay = pacer["clock_start"] + content_pos - now
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+            pacer["frames_paced"] += hi - lo
+            self._frames_sent += hi - lo
+            self._seconds_sent = self._frames_sent / FRAME_RATE
+            video = np.ascontiguousarray(np.stack(frames_list[lo:hi]))
+            await self.emit(
+                FastH3Output(main_video=video, main_audio=samples[:, alo:ahi])
+            )
+
+    # ------------------------------------------------------------ generation
+
+    def _request(
+        self,
+        *,
+        frames: int,
+        prompt: str,
+        seed: int,
+        height: int,
+        width: int,
+        keep_output: bool,
+    ):
+        """Build one generation request.
+
+        Mirrors ``basic_fasth3.py:build_request``. ``keep_output=False`` is the
+        warm-up shape: it skips the whole post-decode path, so a warm-up costs
+        generation time and nothing else.
+        """
+        from fastvideo.api import GenerationRequest, OutputConfig, SamplingConfig
+
+        return GenerationRequest(
+            prompt=prompt,
+            # MiniMax-H3 is guidance-distilled, so there is no negative branch
+            # to steer and no CFG pass to pay for.
+            negative_prompt="",
+            sampling=SamplingConfig(
+                height=height,
+                width=width,
+                num_frames=frames,
+                fps=FRAME_RATE,
+                num_inference_steps=self.num_inference_steps,
+                guidance_scale=1.0,
+                batch_cfg=False,
+                seed=seed,
+            ),
+            output=OutputConfig(save_video=False, return_frames=keep_output),
+        )
+
+    def _generate_clip(
+        self, index: int, frames: int, prompt: str, seed: int, height: int, width: int
+    ):
+        """Build one clip and convert it to what the output tracks want.
+
+        Returns ``(frames_list, samples)``: a list of RGB uint8 ``[h, w, 3]``
+        arrays and int16 ``[1, samples]`` at 48 kHz, trimmed to exactly
+        ``len(frames_list) / 24`` seconds so the two tracks stay in lockstep.
+        """
+        started = time.monotonic()
+        result = self.generator.generate(
+            self._request(
+                frames=frames,
+                prompt=prompt,
+                seed=seed,
+                height=height,
+                width=width,
+                keep_output=True,
+            )
+        )
+        built = time.monotonic() - started
+
+        frames_list = result.frames
+        if not frames_list:
+            raise RuntimeError("the generator returned no frames")
+        samples = self._to_wire_audio(result.audio, result.audio_sample_rate, len(frames_list))
+        logger.info(
+            "clip built",
+            clip=index,
+            frames=len(frames_list),
+            content_s=round(len(frames_list) / FRAME_RATE, 2),
+            build_s=round(built, 2),
+            stages=self._stage_times(result),
+        )
+        return frames_list, samples
+
+    @staticmethod
+    def _stage_times(result) -> dict:
+        """Per-stage seconds from the generator, for the clip log line.
+
+        This is where a regression shows up first: post-decode frame processing
+        scales with resolution x frames and competes with the channel's slack.
+        """
+        try:
+            stages = getattr(getattr(result, "logging_info", None), "stages", None)
+            if not stages:
+                return {}
+            return {
+                name: round(float(metrics["execution_time"]), 3)
+                for name, metrics in stages.items()
+                if metrics.get("execution_time") is not None
+            }
+        except Exception:  # noqa: BLE001 — a log line must never fail a clip
+            logger.exception("could not read the generator stage timings")
+            return {}
+
+    def _to_wire_audio(self, audio, sample_rate, frames: int):
+        """Resample, downmix and quantize one clip's waveform for the wire.
+
+        Mono at the source is deliberate: the transport mean-downmixes before
+        the wire anyway, and the runtime recorder flattens two channels by
+        concatenation, so a stereo emit only corrupts recordings. Averaging here,
+        in float and before the int16 scale, is the same downmix one step
+        earlier.
+        """
+        import torch
+        import torchaudio.functional as AF
+
+        if audio is None:
+            raise RuntimeError("the generator returned no audio")
+        waveform = audio if torch.is_tensor(audio) else torch.as_tensor(audio)
+        waveform = waveform.detach().float().cpu()
+        # The decoder hands back [samples, channels]; the wire wants channel-major.
+        if waveform.ndim == 1:
+            waveform = waveform.unsqueeze(0)
+        elif waveform.shape[0] > waveform.shape[1]:
+            waveform = waveform.transpose(0, 1)
+        waveform = waveform.contiguous()
+
+        rate = int(sample_rate or NATIVE_SAMPLE_RATE)
+        if rate != OUTPUT_SAMPLE_RATE:
+            waveform = AF.resample(waveform, rate, OUTPUT_SAMPLE_RATE)
+        if waveform.shape[0] > 1:
+            waveform = waveform.mean(dim=0, keepdim=True)
+
+        want = round(frames / FRAME_RATE * OUTPUT_SAMPLE_RATE)
+        if waveform.shape[-1] > want:
+            waveform = waveform[:, :want]
+        elif waveform.shape[-1] < want:
+            pad = torch.zeros(
+                (waveform.shape[0], want - waveform.shape[-1]), dtype=waveform.dtype
+            )
+            waveform = torch.cat([waveform, pad], dim=-1)
+        return (waveform.clamp(-1, 1) * 32767).to(torch.int16).numpy()

--- a/models/fasth3/fasth3.yaml
+++ b/models/fasth3/fasth3.yaml
@@ -1,0 +1,99 @@
+# FastH3 — continuous channel configuration.
+#
+# `inference` is the generation recipe; `runtime` is the weight layout and the
+# engine shape. fasth3.py reads this file itself (the runtime hands over the path
+# and does not parse it).
+
+inference:
+  # Aspect the session starts at. `set_canvas` can change it while idle, to any
+  # entry in clip_plan.ASPECT_CHOICES. 16:9 resolves to 1344x768 — the canvas
+  # every published FastH3 number was measured at.
+  aspect: "16:9"
+
+  # Steady-state clip length in seconds. 14.375 s is the longest the checkpoint
+  # will generate: 15.0 s is 360 frames, which aligns up to 362 (15.083 s) and is
+  # then rejected for exceeding the duration cap, so 345 frames is the ceiling.
+  #
+  # Longer is better for the channel. Build cost is sublinear in length, so a
+  # long clip has the most slack between "built" and "needed", and it cuts least
+  # often. The trade is that a new prompt takes longer to reach the viewer.
+  clip_seconds: 14.375
+
+  # Time-to-first-frame ramp: the clip lengths the channel opens with before
+  # settling on `clip_seconds`. A short first clip builds proportionally faster,
+  # so video starts in about a third of the time. Every entry is a distinct
+  # tensor shape the warm-up must cover, so keep the list short; [] disables the
+  # ramp for a uniform cadence from clip zero.
+  ramp_seconds: [5.167]
+
+  # Seed the channel starts from; each clip advances it by one. `set_seed`
+  # overrides per session.
+  seed: 1000
+
+  # Sigma-grid POINTS, not transformer forwards. The distilled schedule is
+  # t=999,749,500,250 -> 0: five points and exactly four forwards. Changing this
+  # leaves the trained schedule and is not supported by the checkpoint.
+  num_inference_steps: 5
+
+  # Video Sparse Attention. 0.9 / tile 64 / sm100a is the checkpoint's trained
+  # and measured policy (fastvideo_inference.json). `triton` is the portable
+  # fallback for a non-Blackwell box and is much slower.
+  vsa_sparsity: 0.9
+  vsa_tile_size: 64
+  vsa_kernel: sm100a
+
+  # FA4 for the dense (text and audio) attention paths, and the inference-only
+  # H3 fusions. Both are part of the measured profile. The fusions change
+  # floating-point operation order, so they are not bit-exact against the
+  # eager route; set h3_fusions: false to compare.
+  fa4: true
+  h3_fusions: true
+
+  # Regional compile of the transformer blocks, and an independently compiled
+  # video VAE decoder. Both are in the measured profile. Regional compile is
+  # shape-keyed, which is why every clip length and canvas has to be warmed.
+  inference_torch_compile: true
+  compile_vae: true
+
+  # Sequence-parallel all-to-all route. `off` reproduces the measured profile;
+  # `auto` opts into the fused NVLink kernel when the installed kernel package
+  # supports it.
+  ulysses_a2a: "off"
+
+  # Canvases warmed at load, one full build per clip shape each. Adding an entry
+  # costs pod-boot time; leaving one out means its first clip pays a one-off
+  # compile stall mid-channel. Start with the default only and widen once the
+  # boot cost is measured.
+  warmup_aspects: ["16:9"]
+
+runtime:
+  # Weight bundle layout, relative to the mounted weights root. One HF snapshot
+  # directory carries every component: transformer, text encoder, both VAEs,
+  # both schedulers, tokenizer and processor.
+  checkpoint_dir: FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree
+
+  # Sequence parallelism spans every GPU (sp_size == num_gpus, tp_size 1).
+  # Eight is what makes the channel work: the published build time for a 15 s
+  # clip is 12.88 s on eight B200s against 15.5 s on four, and only the former
+  # is faster than the video plays.
+  num_gpus: 8
+
+  # false shards the transformer with FSDP, matching the checkpoint's own
+  # contract. Sharding is what frees the VRAM to keep the text encoder resident
+  # below. true replicates it instead (~70 GB per GPU) for the fastest measured
+  # denoise; A/B them on the target hardware.
+  replicated_dit: false
+
+  # Offload policy. The text encoder is ~69 GB and every rank loads its own
+  # copy, so CPU-offloading it on eight ranks would want ~550 GB of host memory
+  # AND pay a host-to-device transfer on every clip. Keeping it resident is both
+  # cheaper and faster once the transformer is sharded — flip these back on only
+  # if VRAM measurements say otherwise.
+  offload_text_encoder: false
+  offload_vae: false
+
+  # Pinned host buffers speed up device-to-host transfer but make the
+  # per-clip pixel allocations expensive to acquire and release. With nothing
+  # offloaded there is little left to pin, so this stays off; turn it on
+  # together with the offload flags above.
+  pin_cpu_memory: false

--- a/models/fasth3/fasth3_clip_plan.py
+++ b/models/fasth3/fasth3_clip_plan.py
@@ -1,0 +1,178 @@
+"""Clip geometry for the FastH3 channel.
+
+Pure arithmetic over the checkpoint's published constraints: how long a clip may
+be, how many frames that is, and what canvas an aspect ratio resolves to. No
+torch, no fastvideo, no GPU — so ``python -m reactor_runtime.schema`` and the
+structural tests import it on any machine.
+
+The constants below are duplicated from FastVideo rather than imported, because
+importing ``fastvideo.pipelines.basic.minimax_h3.packing`` drags in torch.
+``tests/test_fasth3.py`` asserts they still match upstream whenever fastvideo
+is importable, so the duplication cannot drift silently.
+"""
+
+from __future__ import annotations
+
+import math
+
+FPS = 24
+"""The only frame rate MiniMax-H3 accepts; the pipeline rejects anything else."""
+
+# The causal VAE consumes video in 17-frame chunks that decode to 5 latents, so
+# a valid pixel length is always `17n + 5`.
+_FRAMES_PER_CHUNK = 17
+_LATENTS_PER_CHUNK = 5
+
+# The checkpoint's trained duration window, in seconds.
+_MIN_DURATION = 5.0
+_MAX_DURATION = 15.0
+
+# Canvas rules: the short edge is fixed, total area is capped, and both sides
+# must land on a multiple of 32.
+_SHORT_EDGE = 768
+_MAX_PIXELS = 768 * 1344
+_CANVAS_MULTIPLE = 32
+_MIN_ASPECT = 1 / 4
+_MAX_ASPECT = 4
+
+
+def align_frames(frames: int) -> int:
+    """Round up to the next valid `17n + 5` pixel length."""
+    if frames < 1:
+        raise ValueError(f"frames must be positive, got {frames}")
+    while frames % _FRAMES_PER_CHUNK != _LATENTS_PER_CHUNK:
+        frames += 1
+    return frames
+
+
+def _bounds() -> tuple[int, int]:
+    """The shortest and longest clip that satisfies both alignment and duration.
+
+    The ceiling is the subtle one: 15.0 s is 360 frames, which aligns *up* to
+    362 (15.083 s) and is then rejected for exceeding the duration cap. So the
+    longest clip this checkpoint will actually generate is 345 frames.
+    """
+    low = align_frames(int(_MIN_DURATION * FPS))
+    high = low
+    while True:
+        nxt = align_frames(high + 1)
+        if nxt / FPS > _MAX_DURATION:
+            return low, high
+        high = nxt
+
+
+MIN_FRAMES, MAX_FRAMES = _bounds()
+MIN_SECONDS = MIN_FRAMES / FPS
+MAX_SECONDS = MAX_FRAMES / FPS
+
+# The same bounds as the schema publishes them. Rounded *inward* to three
+# decimals so a client reads "5.167", not "5.166666666666667", and so every
+# value inside the published range still snaps to a generatable clip.
+MIN_SECONDS_PUBLISHED = math.ceil(MIN_SECONDS * 1000) / 1000
+MAX_SECONDS_PUBLISHED = math.floor(MAX_SECONDS * 1000) / 1000
+
+
+def frames_for_seconds(seconds: float) -> int:
+    """Snap a requested clip length to the nearest length the model can make.
+
+    Rounds up to a valid frame count, then clamps into the generatable range, so
+    every accepted value round-trips through ``seconds_for_frames``.
+    """
+    if seconds <= 0:
+        raise ValueError(f"seconds must be positive, got {seconds}")
+    frames = align_frames(max(1, round(seconds * FPS)))
+    return max(MIN_FRAMES, min(MAX_FRAMES, frames))
+
+
+def seconds_for_frames(frames: int) -> float:
+    """Exact playout length of a clip, in seconds."""
+    return frames / FPS
+
+
+def canvas_for_aspect(aspect_width: float, aspect_height: float) -> tuple[int, int]:
+    """Resolve an aspect ratio to a `(height, width)` the checkpoint accepts.
+
+    Mirrors FastVideo's ``resolve_canvas_size``: pin the short edge to 768,
+    shrink to the area cap if the result is too wide, then round both sides to a
+    multiple of 32.
+    """
+    if aspect_width <= 0 or aspect_height <= 0:
+        raise ValueError(f"aspect must be positive, got {aspect_width}:{aspect_height}")
+    ratio = aspect_width / aspect_height
+    if not _MIN_ASPECT <= ratio <= _MAX_ASPECT:
+        raise ValueError(f"aspect ratios run from 1:4 to 4:1, got {aspect_width}:{aspect_height}")
+
+    if ratio >= 1:
+        width, height = _SHORT_EDGE * ratio, float(_SHORT_EDGE)
+    else:
+        width, height = float(_SHORT_EDGE), _SHORT_EDGE / ratio
+    area = width * height
+    if area > _MAX_PIXELS:
+        scale = (_MAX_PIXELS / area) ** 0.5
+        width, height = width * scale, height * scale
+    m = _CANVAS_MULTIPLE
+    return max(m, round(height / m) * m), max(m, round(width / m) * m)
+
+
+# The canvases `set_canvas` offers. Deliberately a short list: every entry is a
+# distinct tensor shape that load() must warm, and an unwarmed shape pays a
+# one-off compile stall on its first clip.
+ASPECT_CHOICES: tuple[str, ...] = ("16:9", "1:1", "9:16", "4:3")
+
+_ASPECT_RATIOS: dict[str, tuple[int, int]] = {
+    "16:9": (16, 9),
+    "1:1": (1, 1),
+    "9:16": (9, 16),
+    "4:3": (4, 3),
+}
+
+
+def canvas_for_choice(aspect: str) -> tuple[int, int]:
+    """Resolve one of ``ASPECT_CHOICES`` to `(height, width)`."""
+    try:
+        ratio = _ASPECT_RATIOS[aspect]
+    except KeyError:
+        raise ValueError(f"unknown aspect {aspect!r}; choose one of {list(ASPECT_CHOICES)}") from None
+    return canvas_for_aspect(*ratio)
+
+
+def clip_frames(index: int, steady_frames: int, ramp_frames: tuple[int, ...]) -> int:
+    """Frame count for clip ``index`` of a channel run.
+
+    The ramp exists purely for time-to-first-frame: the channel opens with one or
+    more short clips (which generate proportionally faster) and then settles on
+    ``steady_frames``. An empty ramp means a uniform cadence from clip zero.
+    """
+    if index < 0:
+        raise ValueError(f"clip index must be non-negative, got {index}")
+    if index < len(ramp_frames):
+        return ramp_frames[index]
+    return steady_frames
+
+
+def parse_ramp(seconds: object) -> tuple[int, ...]:
+    """Turn a config list of clip lengths in seconds into snapped frame counts."""
+    if seconds is None:
+        return ()
+    if not isinstance(seconds, list | tuple):
+        raise TypeError(f"ramp must be a list of seconds, got {type(seconds).__name__}")
+    return tuple(frames_for_seconds(float(value)) for value in seconds)
+
+
+__all__ = [
+    "ASPECT_CHOICES",
+    "FPS",
+    "MAX_FRAMES",
+    "MAX_SECONDS",
+    "MAX_SECONDS_PUBLISHED",
+    "MIN_FRAMES",
+    "MIN_SECONDS",
+    "MIN_SECONDS_PUBLISHED",
+    "align_frames",
+    "canvas_for_aspect",
+    "canvas_for_choice",
+    "clip_frames",
+    "frames_for_seconds",
+    "parse_ramp",
+    "seconds_for_frames",
+]

--- a/models/fasth3/fasth3_session_rules.py
+++ b/models/fasth3/fasth3_session_rules.py
@@ -1,0 +1,36 @@
+"""Which commands the session would accept right now.
+
+Kept out of ``fasth3.py`` so the state machine is readable on its own and can be
+tested without a GPU. ``StateUpdate.valid_commands`` carries the result to
+clients, so a frontend enables and greys out controls from the snapshot instead
+of re-deriving these rules.
+"""
+
+from __future__ import annotations
+
+# Always available: they only ever record a value or report one.
+_ALWAYS = ("set_prompt", "set_clip_seconds", "set_seed", "reset", "get_state")
+
+
+def valid_commands(*, running: bool, paused: bool, ready: bool) -> list[str]:
+    """Name every command the session would accept in this state.
+
+    Args:
+        running: A channel is live and streaming clips.
+        paused: The output stream is held; only meaningful while ``running``.
+        ready: A prompt is set, so ``start`` has everything it needs.
+    """
+    commands = list(_ALWAYS)
+    if running:
+        commands.append("resume" if paused else "pause")
+        commands.append("stop")
+    else:
+        # The canvas fixes the video track's geometry, so it can only change
+        # while nothing is streaming.
+        commands.append("set_canvas")
+        if ready:
+            commands.append("start")
+    return sorted(commands)
+
+
+__all__ = ["valid_commands"]

--- a/models/fasth3/fasth3_types.py
+++ b/models/fasth3/fasth3_types.py
@@ -1,0 +1,231 @@
+"""Client-facing types for the FastH3 Reactor model.
+
+Everything a client can see lives here: the outbound video and audio tracks and
+the typed messages the model sends. ``fasth3.py`` imports these; a frontend
+developer reads this file to learn the whole API without opening the inference
+code.
+
+The conditions behind the `set_*` commands are not here. A ``ReactorModel`` owns
+its session state itself, so they are plain attributes on ``FastH3`` reset in
+``_reset_session_state``; their client-facing text lives on each handler's own
+``InputField`` declaration.
+"""
+
+from __future__ import annotations
+
+from reactor_runtime import (
+    Audio,
+    MessageField,
+    ModelMessage,
+    Output,
+    Video,
+)
+
+MAX_PROMPT_CHARS = 800
+
+
+class FastH3Output(Output):
+    """The generated video and its synchronized audio, streamed continuously."""
+
+    main_video: Video
+    main_audio: Audio
+
+
+class StateUpdate(ModelMessage):
+    """Emitted on connect and after every change to the session's state.
+
+    One snapshot of everything observable, so a client can render its whole UI
+    from this alone instead of accumulating the individual messages below.
+    """
+
+    prompt: str | None = MessageField(
+        description=(
+            "Prompt in effect for the next clip the model starts, or null when "
+            "none is set."
+        )
+    )
+    clip_seconds: float = MessageField(
+        description="Length of each clip the channel produces, in seconds."
+    )
+    clip_seconds_min: float = MessageField(
+        description="Shortest clip length `set_clip_seconds` accepts."
+    )
+    clip_seconds_max: float = MessageField(
+        description="Longest clip length `set_clip_seconds` accepts."
+    )
+    seed: int = MessageField(description="Seed the channel started from; each clip advances it by one.")
+    aspect: str = MessageField(description="Aspect ratio in effect, e.g. `16:9`.")
+    width: int = MessageField(description="Width of every frame on `main_video`.")
+    height: int = MessageField(description="Height of every frame on `main_video`.")
+    ready: bool = MessageField(description="A prompt is set, so `start` is valid.")
+    running: bool = MessageField(description="The channel is live and streaming clips.")
+    paused: bool = MessageField(
+        description="The output stream is held; `resume` continues it instantly."
+    )
+    clip_index: int = MessageField(
+        description="Zero-based index of the clip currently streaming, or -1 before the first."
+    )
+    clips_sent: int = MessageField(description="Clips fully streamed since `start`.")
+    seconds_sent: float = MessageField(
+        description="Seconds of video and audio sent since `start`."
+    )
+    prompt_effective_clip_index: int = MessageField(
+        description=(
+            "Clip the prompt shown here will first appear on. The model always "
+            "builds one clip ahead, so a prompt changed mid-channel lands two "
+            "clips out, not on the next one."
+        )
+    )
+    prompt_effective_in_seconds: float = MessageField(
+        description=(
+            "Seconds of already-built video still to play before the prompt "
+            "shown here starts. Zero while the channel is idle."
+        )
+    )
+    valid_commands: list[str] = MessageField(
+        description=(
+            "Names of the commands the session would accept right now. Use this "
+            "to enable or grey out controls instead of re-deriving the state "
+            "machine client-side; any command not listed would be rejected."
+        )
+    )
+
+
+class PromptAccepted(ModelMessage):
+    """Emitted when `set_prompt` is accepted."""
+
+    prompt: str | None = MessageField(
+        description="Prompt now in effect, or null when it was cleared."
+    )
+    effective_clip_index: int = MessageField(
+        description="Clip this prompt will first appear on."
+    )
+    effective_in_seconds: float = MessageField(
+        description=(
+            "Seconds of already-built video still to play before this prompt "
+            "starts. Zero while the channel is idle, so the next `start` uses it "
+            "immediately."
+        )
+    )
+
+
+class ClipLengthAccepted(ModelMessage):
+    """Emitted when `set_clip_seconds` is accepted.
+
+    The requested length is snapped to the nearest length the model can produce,
+    so the value here may differ slightly from the one sent.
+    """
+
+    clip_seconds: float = MessageField(description="Clip length now in effect, in seconds.")
+    frames: int = MessageField(description="Frames each clip will carry on `main_video`.")
+
+
+class SeedAccepted(ModelMessage):
+    """Emitted when `set_seed` is accepted."""
+
+    seed: int = MessageField(description="Seed the next channel run starts from.")
+
+
+class CanvasAccepted(ModelMessage):
+    """Emitted when `set_canvas` is accepted."""
+
+    aspect: str = MessageField(description="Aspect ratio now in effect.")
+    width: int = MessageField(description="Width of every frame on `main_video`.")
+    height: int = MessageField(description="Height of every frame on `main_video`.")
+
+
+class ChannelStarted(ModelMessage):
+    """Emitted once when `start` is accepted, before any frame is sent.
+
+    The first clip must be built before anything can stream, so expect several
+    seconds of no video. Treat this as the cue to show progress, not to expect
+    frames immediately.
+    """
+
+    width: int = MessageField(description="Width of every frame on `main_video`.")
+    height: int = MessageField(description="Height of every frame on `main_video`.")
+    clip_seconds: float = MessageField(description="Length of each steady-state clip, in seconds.")
+    first_clip_seconds: float = MessageField(
+        description=(
+            "Length of the opening clip. The channel can open with a shorter "
+            "clip so video starts sooner; it equals `clip_seconds` when it does not."
+        )
+    )
+
+
+class ClipStarted(ModelMessage):
+    """Emitted as each clip begins streaming on the output tracks.
+
+    Every clip is an independent piece of video and audio, so the picture and
+    the sound cut at this boundary rather than continuing from the last frame.
+    """
+
+    clip_index: int = MessageField(description="Zero-based index of the clip now streaming.")
+    clip_seconds: float = MessageField(description="Length of this clip, in seconds.")
+    prompt: str = MessageField(description="Prompt this clip was built from.")
+
+
+class ClipComplete(ModelMessage):
+    """Emitted when a clip has been fully sent on the output tracks."""
+
+    clip_index: int = MessageField(description="Zero-based index of the clip just finished.")
+    seconds_sent: float = MessageField(
+        description="Seconds of video and audio sent since `start`, this clip included."
+    )
+
+
+class ChannelPaused(ModelMessage):
+    """Emitted when `pause` is accepted.
+
+    The stream freezes on its current frame while the model keeps building
+    ahead, so `resume` continues without any warm-up.
+    """
+
+    seconds_sent: float = MessageField(description="Seconds streamed before the pause.")
+
+
+class ChannelResumed(ModelMessage):
+    """Emitted when `resume` is accepted. The stream continues where it froze."""
+
+    seconds_sent: float = MessageField(description="Seconds streamed so far.")
+
+
+class ChannelStopped(ModelMessage):
+    """Emitted when `stop` is accepted and the channel ends.
+
+    Every condition is kept, so `start` immediately begins a fresh channel with
+    the same setup. The clip already being built is discarded, so the model can
+    take a few seconds to go idle.
+    """
+
+    seconds_sent: float = MessageField(description="Seconds streamed before the stop.")
+    clips_sent: int = MessageField(description="Clips fully streamed before the stop.")
+
+
+class ChannelFailed(ModelMessage):
+    """Emitted when the channel ends early because something went wrong.
+
+    The model then idles; adjust the conditions and `start` again.
+    """
+
+    reason: str = MessageField(description="What went wrong.")
+    seconds_sent: float = MessageField(description="Seconds streamed before it stopped.")
+
+
+class ChannelReset(ModelMessage):
+    """Emitted when `reset` is accepted.
+
+    Every condition is back to its default, the output stream is cleared, and
+    the model is waiting for new conditions.
+    """
+
+    was_running: bool = MessageField(
+        description="A channel was live and has been stopped, so no `channel_stopped` will follow it."
+    )
+
+
+class CommandError(ModelMessage):
+    """Emitted when a command is rejected. The command had no effect."""
+
+    command: str = MessageField(description="Name of the command that was rejected.")
+    reason: str = MessageField(description="Why it was rejected.")

--- a/models/fasth3/reactor.yaml
+++ b/models/fasth3/reactor.yaml
@@ -1,0 +1,79 @@
+# Reactor model specification for the FastH3 continuous channel.
+$schema: reactor/v1
+
+model:
+  name: fasth3
+  version: v0.1.0
+  description: |
+    Stream an endless, prompt-driven channel of 768p video with synchronized
+    audio. MiniMax-H3 (35B), distilled by FastVideo to four transformer
+    forwards with 90% sparse video attention, builds the next clip while the
+    current one plays, so the channel never runs dry.
+  # Eight GPUs is load-bearing rather than a performance preference: sequence
+  # parallelism spans all eight, and a 15 s clip builds in 12.88 s on eight
+  # B200s against 15.5 s on four. Only the former is faster than the video
+  # plays, which is what makes the channel continuous.
+  #
+  # cpu and memory are an opening estimate. With nothing CPU-offloaded the host
+  # holds only the load-time transient of eight ranks streaming a 148 GB bundle
+  # plus one clip's pixel buffers; re-measure on real hardware and tighten. If
+  # the offload flags in fasth3.yaml are turned back on, memory must rise to
+  # several hundred Gi — see the note there.
+  resources:
+    gpu:
+      type: NVIDIA_B200
+      count: 8
+    cpu:
+      request: "8"
+      limit: "32"
+    memory:
+      request: 32Gi
+      limit: 256Gi
+
+runtime:
+  import: fasth3:FastH3
+  config: fasth3.yaml
+  # The weights bundle lives here; nothing is downloaded at load.
+  weights_path: ~/.cache/reactor_registry/fasth3
+  # Left off deliberately. Every clip is generated independently, so a recording
+  # carries a hard cut in picture and sound at each clip boundary; enable it once
+  # that seam has been looked at.
+  recording:
+    enabled: false
+
+build:
+  runtime_version: "3.2.5"
+  python_requirements: requirements.txt
+  # CUDA 13 is the model's requirement, not a preference: the VSA-H3 sparse
+  # kernel and the FA4 CuTe kernels are both cu130 builds. Every other model in
+  # this repo builds on 12.8.1.
+  cuda_version: "13.1.2"
+  python_version: "3.12"
+  # ninja keeps any torch BuildExtension parallel — without it torch falls back
+  # to serial g++ and a 30-minute build runs for hours. git is what pip drives
+  # to resolve the `git+https` flash-attn-4 requirement. libgl1 + libglib2.0-0
+  # are for opencv: fastvideo depends on `opencv-python` (the GUI build), not
+  # `opencv-python-headless`, so the GUI shared libraries have to be present or
+  # the first `import cv2` dies on `libGL.so.1`.
+  system_packages:
+    - build-essential
+    - ffmpeg
+    - git
+    - libgl1
+    - libglib2.0-0
+    - ninja-build
+  # torch comes from the cu130 index in requirements.txt; let the resolver
+  # compare that index with PyPI for everything the index also mirrors.
+  build_env:
+    UV_INDEX_STRATEGY: unsafe-best-match
+  # Long-lived server allocating a clip's worth of pixels over and over, in two
+  # different shapes: the expandable-segments allocator is what stops
+  # fragmentation creeping across a multi-hour channel.
+  #
+  # Every component loads from the local bundle, so the HF libraries must never
+  # reach for the network — offline turns a missing file into a clear error
+  # instead of a hang.
+  runtime_env:
+    PYTORCH_ALLOC_CONF: expandable_segments:True
+    HF_HUB_OFFLINE: "1"
+    TRANSFORMERS_OFFLINE: "1"

--- a/models/fasth3/requirements.txt
+++ b/models/fasth3/requirements.txt
@@ -1,0 +1,30 @@
+# Model dependencies resolved with Reactor Runtime during `reactor build`.
+# `build.runtime_version` in reactor.yaml selects the Runtime release.
+--extra-index-url https://download.pytorch.org/whl/cu130
+
+# The cu130 builds the sparse-attention and FA4 kernels are compiled against.
+# 2.12.0 is what fastvideo 0.2.1 pins; torchvision and torchaudio are left to
+# the index so it picks the matching build.
+torch==2.12.0
+torchaudio
+torchvision
+
+# The inference stack: pipelines, the MiniMax-H3 model code, the VSA-H3
+# attention backend, and the VideoGenerator engine.
+fastvideo==0.2.1
+
+# The Blackwell sparse-attention kernel. fastvideo pins this exact version
+# transitively; naming it here makes the sm100a dependency explicit, because
+# without a wheel carrying the sm_100a build the model refuses to start rather
+# than silently running the slow route.
+fastvideo-kernel==0.3.5
+
+# FA4 CuTe kernels for the dense (text and audio) attention paths. Pinned to
+# the revision FastVideo's own `fasth3` extra selects: it fixes
+# nvidia-cutlass-dsl at 4.6.0.dev0, and an older cutlass-dsl breaks these
+# kernels at JIT time rather than at import.
+flash-attn-4 @ git+https://github.com/Dao-AILab/flash-attention.git@14c377950125c70b7a9dabf9c561fca53715ac7d#subdirectory=flash_attn/cute
+
+# fasth3.py parses fasth3.yaml itself: the runtime hands over the path to the
+# file `runtime.config` names and does not read it.
+pyyaml

--- a/models/fasth3/tests/test_fasth3.py
+++ b/models/fasth3/tests/test_fasth3.py
@@ -1,0 +1,917 @@
+"""FastH3's clip geometry, command contract, channel loop, schema and manifest.
+
+Everything here runs on a laptop: the GPU work sits behind ``load()``, which
+these tests never call, and the clip builder is replaced where the channel loop
+itself is under test.
+
+Run from the model folder: ``PYTHONPATH=. python -m pytest tests/ -q``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import re
+import threading
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+import fasth3_clip_plan as clip_plan
+import fasth3_session_rules as session_rules
+from fasth3 import EMIT_FRAMES, FastH3
+
+MODEL_DIR = Path(__file__).resolve().parents[1]
+
+
+# --------------------------------------------------------------- clip geometry
+#
+# The rules a clip length has to satisfy to be generatable.
+
+
+def test_bounds_are_the_generatable_range():
+    """5 s aligns up to 124 frames; 15 s aligns up to 362 and is out of range."""
+    assert clip_plan.MIN_FRAMES == 124
+    assert clip_plan.MAX_FRAMES == 345
+    # The ceiling is not 15 s: 360 frames aligns up to 362, which is 15.083 s
+    # and past the cap, so 345 frames (14.375 s) is the longest clip there is.
+    assert clip_plan.MAX_SECONDS == pytest.approx(14.375)
+    assert 362 / clip_plan.FPS > 15.0
+
+
+@pytest.mark.parametrize("frames", range(1, 400))
+def test_align_frames_lands_on_the_chunk_grid(frames):
+    aligned = clip_plan.align_frames(frames)
+    assert aligned % 17 == 5
+    assert aligned >= frames
+    assert aligned - frames < 17
+
+
+@pytest.mark.parametrize("seconds", [5.0, 5.167, 8.0, 10.0, 14.375, 15.0, 60.0])
+def test_every_accepted_length_is_generatable(seconds):
+    frames = clip_plan.frames_for_seconds(seconds)
+    assert frames % 17 == 5
+    assert clip_plan.MIN_FRAMES <= frames <= clip_plan.MAX_FRAMES
+    assert 5.0 <= clip_plan.seconds_for_frames(frames) <= 15.0
+
+
+def test_published_bounds_round_inward():
+    """A client reading the schema sees tidy numbers that still snap cleanly."""
+    assert clip_plan.MIN_SECONDS_PUBLISHED == 5.167
+    assert clip_plan.MAX_SECONDS_PUBLISHED == 14.375
+    assert clip_plan.MIN_SECONDS_PUBLISHED >= clip_plan.MIN_SECONDS
+    assert clip_plan.MAX_SECONDS_PUBLISHED <= clip_plan.MAX_SECONDS
+    for bound in (clip_plan.MIN_SECONDS_PUBLISHED, clip_plan.MAX_SECONDS_PUBLISHED):
+        assert clip_plan.frames_for_seconds(bound) % 17 == 5
+
+
+def test_seconds_must_be_positive():
+    with pytest.raises(ValueError):
+        clip_plan.frames_for_seconds(0)
+
+
+@pytest.mark.parametrize("aspect", clip_plan.ASPECT_CHOICES)
+def test_every_offered_canvas_satisfies_the_checkpoint(aspect):
+    height, width = clip_plan.canvas_for_choice(aspect)
+    assert height % 32 == 0 and width % 32 == 0
+    assert height * width <= 768 * 1344
+    assert min(height, width) == 768 or height * width <= 768 * 1344
+    assert 1 / 4 <= width / height <= 4
+
+
+def test_default_canvas_is_the_measured_one():
+    assert clip_plan.canvas_for_choice("16:9") == (768, 1344)
+
+
+def test_unknown_aspect_is_rejected():
+    with pytest.raises(ValueError):
+        clip_plan.canvas_for_choice("32:9")
+
+
+def test_ramp_opens_short_then_settles():
+    ramp = clip_plan.parse_ramp([5.167])
+    assert ramp == (124,)
+    assert clip_plan.clip_frames(0, 345, ramp) == 124
+    assert clip_plan.clip_frames(1, 345, ramp) == 345
+    assert clip_plan.clip_frames(9, 345, ramp) == 345
+
+
+def test_empty_ramp_is_a_uniform_cadence():
+    assert clip_plan.clip_frames(0, 345, ()) == 345
+
+
+def test_upstream_constants_have_not_drifted():
+    """The duplicated constants must still match FastVideo's own.
+
+    ``fasth3_clip_plan`` copies these rather than importing them, so that the
+    schema renders without torch. This is the test that stops the copy going
+    stale.
+    """
+    packing = pytest.importorskip(
+        "fastvideo.pipelines.basic.minimax_h3.packing",
+        reason="fastvideo is not installed on this machine",
+    )
+    assert clip_plan.FPS == packing.MINIMAX_H3_FPS
+    assert clip_plan._FRAMES_PER_CHUNK == packing.MINIMAX_H3_FRAMES_PER_CHUNK
+    assert clip_plan._LATENTS_PER_CHUNK == packing.MINIMAX_H3_LATENTS_PER_CHUNK
+    assert clip_plan._MIN_DURATION == packing.MINIMAX_H3_MIN_DURATION
+    assert clip_plan._MAX_DURATION == packing.MINIMAX_H3_MAX_DURATION
+    assert clip_plan._SHORT_EDGE == packing.MINIMAX_H3_SHORT_EDGE
+    assert clip_plan._MAX_PIXELS == packing.MINIMAX_H3_MAX_PIXELS
+    assert clip_plan._CANVAS_MULTIPLE == packing.MINIMAX_H3_CANVAS_MULTIPLE
+
+    for frames in (1, 100, 124, 200, 345):
+        assert clip_plan.align_frames(frames) == packing.align_num_frames(frames)
+    for aspect in clip_plan.ASPECT_CHOICES:
+        ratio = clip_plan._ASPECT_RATIOS[aspect]
+        assert clip_plan.canvas_for_choice(aspect) == packing.resolve_canvas_size(*ratio)
+
+
+# --------------------------------------------------------------- session rules
+#
+# The command state machine clients read out of `state_update`.
+
+
+def test_idle_without_a_prompt_cannot_start():
+    commands = session_rules.valid_commands(running=False, paused=False, ready=False)
+    assert "start" not in commands
+    assert "set_prompt" in commands
+
+
+def test_idle_with_a_prompt_can_start_and_set_the_canvas():
+    commands = session_rules.valid_commands(running=False, paused=False, ready=True)
+    assert "start" in commands
+    assert "set_canvas" in commands
+
+
+def test_the_canvas_is_locked_while_streaming():
+    """The video track keeps one size for the life of a channel."""
+    commands = session_rules.valid_commands(running=True, paused=False, ready=True)
+    assert "set_canvas" not in commands
+    assert "start" not in commands
+    assert {"pause", "stop"} <= set(commands)
+
+
+def test_a_paused_channel_offers_resume_not_pause():
+    commands = session_rules.valid_commands(running=True, paused=True, ready=True)
+    assert "resume" in commands
+    assert "pause" not in commands
+
+
+def test_conditions_and_reset_are_always_available():
+    for running, paused in ((False, False), (True, False), (True, True)):
+        commands = session_rules.valid_commands(running=running, paused=paused, ready=True)
+        assert {"set_prompt", "set_clip_seconds", "set_seed", "reset", "get_state"} <= set(commands)
+
+
+# ------------------------------------------------------------ command contract
+#
+# The real handlers on a model whose ``load()`` never ran: everything they touch
+# is session state and pure arithmetic, so the whole state machine — refusals
+# included — is testable on a laptop.
+
+
+def run(coro):
+    """Drive one handler to completion."""
+    return asyncio.run(coro)
+
+
+def refusal(model):
+    """The most recent `command_error` broadcast, or None if there is none.
+
+    A refusal is not an exception here: a handler reports failure by
+    broadcasting `command_error` and returning without a value, so that clients
+    on every SDK generation can see it.
+    """
+    errors = [message for message in model.sent if type(message).__name__ == "CommandError"]
+    return errors[-1] if errors else None
+
+
+@pytest.fixture
+def model():
+    """A FastH3 with the attributes ``load()`` would have set, and no engine."""
+    instance = FastH3()
+    # Loop-bound state the runtime creates when the model loop starts.
+    instance._on_loop_ready()
+    # The handful of values load() reads out of fasth3.yaml.
+    instance.default_aspect = "16:9"
+    instance.default_clip_frames = clip_plan.frames_for_seconds(clip_plan.MAX_SECONDS)
+    instance.ramp_frames = (clip_plan.MIN_FRAMES,)
+    instance.default_seed = 1000
+    instance.num_inference_steps = 5
+    instance._reset_session_state()
+
+    sent: list = []
+
+    async def capture(message):
+        sent.append(message)
+
+    instance.send = capture
+    instance.sent = sent
+    return instance
+
+
+def test_start_needs_a_prompt(model):
+    """A fresh session has no prompt, so the channel waits for the client."""
+    assert model._prompt == ""
+    assert run(model.start()) is None
+    assert refusal(model).command == "start"
+    assert model._started is False
+
+
+def test_start_arms_the_channel(model):
+    run(model.set_prompt(prompt="a lighthouse in fog"))
+    run(model.start())
+    assert model._started is True
+
+
+def test_start_is_refused_while_a_channel_runs(model):
+    model._running = True
+    assert run(model.start()) is None
+    assert refusal(model).command == "start"
+
+
+def test_an_empty_prompt_clears_the_condition(model):
+    run(model.set_prompt(prompt="a lighthouse in fog"))
+    reply = run(model.set_prompt(prompt="   "))
+    # "Unset" is null on the wire, never an empty string — the same convention
+    # `state_update.prompt` uses, so a client reads one shape from both.
+    assert reply.prompt is None
+    assert model._prompt == ""
+    # And `start` goes back to being refused.
+    assert run(model.start()) is None
+    assert refusal(model).command == "start"
+
+
+def test_clip_length_snaps_to_something_generatable(model):
+    reply = run(model.set_clip_seconds(seconds=8.3))
+    assert reply.frames % 17 == 5
+    assert reply.clip_seconds == pytest.approx(reply.frames / 24, abs=1e-3)
+    assert model._clip_frames == reply.frames
+
+
+def test_the_canvas_is_locked_once_a_channel_runs(model):
+    reply = run(model.set_canvas(aspect="9:16"))
+    assert (reply.height, reply.width) == clip_plan.canvas_for_choice("9:16")
+    model._running = True
+    assert run(model.set_canvas(aspect="1:1")) is None
+    assert refusal(model).command == "set_canvas"
+    # The refused command had no effect.
+    assert model._aspect == "9:16"
+
+
+def test_pause_and_resume_only_apply_to_a_live_channel(model):
+    assert run(model.pause()) is None
+    assert refusal(model).command == "pause"
+
+    model._running = True
+    assert run(model.pause()) is not None  # accepted: a real reply comes back
+    assert model._paused is True
+    assert run(model.pause()) is None
+    assert refusal(model).command == "pause"
+
+    assert run(model.resume()) is not None
+    assert model._paused is False
+    assert run(model.resume()) is None
+    assert refusal(model).command == "resume"
+
+
+def test_stop_keeps_the_conditions(model):
+    run(model.set_prompt(prompt="a lighthouse in fog"))
+    run(model.set_clip_seconds(seconds=10.0))
+    model._running = True
+    run(model.stop())
+    assert model._started is False
+    assert model._do_reset is True
+    assert model._stop_only is True
+    assert model._prompt == "a lighthouse in fog"
+    assert model._clip_frames == clip_plan.frames_for_seconds(10.0)
+
+
+def test_reset_restores_every_default(model):
+    run(model.set_prompt(prompt="a lighthouse in fog"))
+    run(model.set_clip_seconds(seconds=10.0))
+    run(model.set_seed(seed=7))
+    run(model.set_canvas(aspect="1:1"))
+
+    reply = run(model.reset())
+    assert reply.was_running is False
+    assert model._prompt == ""
+    assert model._clip_frames == model.default_clip_frames
+    assert model._seed == model.default_seed
+    assert model._aspect == model.default_aspect
+
+
+def test_reset_while_idle_does_not_wedge_the_arm_loop(model):
+    """`_do_reset` left set with nothing running would block every later start.
+
+    ``_wait_until_armed`` deliberately does not read the flag, and ``reset``
+    only raises it for a channel that is actually live. Both halves are asserted
+    here because either alone would still hang the model loop.
+    """
+    run(model.reset())
+    assert model._do_reset is False
+
+    run(model.set_prompt(prompt="a lighthouse in fog"))
+    run(model.start())
+    assert model._started and model._prompt
+
+
+def test_a_prompt_set_while_idle_lands_on_the_first_clip(model):
+    reply = run(model.set_prompt(prompt="a lighthouse in fog"))
+    assert reply.effective_clip_index == 0
+    assert reply.effective_in_seconds == 0.0
+
+
+def test_a_prompt_set_before_the_first_clip_lands_on_the_second(model):
+    """Clip 0 is already being built, so the earliest a change can land is clip 1."""
+    model._running = True
+    model._clip_index = -1
+    reply = run(model.set_prompt(prompt="a lighthouse in fog"))
+    assert reply.effective_clip_index == 1
+    # The wait is the whole of clip 0 — the ramp's short opening clip.
+    assert reply.effective_in_seconds == pytest.approx(clip_plan.MIN_FRAMES / 24, abs=0.01)
+
+
+def test_a_prompt_set_mid_channel_lands_two_clips_out(model):
+    """Clip k is playing and clip k+1 is already built, so a change lands on k+2."""
+    model._running = True
+    model._clip_index = 3
+    model._current_clip_seconds = 14.375
+    model._clip_start_seconds = 40.0
+    model._seconds_sent = 44.0  # 4 s into clip 3
+
+    reply = run(model.set_prompt(prompt="a lighthouse in fog"))
+    assert reply.effective_clip_index == 5
+    # 10.375 s left of clip 3, then the whole of clip 4.
+    assert reply.effective_in_seconds == pytest.approx(10.375 + 14.375, abs=0.01)
+
+
+def test_get_state_reports_the_same_snapshot_that_is_broadcast(model):
+    run(model.set_prompt(prompt="a lighthouse in fog"))
+    model.sent.clear()
+    run(model._send_state_update())
+    broadcast = model.sent[-1]
+    direct = run(model.get_state())
+    assert vars(direct) == vars(broadcast)
+
+
+def test_the_snapshot_publishes_the_live_command_set(model):
+    snapshot = run(model.get_state())
+    assert snapshot.ready is False
+    assert "start" not in snapshot.valid_commands  # no prompt yet
+
+    run(model.set_prompt(prompt="a lighthouse in fog"))
+    snapshot = run(model.get_state())
+    assert snapshot.ready is True
+    assert "start" in snapshot.valid_commands
+    assert (snapshot.height, snapshot.width) == clip_plan.canvas_for_choice("16:9")
+
+
+def test_the_ramp_shortens_only_the_opening_clip(model):
+    assert model._frames_for_clip(0) == clip_plan.MIN_FRAMES
+    assert model._frames_for_clip(1) == model.default_clip_frames
+    assert model._frames_for_clip(50) == model.default_clip_frames
+
+
+def test_a_refusal_never_masquerades_as_a_reply(model):
+    """A handler must return only the type its annotation names.
+
+    `pause` is annotated `-> ChannelPaused`; a refusal that returned a
+    `CommandError` from it would reach the client typed as the message the
+    schema promised, with every guaranteed field undefined.
+    """
+    assert run(model.pause()) is None
+    error = refusal(model)
+    assert type(error).__name__ == "CommandError"
+    assert error.reason
+
+
+def test_the_runtime_exception_is_never_raised(model):
+    """Its correlated failure frame is withheld from v0 clients, so a raise is
+    silence for anyone on the 2.x SDK. The broadcast is what reaches them."""
+    source = (MODEL_DIR / "fasth3.py").read_text(encoding="utf-8")
+    assert "raise CommandError" not in source
+    # And the name in scope is the model's own message, not the runtime's.
+    from fasth3 import CommandError as in_scope
+    from fasth3_types import CommandError as ours
+
+    assert in_scope is ours
+
+
+# ----------------------------------------------------------------- the channel
+#
+# ``_run_channel`` is the concurrent part of this model — a worker thread
+# building clips, an event loop pacing them out, and abort paths crossing both.
+# These tests replace only the clip *builder*, so the real queueing, ordering,
+# emission and teardown all run.
+#
+# Clips are shrunk to a few frames so a whole channel plays in well under a
+# second; the pacer is a real 24 fps clock, so the numbers below are wall time.
+
+FRAMES_PER_CLIP = 6  # 0.25 s of content at 24 fps
+
+
+@pytest.fixture
+def channel():
+    instance = FastH3()
+    instance._on_loop_ready()
+    instance.connected.set()
+    instance.default_aspect = "16:9"
+    instance.default_clip_frames = clip_plan.frames_for_seconds(clip_plan.MAX_SECONDS)
+    instance.ramp_frames = ()
+    instance.default_seed = 1000
+    instance.num_inference_steps = 5
+    instance._reset_session_state()
+    instance._prompt = "a lighthouse in fog"
+    # `_run_channel` is driven directly here, so arm the session as `start` does.
+    instance._started = True
+
+    instance._jobs = queue.Queue()
+    instance._worker = threading.Thread(
+        target=instance._worker_loop, name="test-generation", daemon=True
+    )
+    instance._worker.start()
+
+    # Every clip is a handful of tiny frames; shape does not matter here.
+    instance._frames_for_clip = lambda index: FRAMES_PER_CLIP
+
+    built: list[tuple[int, str, int]] = []
+
+    def fake_generate(index, frames, prompt, seed, height, width):
+        built.append((index, prompt, seed))
+        video = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(frames)]
+        samples = np.zeros((1, round(frames / 24 * 48_000)), dtype=np.int16)
+        return video, samples
+
+    instance._generate_clip = fake_generate
+    instance.built = built
+
+    emitted: list = []
+
+    async def fake_emit(output):
+        emitted.append(output)
+
+    instance.emit = fake_emit
+    instance.emitted = emitted
+
+    messages: list = []
+
+    async def fake_send(message):
+        messages.append(message)
+
+    instance.send = fake_send
+    instance.messages = messages
+    return instance
+
+
+def names(messages) -> list[str]:
+    return [type(m).__name__ for m in messages]
+
+
+def run_channel_until(channel, stop_after_clips: int):
+    """Run a channel, stopping it once `stop_after_clips` clips have completed."""
+
+    async def drive():
+        async def stopper():
+            while channel._clips_sent < stop_after_clips:
+                await asyncio.sleep(0.01)
+            channel._started = False
+            channel._stop_only = True
+            channel._do_reset = True
+
+        await asyncio.gather(channel._run_channel(), stopper())
+
+    asyncio.run(drive())
+
+
+async def armed_within(channel, seconds: float) -> bool:
+    """Whether `_wait_until_armed` would arm a channel inside `seconds`."""
+    try:
+        return await asyncio.wait_for(channel._wait_until_armed(), timeout=seconds)
+    except TimeoutError:
+        return False
+
+
+def test_clips_stream_in_order_and_the_channel_ends_cleanly(channel):
+    run_channel_until(channel, stop_after_clips=3)
+
+    started = [m for m in channel.messages if type(m).__name__ == "ClipStarted"]
+    assert [m.clip_index for m in started[:3]] == [0, 1, 2]
+    assert names(channel.messages)[0] == "ChannelStarted"
+    assert "ChannelStopped" in names(channel.messages)
+    assert channel._running is False
+
+
+def test_the_next_clip_is_built_while_the_current_one_plays(channel):
+    """This is what makes the channel endless; without it every clip is a stall."""
+    run_channel_until(channel, stop_after_clips=2)
+
+    # Clip 0 is emitted only after clip 1 has been asked for.
+    assert [index for index, _prompt, _seed in channel.built][:3] == [0, 1, 2]
+    assert len(channel.built) >= 3
+
+
+def test_every_frame_of_every_clip_reaches_the_wire(channel):
+    run_channel_until(channel, stop_after_clips=2)
+
+    frames = sum(output.main_video.shape[0] for output in channel.emitted)
+    # Every completed clip went out whole. The stop lands mid-clip, so the tally
+    # can exceed that by part of the clip that was interrupted.
+    assert frames >= channel._clips_sent * FRAMES_PER_CLIP
+    assert channel._clips_sent == 2
+    # The counters clients see are derived from what was actually emitted.
+    assert channel._frames_sent == frames
+    assert channel._seconds_sent == pytest.approx(frames / 24)
+
+
+def test_video_and_audio_stay_locked_slice_for_slice(channel):
+    run_channel_until(channel, stop_after_clips=2)
+
+    for output in channel.emitted:
+        video_frames = output.main_video.shape[0]
+        audio_samples = output.main_audio.shape[1]
+        assert output.main_video.dtype == np.uint8
+        assert output.main_audio.dtype == np.int16
+        assert output.main_audio.ndim == 2 and output.main_audio.shape[0] == 1
+        assert audio_samples == pytest.approx(video_frames * 48_000 / 24, abs=1)
+
+
+def test_the_prompt_of_a_clip_is_the_one_set_when_it_was_asked_for(channel):
+    """A prompt change lands on the next clip *submitted*, never the one in flight."""
+
+    async def drive():
+        async def change():
+            # Wait until clip 0 is streaming; clip 1 has been submitted by then.
+            while channel._clip_index < 0:
+                await asyncio.sleep(0.005)
+            channel._prompt = "a neon alley in the rain"
+            while channel._clips_sent < 3:
+                await asyncio.sleep(0.01)
+            channel._started = False
+            channel._stop_only = True
+            channel._do_reset = True
+
+        await asyncio.gather(channel._run_channel(), change())
+
+    asyncio.run(drive())
+
+    prompts = [prompt for _index, prompt, _seed in channel.built]
+    assert prompts[0] == "a lighthouse in fog"
+    assert prompts[1] == "a lighthouse in fog"  # already in flight when it changed
+    assert prompts[2] == "a neon alley in the rain"
+
+
+def test_each_clip_advances_the_seed(channel):
+    run_channel_until(channel, stop_after_clips=2)
+    seeds = [seed for _index, _prompt, seed in channel.built]
+    assert seeds[:3] == [1000, 1001, 1002]
+
+
+def test_a_lost_audience_winds_the_channel_down(channel):
+    """No client means no GPU spend; the channel stops at the next boundary."""
+
+    async def drive():
+        async def leave():
+            while channel._clips_sent < 1:
+                await asyncio.sleep(0.01)
+            channel.connected.clear()
+
+        await asyncio.gather(channel._run_channel(), leave())
+
+    asyncio.run(drive())
+
+    assert channel._running is False
+    # A lost audience is not a `stop`, so no channel_stopped is sent.
+    assert "ChannelStopped" not in names(channel.messages)
+    # The conditions survive, so reconnecting resumes the same channel.
+    assert channel._prompt == "a lighthouse in fog"
+    assert channel._started is True
+
+
+def test_a_failing_clip_reports_and_returns_the_model_to_idle(channel):
+    def explode(index, frames, prompt, seed, height, width):
+        raise RuntimeError("the engine fell over")
+
+    channel._generate_clip = explode
+    asyncio.run(channel._run_channel())
+
+    failures = [m for m in channel.messages if type(m).__name__ == "ChannelFailed"]
+    assert len(failures) == 1
+    assert "the engine fell over" in failures[0].reason
+    assert channel._running is False
+
+
+def test_pause_holds_the_stream_and_resume_continues_it(channel):
+    async def drive():
+        async def hold():
+            while not channel.emitted:
+                await asyncio.sleep(0.005)
+            channel._paused = True
+            # The pause is read once per slice, and a slice already waiting on
+            # the pacer is committed to going out — so it takes effect within
+            # one slice interval (EMIT_FRAMES / 24, about 0.125 s), not
+            # instantly. Wait past that before measuring.
+            await asyncio.sleep(0.25)
+            held = len(channel.emitted)
+            await asyncio.sleep(0.3)
+            assert len(channel.emitted) == held, "the stream moved while paused"
+            channel._paused = False
+            while channel._clips_sent < 1:
+                await asyncio.sleep(0.01)
+            channel._started = False
+            channel._stop_only = True
+            channel._do_reset = True
+
+        await asyncio.gather(channel._run_channel(), hold())
+
+    asyncio.run(drive())
+    assert sum(o.main_video.shape[0] for o in channel.emitted) >= FRAMES_PER_CLIP
+
+
+def test_the_pacer_holds_24_fps_across_a_clip_boundary(channel):
+    """A seam must not cost time: the clock carries from one clip to the next."""
+    started = time.monotonic()
+    run_channel_until(channel, stop_after_clips=3)
+    elapsed = time.monotonic() - started
+
+    content = 3 * FRAMES_PER_CLIP / 24
+    # A slice is handed over at the instant its content is due, so the run ends
+    # one slice before the content it queued finishes playing.
+    expected = content - EMIT_FRAMES / 24
+    # Real-time, not faster: the metronome is what keeps the audio in sync.
+    assert elapsed >= expected * 0.95
+    # And no seam stall: each clip was built long before it was needed, so three
+    # of them must not take appreciably longer than their own content.
+    assert elapsed < content + 0.3
+
+
+def test_a_failed_channel_does_not_restart_itself(channel):
+    """`run()` re-arms from `_started`; leaving it set is an eight-GPU crash loop."""
+
+    def explode(index, frames, prompt, seed, height, width):
+        raise RuntimeError("the engine fell over")
+
+    channel._generate_clip = explode
+    assert channel._started is True
+    asyncio.run(channel._run_channel())
+
+    assert channel._started is False
+    # And the arm loop agrees: it would not start another channel unattended.
+    assert asyncio.run(armed_within(channel, seconds=0.2)) is False
+
+
+# ---------------------------------------------------------- published contract
+#
+# ``reactor schema`` compiles this document out of the model class, and
+# generated SDKs are built from nothing else. A change here is a change to every
+# client, so these tests exist to make an accidental one fail loudly and a
+# deliberate one obvious in review — together with the version bump it needs.
+
+# Every command a client can send, and the message each answers with. `None`
+# means the command is answered with a bare acknowledgement.
+EXPECTED_COMMANDS = {
+    "get_state": "StateUpdate",
+    "pause": "ChannelPaused",
+    "reset": "ChannelReset",
+    "resume": "ChannelResumed",
+    "set_canvas": "CanvasAccepted",
+    "set_clip_seconds": "ClipLengthAccepted",
+    "set_prompt": "PromptAccepted",
+    "set_seed": "SeedAccepted",
+    "start": None,
+    "stop": None,
+}
+
+EXPECTED_MESSAGES = {
+    "canvas_accepted",
+    "channel_failed",
+    "channel_paused",
+    "channel_reset",
+    "channel_resumed",
+    "channel_started",
+    "channel_stopped",
+    "clip_complete",
+    "clip_length_accepted",
+    "clip_started",
+    "command_error",
+    "prompt_accepted",
+    "seed_accepted",
+    "state_update",
+}
+
+# Commands that can be refused. Each one has to say so in its own summary, and
+# name the message a client will actually receive.
+EXPECTED_REJECTIONS = ("set_canvas", "start", "pause", "resume", "stop")
+
+
+@pytest.fixture(scope="module")
+def schema():
+    """Render the document exactly as the release pipeline does.
+
+    The renderer imports the model without loading it, so this needs no weights
+    and no GPU — but it does need the model's own imports to stay light, which
+    is itself part of what this asserts.
+    """
+    from reactor_runtime.schema import render
+
+    return render(MODEL_DIR, version="v0.1.0")
+
+
+def test_the_model_publishes_two_outbound_tracks(schema):
+    tracks = schema["x-reactor"]["tracks"]
+    assert [(t["name"], t["kind"], t["direction"]) for t in tracks] == [
+        ("main_video", "video", "out"),
+        ("main_audio", "audio", "out"),
+    ]
+
+
+def test_the_command_set_is_exactly_what_clients_expect(schema):
+    published = {path.removeprefix("/events/") for path in schema["paths"]}
+    assert published == set(EXPECTED_COMMANDS)
+
+
+def test_every_command_answers_with_the_type_it_promises(schema):
+    for name, message in EXPECTED_COMMANDS.items():
+        operation = schema["paths"][f"/events/{name}"]["post"]
+        responses = operation["responses"]
+        if message is None:
+            # A handler that returns nothing is answered with a bare 202, so an
+            # awaiting client still resolves — it just learns nothing.
+            assert set(responses) == {"202"}, name
+            continue
+        body = responses["200"]["content"]["application/json"]["schema"]
+        assert body["$ref"] == f"#/components/schemas/{message}", name
+
+
+def test_every_message_is_published_once(schema):
+    assert set(schema["webhooks"]) == EXPECTED_MESSAGES
+    for message in EXPECTED_COMMANDS.values():
+        if message is not None:
+            assert message in schema["components"]["schemas"]
+
+
+def test_the_clip_length_bounds_a_client_reads_are_generatable(schema):
+    seconds = schema["paths"]["/events/set_clip_seconds"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]["seconds"]
+    assert seconds["minimum"] == clip_plan.MIN_SECONDS_PUBLISHED
+    assert seconds["maximum"] == clip_plan.MAX_SECONDS_PUBLISHED
+    for bound in (seconds["minimum"], seconds["maximum"]):
+        assert clip_plan.frames_for_seconds(bound) % 17 == 5
+
+
+def test_the_canvas_choices_are_published_as_an_enum(schema):
+    aspect = schema["paths"]["/events/set_canvas"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]["aspect"]
+    assert aspect["enum"] == list(clip_plan.ASPECT_CHOICES)
+
+
+def test_every_client_facing_string_is_documented(schema):
+    """A frontend developer who cannot read this repo works from these alone."""
+    for path, operations in schema["paths"].items():
+        assert operations["post"].get("summary"), f"{path} has no description"
+        body = operations["post"].get("requestBody")
+        if not body:
+            continue
+        properties = body["content"]["application/json"]["schema"]["properties"]
+        for name, field in properties.items():
+            assert field.get("description"), f"{path} parameter {name} has no description"
+    for name, message in schema["webhooks"].items():
+        assert message["post"].get("summary"), f"message {name} has no description"
+    # Only the messages this model declares. The runtime contributes its own
+    # components (the upload reference, for one), and those are not ours to
+    # document.
+    ours = {
+        message["post"]["requestBody"]["content"]["application/json"]["schema"]["$ref"].rsplit(
+            "/", 1
+        )[-1]
+        for message in schema["webhooks"].values()
+    }
+    assert ours, "no message definitions were resolved from the webhooks"
+    for name in ours:
+        definition = schema["components"]["schemas"][name]
+        for field_name, field in definition.get("properties", {}).items():
+            assert field.get("description"), f"{name}.{field_name} has no description"
+
+
+def test_every_message_summary_says_when_it_is_emitted(schema):
+    """The house style: a message docstring opens with "Emitted ..."."""
+    for name, message in schema["webhooks"].items():
+        summary = message["post"]["summary"]
+        assert summary.startswith("Emitted "), f"{name}: {summary!r}"
+
+
+def test_no_message_name_repeats_the_model_name(schema):
+    """The SDK client already identifies the model; a prefix is dead weight."""
+    for name in schema["webhooks"]:
+        assert not name.startswith("fasth3"), name
+    for name in schema["components"]["schemas"]:
+        assert not name.lower().startswith("fasth3"), name
+
+
+def test_every_command_summary_names_what_it_emits(schema):
+    for name in EXPECTED_COMMANDS:
+        summary = schema["paths"][f"/events/{name}"]["post"]["summary"]
+        if name == "get_state":
+            # A pure read: it answers, it does not emit.
+            assert "state_update" in summary
+            continue
+        assert "`state_update`" in summary, f"{name} does not say it broadcasts a snapshot"
+
+
+def test_every_refusable_command_documents_its_failure(schema):
+    for name in EXPECTED_REJECTIONS:
+        summary = schema["paths"][f"/events/{name}"]["post"]["summary"]
+        assert "`command_error`" in summary, f"{name} does not document its failure"
+
+
+def test_a_prompt_that_is_not_set_is_null_not_empty(schema):
+    """`None` is the unset value on the wire; an empty string would be ambiguous."""
+    for message in ("StateUpdate", "PromptAccepted"):
+        prompt = schema["components"]["schemas"][message]["properties"]["prompt"]
+        types = prompt.get("anyOf") or [prompt]
+        assert any(entry.get("type") == "null" for entry in types), f"{message}.prompt: {prompt}"
+
+
+def test_clip_length_prose_matches_the_published_bounds(schema):
+    """The numbers in the description are generated from the same constants."""
+    summary = schema["paths"]["/events/set_clip_seconds"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]["seconds"]["description"]
+    assert f"{clip_plan.MIN_SECONDS_PUBLISHED:g}" in summary
+    assert f"{clip_plan.MAX_SECONDS_PUBLISHED:g}" in summary
+
+
+# ------------------------------------------------------------------- manifest
+#
+# The workspace rules from GUIDELINES.md, checked here rather than discovered
+# during a build.
+
+# A stray checkpoint in the folder is a large, slow mistake to discover later.
+WEIGHT_SUFFIXES = {".safetensors", ".ckpt", ".pt", ".pth", ".bin", ".gguf", ".onnx"}
+
+
+@pytest.fixture(scope="module")
+def manifest() -> dict:
+    return yaml.safe_load((MODEL_DIR / "reactor.yaml").read_text(encoding="utf-8"))
+
+
+def test_the_model_name_matches_the_folder(manifest):
+    """The folder is the workspace, and the name is the published slug."""
+    assert manifest["model"]["name"] == MODEL_DIR.name
+
+
+def test_the_version_is_semver_with_a_v_prefix(manifest):
+    version = manifest["model"]["version"]
+    assert isinstance(version, str), "quote the version so it is not parsed as a number"
+    assert re.fullmatch(r"v\d+\.\d+\.\d+", version), f"{version!r} must be semver with a `v`"
+
+
+def test_the_manifest_carries_a_complete_resource_spec(manifest):
+    resources = manifest["model"]["resources"]
+    assert resources["gpu"]["type"] and resources["gpu"]["count"] >= 1
+    assert resources["cpu"]["request"] and resources["cpu"]["limit"]
+    assert resources["memory"]["request"] and resources["memory"]["limit"]
+
+
+def test_the_image_is_built_from_the_manifest_not_a_dockerfile(manifest):
+    """`reactor build` owns the image; a Dockerfile here would be ignored."""
+    assert not (MODEL_DIR / "Dockerfile").exists()
+    build = manifest["build"]
+    assert build["python_requirements"] == "requirements.txt"
+    assert (MODEL_DIR / build["python_requirements"]).is_file()
+
+
+def test_the_config_the_runtime_hands_to_load_exists(manifest):
+    config = manifest["runtime"]["config"]
+    assert (MODEL_DIR / config).is_file(), f"runtime.config points at a missing {config}"
+
+
+def test_the_runtime_pin_matches_the_rest_of_the_repo(manifest):
+    """Every model here pins the same Reactor Runtime release."""
+    assert manifest["build"]["runtime_version"] == "3.2.5"
+
+
+def test_the_runtime_release_is_pinned_once(manifest):
+    """`build.runtime_version` owns it; a second pin would let the two drift."""
+    assert "reactor-runtime" not in (MODEL_DIR / "requirements.txt").read_text(encoding="utf-8")
+
+
+def test_the_runtime_import_resolves_to_the_model_class(manifest):
+    module_name, _, class_name = manifest["runtime"]["import"].partition(":")
+    module = __import__(module_name)
+    assert getattr(module, class_name, None) is not None, f"{module_name}.py has no {class_name}"
+
+
+def test_no_weights_are_committed_alongside_the_model():
+    offenders = [
+        path.relative_to(MODEL_DIR)
+        for path in MODEL_DIR.rglob("*")
+        if path.is_file() and path.suffix.lower() in WEIGHT_SUFFIXES
+    ]
+    assert not offenders, f"weights never live in git: {offenders}"


### PR DESCRIPTION
FastH3 is MiniMax-H3 (35B) distilled by FastVideo to four transformer forwards
with 90% sparse video attention. On eight B200s it builds video faster than the
video plays, so this model turns that into an endless prompt-driven channel: it
always builds the next clip while the current one is on the wire, and
`main_video` and `main_audio` never run dry. Change the prompt live and the
channel follows it.

Ported from an internal workspace onto this repo's authoring standard:

- Modules carry the model-name prefix — `fasth3.py`, `fasth3_types.py`,
  `fasth3_clip_plan.py`, `fasth3_session_rules.py`, `fasth3.yaml`.
- The image is described by the manifest's `build:` block instead of a
  Dockerfile; `mise.toml` is gone.
- `model.version` is `v`-prefixed, `recording:` is nested under `runtime:`, and
  the runtime pin joins the rest of the repo at 3.2.5 (was 3.2.0).
- Six test modules merged into one `tests/test_fasth3.py`; every behavioural
  test carried over unchanged, and the manifest tests were rewritten against
  this repo's rules.
- The client-facing behaviour doc folded into `README.md`.

### Notes for review

- **`ReactorModel`, not `ReactorPipeline`.** The unit of work is a whole clip
  produced by one blocking call, not a frame, so the generator base would buy
  nothing. Command handlers run concurrent with `run()`, which is what lets
  `pause` and `stop` answer mid-build. This is the one place the port departs
  from GUIDELINES.md's authoring shape, and the README says why.
- **`cuda_version: "13.1.2"`**, against 12.8.1 everywhere else here. The VSA-H3
  sparse kernel and the FA4 CuTe kernels are both cu130 builds.
- **Not yet built or run in this repo's toolchain.** The port is mechanical and
  the manifests parse, but `reactor build` needs verifying, and the test suite
  needs Python 3.12 plus reactor-runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)