### PR TITLE
Turn fasth3 into an explicit clip queue with per-clip playback

### DIFF
--- a/models/fasth3/.dockerignore
+++ b/models/fasth3/.dockerignore
@@ -19,3 +19,6 @@ Thumbs.db
 .gitignore
 weights/
 
+# Client-side code; nothing in the image imports it
+client/
+

--- a/models/fasth3/README.md
+++ b/models/fasth3/README.md
@@ -1,14 +1,19 @@
 # FastH3
 
-An endless, prompt-driven video and audio channel. Set a prompt and the model
-streams 768p video with synchronized audio over WebRTC continuously, always
-building the next clip while the current one plays, so the stream never runs
-dry. Change the prompt live and the channel follows it.
+A queue of prompt-driven video clips with synchronized audio. Clients enqueue
+generation requests — a prompt plus their own metadata, each answered with a
+UUID — the model builds them in order into a bounded buffer, and playback is a
+separate, explicit step: `play` streams one built clip at 768p over WebRTC,
+and when it ends the stream holds on black until the next `play`. Nothing
+plays on its own.
 
-Reach for this when you want a *channel* rather than a file: a always-on
-backdrop, a live visual that responds to typed direction, a stream a room full
-of people watches together. If you want one finished clip returned to you, this
-is the wrong shape — the model never stops on its own.
+Reach for this when something else decides what plays and when: a frontend
+that lets people submit prompts and curates the order, a playlist that is
+assembled faster than it is watched, a controller that wants clips ready
+before they are needed. The model is the queue handler and the renderer; the
+scheduling brain sits on the client side of the API. If you want one finished
+clip returned as a file, this is the wrong shape — clips are streamed, not
+returned.
 
 [FastH3 Preview v1](https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree)
 is MiniMax-H3 (35B) distilled by FastVideo with data-free DMD2 down to **four
@@ -21,8 +26,8 @@ conditioning are not.
 
 - **Eight NVIDIA B200s.** Eight is load-bearing, not a performance preference:
   sequence parallelism spans all of them, and a 15 s clip builds in 12.88 s on
-  eight against 15.5 s on four. Only the former is faster than the video plays,
-  which is the whole premise of a continuous channel.
+  eight against 15.5 s on four. Only the former keeps a queued prompt playable
+  in under its own duration, which is what makes the queue feel live.
 - **CUDA 13.** The VSA-H3 sparse kernel and the FA4 CuTe kernels are both cu130
   builds, which is why this model's `build.cuda_version` differs from every
   other model here.
@@ -64,15 +69,61 @@ reactor build
 reactor run
 ```
 
-`load()` warms one throwaway clip per shape before the pod reports ready, so the
-first real clip streams at warm speed. Every distinct frame count and canvas is
-a separate one-time cost, which is why `inference.warmup_aspects` in
-[`fasth3.yaml`](./fasth3.yaml) is a deliberately short list.
+`load()` warms one throwaway clip per configured canvas before the pod reports
+ready, so the first real build runs at warm speed. Every distinct frame count
+and canvas is a separate one-time compile cost, which is why
+`inference.warmup_aspects` in [`fasth3.yaml`](./fasth3.yaml) is a deliberately
+short list and why the first build at a non-default `set_clip_seconds` pays a
+one-off stall.
 
-Before blaming the adapter for a slow channel, baseline the recipe itself with
+Before blaming the adapter for slow builds, baseline the recipe itself with
 FastVideo's own `examples/inference/basic/basic_fasth3.py` at the same settings.
 Its median is the number this model should match; a gap is the adapter's fault,
 not the model's.
+
+## The mental model
+
+```
+enqueue ──► [ queue, oldest first, up to inference.queue_size ] ──► play ──► tracks
+              build build build ... (in order, one at a time)          │
+              ready clips wait in host memory                          ▼
+                                                            clip ends or stop:
+                                                            flush → black, wait
+```
+
+- **`enqueue` is the only way in.** Each request snapshots the session's
+  conditions (`set_clip_seconds`, `set_seed`, `set_canvas`) as they stand, gets
+  a UUID, and joins the back of the queue. The queue is bounded
+  (`inference.queue_size`, default 10); a full queue refuses further enqueues.
+- **Builds run through the queue front to back**, one at a time, whenever an
+  audience is connected — including while another clip is playing. A finished
+  build turns the entry `ready: true`, announced on `queue_update`.
+- **`play` is the only way out.** Bare `play` takes the oldest ready clip; a
+  `clip_id` takes that specific one. Playing consumes the entry. When the clip
+  ends — or `stop` cuts it — the output flushes to black and the session waits
+  for the next `play`.
+- **Everything a clip is travels with every mention of it.** `clip_queued`,
+  `queue_update`, `clip_started`, `clip_finished`, `clip_stopped` and
+  `clip_failed` all embed the full `ClipInfo` structure, so a client never has
+  to join a UUID against an earlier message.
+
+## The `ClipInfo` structure
+
+| Field | Type | Meaning |
+|---|---|---|
+| `clip_id` | string | UUID assigned at `enqueue`; every later reference uses it. |
+| `prompt` | string | What the clip shows, exactly as enqueued. |
+| `metadata` | string | Opaque client string, echoed back untouched — see below. |
+| `frames` | int | Clip length in frames, fixed at enqueue time. |
+| `seconds` | float | The same length in seconds (`frames / 24`). |
+| `seed` | int | Seed this clip generates from. |
+| `ready` | bool | Whether the clip is built and can be played. |
+
+**Metadata is for the frontend, not the model.** The model stores it and echoes
+it back on every message that references the clip; it never parses it. Use it to
+carry whatever your application needs to track — which request produced the
+clip, who asked for it, which group of enqueues it belongs to, text to show
+while it plays. Up to 2000 characters; JSON fits if you want structure.
 
 ## Tracks
 
@@ -82,52 +133,42 @@ not the model's.
 | `main_audio` | out | audio | 48 kHz | Mono, synchronized frame-for-frame with `main_video` |
 
 There are no inbound tracks: the model reads no camera and no microphone. The
-video size is fixed for the life of a channel — `set_canvas` chooses it and is
-only accepted while the channel is idle, so the track never changes size
-mid-stream.
+video track keeps one size — `set_canvas` chooses it and is only accepted while
+the queue is empty and nothing is playing, since queued clips are built at the
+size in force.
 
 ## Commands
 
-| Command | Parameters | Effect | Rejected with |
+| Command | Parameters | Effect | Rejected when |
 |---|---|---|---|
-| `set_prompt` | `prompt` (≤ 800 chars) | Sets what the channel shows. Empty clears it. Replies `prompt_accepted`. | — |
-| `set_clip_seconds` | `seconds` (5.167–14.375) | Sets clip length; the value is snapped to what the model can produce and the effective one is returned in `clip_length_accepted`. | — |
-| `set_seed` | `seed` (≥ 0) | Seed the next channel starts from; each clip advances it by one. Replies `seed_accepted`. | — |
-| `set_canvas` | `aspect` (`16:9`, `1:1`, `9:16`, `4:3`) | Sets the video size for the session. Replies `canvas_accepted`. | `channel_running`, `unsupported_aspect` |
-| `start` | — | Begins the channel. Emits `channel_started`, then streams. | `already_running`, `missing_prompt` |
-| `pause` | — | Freezes playout. Replies `channel_paused`. | `not_running`, `already_paused` |
-| `resume` | — | Continues playout. Replies `channel_resumed`. | `not_paused` |
-| `stop` | — | Ends the channel, keeping every condition. Emits `channel_stopped`. | `not_running` |
-| `reset` | — | Returns every condition to its default and clears the stream. Replies `channel_reset`. | — |
+| `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars) | Queues one generation; replies `clip_queued` with the full `ClipInfo`. | queue full, empty prompt |
+| `play` | `clip_id` (optional UUID) | Streams the oldest ready clip, or the named one. Emits `clip_started` as frames begin. | already playing, unknown id, clip not ready |
+| `stop` | — | Cuts the playing clip to black; the queue is untouched. Emits `clip_stopped`. | nothing playing |
+| `get_queue` | — | Replies with the full queue — the same payload as `queue_update`. | — |
+| `set_clip_seconds` | `seconds` (5.167–14.375) | Length for *newly enqueued* clips, snapped to what the model can produce; the effective value returns in `clip_length_accepted`. | — |
+| `set_seed` | `seed` (≥ 0) | Seed the next enqueue uses; each enqueue advances it by one. Replies `seed_accepted`. | — |
+| `set_canvas` | `aspect` (`16:9`, `1:1`, `9:16`, `4:3`) | Video size for the session. Replies `canvas_accepted`. | clips queued or playing, unsupported aspect |
+| `reset` | — | Drops the whole queue, cuts any playing clip, restores every default. Replies `session_reset`. | — |
 | `get_state` | — | Replies with the full `state_update` snapshot. | — |
 
-A rejected command has no effect. Rejections carry a stable `code` (the values
-above) plus a readable message, so a client can branch on the code.
-
-`stop` halts the stream within about a second. The clip already being built
-cannot be cancelled, so the model can take several more seconds to go fully
-idle; `state_update` reports `running: false` when it has.
+A rejected command has no effect and is answered by a broadcast
+`command_error` naming the command and the reason.
 
 ## Messages
 
 | Message | Reaches | When |
 |---|---|---|
-| `state_update` | everyone | On connect, and after every change. A complete snapshot — render from this alone. |
-| `prompt_accepted` | the caller | Reply to `set_prompt`. Carries where the prompt lands. |
+| `state_update` | everyone | On connect, and after every change. A complete snapshot minus the queue's contents — render from this plus `queue_update` alone. |
+| `queue_update` | everyone | On connect, and whenever the queue changes: an enqueue, a clip turning ready, a clip leaving to play, a reset. Carries every `ClipInfo`, oldest first. |
+| `clip_queued` | the caller | Reply to `enqueue`. The full `ClipInfo`, UUID included. |
+| `clip_started` | everyone | A clip's first frames reach the tracks. |
+| `clip_finished` | everyone | A clip was fully sent; the stream is now black until the next `play`. |
+| `clip_stopped` | everyone | `stop` (or `reset`) cut the clip; the rest of it is discarded. |
+| `clip_failed` | everyone | A build failed; the clip left the queue and the queue moves on. |
 | `clip_length_accepted` | the caller | Reply to `set_clip_seconds`. Carries the snapped value. |
 | `seed_accepted` | the caller | Reply to `set_seed`. |
 | `canvas_accepted` | the caller | Reply to `set_canvas`. Carries the exact pixel size. |
-| `channel_started` | everyone | `start` accepted. No frames yet. |
-| `clip_started` | everyone | A clip begins streaming — this is where the picture and sound cut. |
-| `clip_complete` | everyone | A clip has been fully sent. |
-| `channel_paused` / `channel_resumed` | the caller | Replies to `pause` / `resume`. |
-| `channel_stopped` | everyone | The channel ended via `stop`. |
-| `channel_failed` | everyone | The channel ended early because something went wrong; the model returns to idle. |
-| `channel_reset` | the caller | Reply to `reset`. |
-
-Anywhere a prompt appears on the wire — `state_update.prompt`,
-`prompt_accepted.prompt` — **"not set" is `null`, never an empty string**, so a
-client can test one thing rather than two.
+| `session_reset` | the caller | Reply to `reset`. Says how many clips were dropped. |
 
 ## Session lifecycle
 
@@ -135,73 +176,61 @@ client can test one thing rather than two.
   session starts (no clients yet)
     |
     v
-  client connects            -> state_update (a full snapshot, to this client)
+  client connects       -> state_update + queue_update (to this client)
     |
-  ┌──────────────────────────────────────────────────────────────┐
-  │ IDLE                                                         │
-  │ Valid: set_prompt, set_clip_seconds, set_seed, set_canvas,   │
-  │        reset, get_state, and start once a prompt is set      │
-  │ No frames on either track                                    │
-  └───────────────────────────┬──────────────────────────────────┘
-                              v  start
-  ┌──────────────────────────────────────────────────────────────┐
-  │ BUILDING THE FIRST CLIP                                      │
-  │ channel_started is emitted immediately; NO frames yet        │
-  │ Lasts several seconds — show progress, not a stalled player  │
-  └───────────────────────────┬──────────────────────────────────┘
-                              v
-  ┌──────────────────────────────────────────────────────────────┐
-  │ STREAMING                                                    │
-  │ Valid: set_prompt, set_clip_seconds, set_seed, pause/resume, │
-  │        stop, reset, get_state                                │
-  │ Messages: clip_started, clip_complete, state_update          │
-  │ Tracks: main_video + main_audio, continuously                │
-  └───────────────────────────┬──────────────────────────────────┘
-                              v  stop / reset / last client leaves
-                        (back to IDLE)
+  ┌───────────────────────────────────────────────────────────────┐
+  │ IDLE (black screen)                                           │
+  │ Valid: enqueue, set_clip_seconds, set_seed, reset, get_queue, │
+  │        get_state; set_canvas while the queue is empty;        │
+  │        play once a clip is ready                              │
+  │ Builds run in the background whenever the queue has work      │
+  └───────────────────────────┬───────────────────────────────────┘
+                              v  play
+  ┌───────────────────────────────────────────────────────────────┐
+  │ PLAYING one clip                                              │
+  │ Valid: enqueue, set_clip_seconds, set_seed, stop, reset,      │
+  │        get_queue, get_state                                   │
+  │ Messages: clip_started, then clip_finished or clip_stopped    │
+  │ Builds keep running behind the playout                        │
+  └───────────────────────────┬───────────────────────────────────┘
+                              v  clip ends / stop / reset
+                    (flush to black, back to IDLE)
 ```
 
-**Single session, shared state.** Several clients may watch one session, and
-they all see the same channel: a `set_prompt` or a `stop` from any client
-affects everyone, and every client receives every `state_update`. Generation is
-gated on having an audience — when the last client leaves the channel winds down
-at the next clip boundary, so nothing is generated with nobody watching.
+**Single session, shared state.** Several clients may attach to one session and
+they all see the same queue and the same stream: an `enqueue` or a `stop` from
+any client affects everyone, and every client receives every `state_update` and
+`queue_update`. Generation is gated on having an audience — with nobody
+connected no new build starts, though a build already running finishes into the
+queue.
 
-A prompt is required before `start`; everything else has a default.
+`state_update.valid_commands` names exactly what the session would accept at
+that moment, so a frontend enables and greys out controls from the snapshot
+instead of re-deriving these rules.
 
 ## What to expect from the timing
 
-Two numbers matter, and they are different things:
+- **Enqueue-to-ready** is one build: roughly the clip's own duration on eight
+  B200s (a 14.375 s clip in about 13 s), plus the wait behind earlier queued
+  builds. `queue_update` reports the clip turning `ready`.
+- **Play-to-first-frame** is near-instant for a ready clip — the frames are
+  already in host memory; the only latency is the transport.
+- **`stop`** cuts to black within a fraction of a second: the emitter checks the
+  flag every slice (about an eighth of a second) and whatever the transport
+  still holds is flushed. A build in flight for another clip is unaffected —
+  and cannot be cancelled, so `reset` may keep the GPUs busy for a few more
+  seconds finishing a clip it will then discard.
 
-- **Time to first frame.** Nothing streams until the first clip is fully built.
-  The channel deliberately opens with a *shorter* clip (`inference.ramp_seconds`),
-  which builds proportionally faster, so this is a few seconds rather than a
-  full clip build. `channel_started` fires immediately and carries
-  `first_clip_seconds`; treat it as the cue to show progress.
-- **Steady state.** From then on the model builds faster than the video plays,
-  so the stream should not stall. If the hardware cannot keep up, the symptom is
-  a brief freeze at a clip boundary, not a dropped or corrupted stream. `seam
-  late` in the log is the gate: it fires when a clip was not ready by the time
-  its predecessor ran out, and a clean multi-hour run should never print it. The
-  levers, in order, are longer clips, regional compile, and replicated rather
-  than sharded weights.
-
-Output is a strict 24 fps metronome and the audio is sample-clocked against the
-same rate, so the two tracks stay locked over hours. `pause` freezes the stream
-within about an eighth of a second; the model keeps building ahead while paused,
-so `resume` continues instantly rather than skipping forward to catch up.
+Playout is a strict 24 fps metronome and the audio is sample-clocked against
+the same rate, so the two tracks stay locked for the length of any clip.
 
 ## Clip boundaries are hard cuts
 
-Every clip is generated independently. **The picture and the sound cut at each
-boundary** — there is no continuity of subject, framing, or voice from one clip
-to the next, even with the prompt unchanged. `clip_started` marks each cut, so a
-UI can anticipate it.
-
-This checkpoint has no continuation path, and inventing one is not an adapter's
-decision. It is why [`fasth3.yaml`](./fasth3.yaml) defaults to the longest clip
-the model supports, and why `runtime.recording` is left disabled: a recording
-would carry those cuts too.
+Every clip is generated independently. There is no continuity of subject,
+framing, or voice from one clip to the next, even with identical prompts — and
+the stream holds on black between plays. This checkpoint has no continuation
+path, and inventing one is not an adapter's decision. It is why
+`runtime.recording` is left disabled: a recording would carry those cuts too.
 
 The geometry it accepts is narrow, and [`fasth3_clip_plan.py`](./fasth3_clip_plan.py)
 encodes it: 24 fps, a frame count of the form `17n + 5`, a duration between 5
@@ -210,47 +239,33 @@ multiple of 32. The duration cap has a sharp edge — 15.0 s is 360 frames, whic
 aligns *up* to 362 (15.083 s) and is then rejected, so **the longest clip this
 model can make is 345 frames, 14.375 s**.
 
-## Changing the prompt mid-channel
-
-The model is always one clip ahead. When clip *k* is playing, clip *k+1* has
-already been built with the prompt as it stood earlier, so a prompt sent now
-first appears on clip *k+2*.
-
-You never have to work this out. Both `prompt_accepted` and `state_update` carry
-`prompt_effective_clip_index` (the clip this prompt will first appear on) and
-`prompt_effective_in_seconds` (how much already-built video plays before it).
-Render the second one directly — "new prompt in ~21 s". Shorter clips
-(`set_clip_seconds`) shorten this wait, at the cost of cutting more often.
-
 ## Determinism
 
-`set_seed` fixes the seed the channel starts from, and each clip advances it by
-one, so the same seed with the same prompt, clip length and canvas reproduces
-the same sequence of clips. Reproduction is approximate rather than bit-exact:
-the deployment runs fused and compiled kernels that can reorder floating-point
-operations.
+Each enqueued clip carries its own seed: `set_seed` fixes the next one, and
+each `enqueue` advances it by one. Re-enqueuing the same prompts in the same
+order with the same starting seed, clip length and canvas reproduces the same
+clips. Reproduction is approximate rather than bit-exact: the deployment runs
+fused and compiled kernels that can reorder floating-point operations.
 
 ## Notes on the code
 
 **`ReactorModel`, not `ReactorPipeline`.** The generator base is shaped for
 frame-per-step models, where a `yield` is the natural unit of work. Here the
 unit is a whole clip produced by one blocking call, so the generator would buy
-nothing and cost the usual workarounds — `pause` holding by yielding `Idle`,
-polling the handoff with `get_nowait()`, and session state living in a
-runtime-built `InputState`. Under `ReactorModel`, command handlers and lifecycle
-hooks run on background coroutines *concurrent* with `run()`, so:
+nothing. Under `ReactorModel`, command handlers and lifecycle hooks run on
+background coroutines *concurrent* with `run()`, so:
 
 - session state is plain attributes reset in `_reset_session_state`, called from
   `@session_started` (not `@connected`: a client rejoining mid-session keeps the
-  channel it joined);
-- one persistent worker thread serialises every clip and gives teardown a single
-  handle to wait on;
-- refusals and accepts answer immediately, even mid-build.
+  queue it joined);
+- one persistent worker thread serialises every build and gives teardown a
+  single handle to wait on;
+- refusals and accepts answer immediately, even mid-build and mid-play.
 
-**The lookahead is exactly one clip.** `_run_channel` submits clip *k+1* the
-moment clip *k* is dequeued, then paces clip *k* out at a strict 24 fps while
-*k+1* builds. The handoff is a `Queue(maxsize=1)`, which is what bounds it —
-deeper would only bury prompt changes further behind.
+**Built clips live in host memory.** A ready clip is about 1 GB of uint8 pixels
+at the 16:9 canvas and the longest length, and the queue can hold
+`inference.queue_size` of them — size `resources.memory` in the manifest
+together with that knob.
 
 **Refusals are broadcast, not raised.** A handler returns only the message its
 annotation names and reports failure by broadcasting `command_error`. A raised
@@ -264,11 +279,14 @@ tree arrives through `requirements.txt` and an upgrade is a one-line bump.
 
 | Path | What it is |
 |---|---|
-| `fasth3.py` | The `ReactorModel`: weight loading, commands, and the `run()` loop |
-| `fasth3_types.py` | Everything a client sees — output tracks and messages |
+| `fasth3.py` | The `ReactorModel`: commands, lifecycle, the queue/playout loop |
+| `fasth3_types.py` | Everything a client sees — tracks, `ClipInfo`, messages |
+| `fasth3_queue.py` | The bounded clip queue and its entries |
+| `fasth3_backend.py` | The FastVideo engine, its worker thread, warm-up, audio conversion |
+| `fasth3_assets.py` | Config parsing and weights-bundle validation |
 | `fasth3_clip_plan.py` | Clip geometry: valid lengths, frame counts, canvases |
 | `fasth3_session_rules.py` | Which commands each session state accepts |
-| `fasth3.yaml` | `inference:` the generation recipe, `runtime:` weight layout and engine shape |
+| `fasth3.yaml` | `inference:` the recipe and queue size, `runtime:` weight layout and engine shape |
 | `reactor.yaml` | The manifest: identity, version, resources, runtime, image build |
 | `tests/` | Structural tests that need no GPU |
 
@@ -279,13 +297,14 @@ tree arrives through `requirements.txt` and an upgrade is a one-line bump.
   transfer per clip. `fasth3.yaml` therefore keeps it resident on the GPU, which
   the FSDP-sharded transformer leaves room for. Confirm against measured VRAM
   before changing either flag, and re-size `resources.memory` in the manifest
-  from what real hardware uses — the values there are an opening estimate.
+  from what real hardware uses — the values there are an opening estimate that
+  must also cover the built-clip buffer (`queue_size` × ~1 GB).
 - **Post-decode cost.** Asking FastVideo for frames in memory
   (`return_frames=True`) also allocates a full fp32 mirror of the decoded video
   and copies into it — several GB per clip that nothing reads, on top of the
   uint8 conversion that is actually needed. The per-clip log line carries the
-  stage timings; if `PostDecodeFrameProcessStage` eats the channel's slack, the
-  fix belongs upstream in FastVideo rather than here.
+  stage timings; if `PostDecodeFrameProcessStage` dominates the build, the fix
+  belongs upstream in FastVideo rather than here.
 - **The dependency closure is not yet exact.** `requirements.txt` lists what the
   model's own code needs and leaves torchvision/torchaudio to the cu130 index.
   Regenerate it from a `pip freeze` of the first successfully built image so a

--- a/models/fasth3/README.md
+++ b/models/fasth3/README.md
@@ -69,6 +69,9 @@ PYTHONPATH=. python -m pytest tests/ -q
 # Build the image and serve (needs the weights and four GPUs).
 reactor build
 reactor run
+
+# Drive the served model end to end with the reference client (saves .mp4s).
+python client/client.py
 ```
 
 `load()` warms one throwaway clip per configured canvas before the pod reports
@@ -293,6 +296,7 @@ tree arrives through `requirements.txt` and an upgrade is a one-line bump.
 | `fasth3.yaml` | `inference:` the recipe and queue size, `runtime:` weight layout and engine shape |
 | `reactor.yaml` | The manifest: identity, version, resources, runtime, image build |
 | `tests/` | Structural tests that need no GPU |
+| `client/` | Reference SDK client that drives the whole queue contract and saves what it receives |
 
 ## Open questions for bring-up
 

--- a/models/fasth3/README.md
+++ b/models/fasth3/README.md
@@ -24,10 +24,12 @@ conditioning are not.
 
 ## Prerequisites
 
-- **Eight NVIDIA B200s.** Eight is load-bearing, not a performance preference:
-  sequence parallelism spans all of them, and a 15 s clip builds in 12.88 s on
-  eight against 15.5 s on four. Only the former keeps a queued prompt playable
-  in under its own duration, which is what makes the queue feel live.
+- **Four NVIDIA B200s** — FastVideo's tested default for this checkpoint. A
+  15 s clip builds in about 15.5 s on four and 12.9 s on eight; playback is
+  explicit and clips are pre-built, so the GPU count only moves the
+  enqueue-to-ready wait. The count must divide H3's 56 attention heads
+  (1, 2, 4, 7, 8 …), and each rank holds its own ~63 GB text encoder plus a
+  66/N GB transformer shard, so fewer than four wants offloading.
 - **CUDA 13.** The VSA-H3 sparse kernel and the FA4 CuTe kernels are both cu130
   builds, which is why this model's `build.cuda_version` differs from every
   other model here.
@@ -64,7 +66,7 @@ python -m reactor_runtime.schema --path . --out /tmp/schema.json
 # The CPU-only structural tests.
 PYTHONPATH=. python -m pytest tests/ -q
 
-# Build the image and serve (needs the weights and eight GPUs).
+# Build the image and serve (needs the weights and four GPUs).
 reactor build
 reactor run
 ```
@@ -210,9 +212,11 @@ instead of re-deriving these rules.
 
 ## What to expect from the timing
 
-- **Enqueue-to-ready** is one build: roughly the clip's own duration on eight
-  B200s (a 14.375 s clip in about 13 s), plus the wait behind earlier queued
-  builds. `queue_update` reports the clip turning `ready`.
+- **Enqueue-to-ready** is one build, plus the wait behind earlier queued
+  builds; `queue_update` reports the clip turning `ready`. On the measured
+  sm100a profile a 14.375 s clip builds in about 15 s on four B200s (13 s on
+  eight); on the portable profile this deployment currently runs (triton VSA,
+  offloaded text encoder — see `fasth3.yaml`) the measured number is 31–35 s.
 - **Play-to-first-frame** is near-instant for a ready clip — the frames are
   already in host memory; the only latency is the transport.
 - **`stop`** cuts to black within a fraction of a second: the emitter checks the
@@ -292,8 +296,14 @@ tree arrives through `requirements.txt` and an upgrade is a one-line bump.
 
 ## Open questions for bring-up
 
+- **The sm100a VSA kernel does not launch.** fastvideo-kernel 0.3.5's CUDA
+  block-sparse kernel fails with `block_sparse_sm100a launch failed: invalid
+  argument` on driver 595 / CUDA 13.1 / B200, eager and compiled alike, so
+  `fasth3.yaml` runs the triton route at ~2.5x the build time. Retest each
+  fastvideo-kernel release and switch back — it also re-enables regional
+  compile, the other half of the measured fast profile.
 - **Host memory.** Every rank loads its own text encoder, so CPU-offloading it
-  across eight ranks would want several hundred GB of host memory *and* pay a
+  across four ranks would want ~250 GB of host memory *and* pay a
   transfer per clip. `fasth3.yaml` therefore keeps it resident on the GPU, which
   the FSDP-sharded transformer leaves room for. Confirm against measured VRAM
   before changing either flag, and re-size `resources.memory` in the manifest

--- a/models/fasth3/README.md
+++ b/models/fasth3/README.md
@@ -103,10 +103,12 @@ enqueue ──► [ queue, oldest first, up to inference.queue_size ] ──► 
 - **Builds run through the queue front to back**, one at a time, whenever an
   audience is connected — including while another clip is playing. A finished
   build turns the entry `ready: true`, announced on `queue_update`.
-- **`play` is the only way out.** Bare `play` takes the oldest ready clip; a
-  `clip_id` takes that specific one. Playing consumes the entry. When the clip
-  ends — or `stop` cuts it — the output flushes to black and the session waits
-  for the next `play`.
+- **`play` is the only way out** — unless autoplay is on. Bare `play` takes the
+  oldest ready clip; a `clip_id` takes that specific one. Playing consumes the
+  entry. When the clip ends — or `stop` cuts it — the output flushes to black
+  and the session waits for the next `play`. With `set_autoplay` on, the
+  oldest ready clip starts on its own whenever nothing is playing, so a
+  steadily fed queue plays through hands-free; `stop` then acts as a skip.
 - **Everything a clip is travels with every mention of it.** `clip_queued`,
   `queue_update`, `clip_started`, `clip_finished`, `clip_stopped` and
   `clip_failed` all embed the full `ClipInfo` structure, so a client never has
@@ -146,12 +148,13 @@ size in force.
 
 | Command | Parameters | Effect | Rejected when |
 |---|---|---|---|
-| `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars) | Queues one generation; replies `clip_queued` with the full `ClipInfo`. | queue full, empty prompt |
+| `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars), `seed` (optional, ≥ 0) | Queues one generation; replies `clip_queued` with the full `ClipInfo`. Without a seed, the session's advancing default is used. | queue full, empty prompt |
 | `play` | `clip_id` (optional UUID) | Streams the oldest ready clip, or the named one. Emits `clip_started` as frames begin. | already playing, unknown id, clip not ready |
-| `stop` | — | Cuts the playing clip to black; the queue is untouched. Emits `clip_stopped`. | nothing playing |
+| `stop` | — | Cuts the playing clip to black; the queue is untouched. With autoplay on, acts as a skip. Emits `clip_stopped`. | nothing playing |
 | `get_queue` | — | Replies with the full queue — the same payload as `queue_update`. | — |
+| `set_autoplay` | `enabled` (bool) | On, the oldest ready clip starts on its own whenever nothing is playing. Off (default), the stream holds until `play`. Replies `autoplay_accepted`. | — |
 | `set_clip_seconds` | `seconds` (5.167–14.375) | Length for *newly enqueued* clips, snapped to what the model can produce; the effective value returns in `clip_length_accepted`. | — |
-| `set_seed` | `seed` (≥ 0) | Seed the next enqueue uses; each enqueue advances it by one. Replies `seed_accepted`. | — |
+| `set_seed` | `seed` (≥ 0) | Default seed for enqueues that carry none; each such enqueue advances it by one. Replies `seed_accepted`. | — |
 | `set_canvas` | `aspect` (`16:9`, `1:1`, `9:16`, `4:3`) | Video size for the session. Replies `canvas_accepted`. | clips queued or playing, unsupported aspect |
 | `reset` | — | Drops the whole queue, cuts any playing clip, restores every default. Replies `session_reset`. | — |
 | `get_state` | — | Replies with the full `state_update` snapshot. | — |
@@ -172,6 +175,7 @@ A rejected command has no effect and is answered by a broadcast
 | `clip_failed` | everyone | A build failed; the clip left the queue and the queue moves on. |
 | `clip_length_accepted` | the caller | Reply to `set_clip_seconds`. Carries the snapped value. |
 | `seed_accepted` | the caller | Reply to `set_seed`. |
+| `autoplay_accepted` | the caller | Reply to `set_autoplay`. |
 | `canvas_accepted` | the caller | Reply to `set_canvas`. Carries the exact pixel size. |
 | `session_reset` | the caller | Reply to `reset`. Says how many clips were dropped. |
 
@@ -248,11 +252,13 @@ model can make is 345 frames, 14.375 s**.
 
 ## Determinism
 
-Each enqueued clip carries its own seed: `set_seed` fixes the next one, and
-each `enqueue` advances it by one. Re-enqueuing the same prompts in the same
-order with the same starting seed, clip length and canvas reproduces the same
-clips. Reproduction is approximate rather than bit-exact: the deployment runs
-fused and compiled kernels that can reorder floating-point operations.
+Each enqueued clip carries its own seed — passed explicitly on `enqueue`, or
+taken from the session's advancing default (`set_seed` fixes it; each seedless
+enqueue advances it by one, and explicit seeds leave it untouched).
+Re-enqueuing the same prompts with the same seeds, clip length and canvas
+reproduces the same clips. Reproduction is approximate rather than bit-exact:
+the deployment runs fused and compiled kernels that can reorder floating-point
+operations.
 
 ## Notes on the code
 

--- a/models/fasth3/README.md
+++ b/models/fasth3/README.md
@@ -148,12 +148,12 @@ size in force.
 
 | Command | Parameters | Effect | Rejected when |
 |---|---|---|---|
-| `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars), `seed` (optional, ≥ 0) | Queues one generation; replies `clip_queued` with the full `ClipInfo`. Without a seed, the session's advancing default is used. | queue full, empty prompt |
+| `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars), `seed` (optional, ≥ 0), `seconds` (optional, 5.167–14.375) | Queues one generation; replies `clip_queued` with the full `ClipInfo`. Without a seed the session's advancing default is used; without `seconds` the session's default length. | queue full, empty prompt |
 | `play` | `clip_id` (optional UUID) | Streams the oldest ready clip, or the named one. Emits `clip_started` as frames begin. | already playing, unknown id, clip not ready |
 | `stop` | — | Cuts the playing clip to black; the queue is untouched. With autoplay on, acts as a skip. Emits `clip_stopped`. | nothing playing |
 | `get_queue` | — | Replies with the full queue — the same payload as `queue_update`. | — |
 | `set_autoplay` | `enabled` (bool) | On, the oldest ready clip starts on its own whenever nothing is playing. Off (default), the stream holds until `play`. Replies `autoplay_accepted`. | — |
-| `set_clip_seconds` | `seconds` (5.167–14.375) | Length for *newly enqueued* clips, snapped to what the model can produce; the effective value returns in `clip_length_accepted`. | — |
+| `set_clip_seconds` | `seconds` (5.167–14.375) | Default length for enqueues that carry no `seconds`, snapped to what the model can produce; the effective value returns in `clip_length_accepted`. | — |
 | `set_seed` | `seed` (≥ 0) | Default seed for enqueues that carry none; each such enqueue advances it by one. Replies `seed_accepted`. | — |
 | `set_canvas` | `aspect` (`16:9`, `1:1`, `9:16`, `4:3`) | Video size for the session. Replies `canvas_accepted`. | clips queued or playing, unsupported aspect |
 | `reset` | — | Drops the whole queue, cuts any playing clip, restores every default. Replies `session_reset`. | — |

--- a/models/fasth3/README.md
+++ b/models/fasth3/README.md
@@ -150,6 +150,7 @@ size in force.
 |---|---|---|---|
 | `enqueue` | `prompt` (≤ 800 chars), `metadata` (≤ 2000 chars), `seed` (optional, ≥ 0), `seconds` (optional, 5.167–14.375) | Queues one generation; replies `clip_queued` with the full `ClipInfo`. Without a seed the session's advancing default is used; without `seconds` the session's default length. | queue full, empty prompt |
 | `play` | `clip_id` (optional UUID) | Streams the oldest ready clip, or the named one. Emits `clip_started` as frames begin. | already playing, unknown id, clip not ready |
+| `pop` | `clip_id` (UUID) | Removes that clip from the queue, freeing its slot; a build in flight for it is discarded. Replies `clip_popped`. | unknown or missing id |
 | `stop` | — | Cuts the playing clip to black; the queue is untouched. With autoplay on, acts as a skip. Emits `clip_stopped`. | nothing playing |
 | `get_queue` | — | Replies with the full queue — the same payload as `queue_update`. | — |
 | `set_autoplay` | `enabled` (bool) | On, the oldest ready clip starts on its own whenever nothing is playing. Off (default), the stream holds until `play`. Replies `autoplay_accepted`. | — |
@@ -173,6 +174,7 @@ A rejected command has no effect and is answered by a broadcast
 | `clip_finished` | everyone | A clip was fully sent; the stream is now black until the next `play`. |
 | `clip_stopped` | everyone | `stop` (or `reset`) cut the clip; the rest of it is discarded. |
 | `clip_failed` | everyone | A build failed; the clip left the queue and the queue moves on. |
+| `clip_popped` | the caller | Reply to `pop`. The clip left the queue and its slot is free. |
 | `clip_length_accepted` | the caller | Reply to `set_clip_seconds`. Carries the snapped value. |
 | `seed_accepted` | the caller | Reply to `set_seed`. |
 | `autoplay_accepted` | the caller | Reply to `set_autoplay`. |

--- a/models/fasth3/client/README.md
+++ b/models/fasth3/client/README.md
@@ -1,0 +1,33 @@
+# fasth3 queue client
+
+A reference client for the fasth3 clip queue, built on the Reactor Python SDK
+(`reactor-sdk`). It walks the whole contract once — enqueue two prompts with
+metadata, watch `queue_update` report them ready, play the first clip to the
+end, confirm the stream holds on black, play the second by UUID, stop it
+mid-play — and writes everything it received to disk: one `.mp4` per clip
+(video with its synchronized audio), the raw message log, and a timing report.
+
+Use it as a smoke test after serving the model, or as the starting point for
+your own queue-driving application.
+
+## Run
+
+```sh
+pip install -r requirements.txt   # reactor-sdk + numpy; ffmpeg must be on PATH
+
+# Against a local `reactor run` on :8080 (the default):
+python client.py
+
+# Against a hosted session:
+python client.py --api-key rk_...
+
+# Shorter clips build faster; outputs land in ./fasth3_out by default:
+python client.py --seconds 5.167 --out ./out
+```
+
+What to expect: `enqueue` answers immediately with the clip's UUID; the clip
+turns `ready: true` on `queue_update` after one build (roughly the clip's own
+duration up to a few multiples of it, depending on the deployment's kernel
+profile and GPU count); `play` puts first frames on the tracks within a
+fraction of a second, because the clip is already built. Nothing plays on its
+own: after `clip_finished` the stream stays black until the next `play`.

--- a/models/fasth3/client/client.py
+++ b/models/fasth3/client/client.py
@@ -1,0 +1,272 @@
+"""Drive the fasth3 clip queue end to end with the Reactor Python SDK.
+
+Connects to a served fasth3 model, exercises the whole queue contract —
+enqueue with metadata, watching the queue turn ready, playing a clip to the
+end, the hold on black, playing a specific clip by UUID, and stopping one
+mid-play — and writes everything received to disk: one .mp4 per clip (video
+plus synchronized audio), the full message log, and a small timing report.
+
+Run against a local `reactor run` (the default), or against a hosted session
+with --api-key. Requires ffmpeg on PATH for the .mp4 encode.
+
+Usage:
+    python client.py                          # local runtime on :8080
+    python client.py --api-key rk_...        # hosted session
+    python client.py --seconds 8 --out ./out
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import subprocess
+import time
+import wave
+from pathlib import Path
+
+import numpy as np
+from reactor_sdk import Reactor
+
+FPS = 24
+AUDIO_RATE = 48_000
+
+PROMPTS = [
+    "A lighthouse on a rocky coast in heavy fog, slow cinematic drone orbit, waves crashing",
+    "A neon-lit alley in the rain at night, puddles reflecting signs, slow dolly forward",
+]
+
+
+def payload(reply):
+    """Unwrap a send_command reply envelope ({"type", "data"}) to its data."""
+    if isinstance(reply, dict) and "data" in reply and "type" in reply:
+        return reply["data"]
+    return reply
+
+
+class ClipCapture:
+    """Frames and audio received while one clip plays."""
+
+    def __init__(self, clip: dict):
+        self.clip = clip
+        self.frames: list[np.ndarray] = []
+        self.audio: list[np.ndarray] = []
+        self.first_frame_at: float | None = None
+
+
+class Session:
+    """Message log, per-clip media capture, and wait-for helpers."""
+
+    def __init__(self, out_dir: Path):
+        self.out = out_dir
+        self.messages: list[dict] = []
+        self.log = (out_dir / "messages.jsonl").open("w")
+        self.captures: dict[str, ClipCapture] = {}
+        self.current: ClipCapture | None = None
+        self.stray_frames = 0  # frames received while nothing should play
+
+    def on_message(self, message):
+        stamp = time.monotonic()
+        kind = message.get("type") if isinstance(message, dict) else None
+        data = message.get("data", {}) if isinstance(message, dict) else {}
+        self.messages.append({"t": stamp, "type": kind, "data": data})
+        self.log.write(json.dumps({"t": stamp, "type": kind, "data": data}) + "\n")
+        self.log.flush()
+        clip = data.get("clip") if isinstance(data, dict) else None
+        print(f"  msg {kind}" + (f" clip={clip['clip_id'][:8]}" if isinstance(clip, dict) else ""))
+
+        if kind == "clip_started":
+            capture = ClipCapture(data["clip"])
+            self.captures[data["clip"]["clip_id"]] = capture
+            self.current = capture
+        elif kind in ("clip_finished", "clip_stopped"):
+            self.current = None
+
+    async def wait_for(self, kind: str, timeout: float, predicate=None) -> dict:
+        """Wait for the next `kind` message (optionally matching predicate)."""
+        deadline = time.monotonic() + timeout
+        seen = 0
+        while True:
+            for message in self.messages[seen:]:
+                seen += 1
+                if message["type"] == kind and (predicate is None or predicate(message["data"])):
+                    return message["data"]
+            if time.monotonic() > deadline:
+                raise TimeoutError(f"no {kind} within {timeout}s")
+            await asyncio.sleep(0.05)
+
+    def on_video(self, frame: np.ndarray):
+        if self.current is not None:
+            if self.current.first_frame_at is None:
+                self.current.first_frame_at = time.monotonic()
+            self.current.frames.append(np.asarray(frame))
+        else:
+            self.stray_frames += 1
+
+    def on_audio(self, frame, sample_rate=AUDIO_RATE, num_channels=1):
+        if self.current is not None:
+            self.current.audio.append(np.asarray(frame).reshape(-1))
+
+
+def save_clip(out: Path, name: str, capture: ClipCapture) -> str:
+    """Encode one captured clip to .mp4 (h264 + aac) via ffmpeg."""
+    if not capture.frames:
+        return "no frames captured"
+    height, width = capture.frames[0].shape[:2]
+    wav_path = out / f"{name}.wav"
+    samples = (
+        np.concatenate(capture.audio) if capture.audio else np.zeros(1, dtype=np.int16)
+    ).astype(np.int16)
+    with wave.open(str(wav_path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(AUDIO_RATE)
+        handle.writeframes(samples.tobytes())
+
+    mp4_path = out / f"{name}.mp4"
+    encoder = subprocess.Popen(
+        [
+            "ffmpeg", "-y", "-loglevel", "error",
+            "-f", "rawvideo", "-pix_fmt", "rgb24", "-s", f"{width}x{height}",
+            "-r", str(FPS), "-i", "-",
+            "-i", str(wav_path),
+            "-c:v", "libx264", "-preset", "veryfast", "-crf", "20", "-pix_fmt", "yuv420p",
+            "-c:a", "aac", "-shortest", str(mp4_path),
+        ],
+        stdin=subprocess.PIPE,
+    )
+    for frame in capture.frames:
+        encoder.stdin.write(np.ascontiguousarray(frame[:, :, :3], dtype=np.uint8).tobytes())
+    encoder.stdin.close()
+    encoder.wait()
+    seconds = len(capture.frames) / FPS
+    return (
+        f"{mp4_path} ({len(capture.frames)} frames, {seconds:.2f}s video, "
+        f"{len(samples) / AUDIO_RATE:.2f}s audio)"
+    )
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model", default="fasth3")
+    parser.add_argument("--api-key", default=None, help="hosted session; default is local mode")
+    parser.add_argument("--seconds", type=float, default=None, help="clip length to set")
+    parser.add_argument("--out", default="./fasth3_out")
+    parser.add_argument("--ready-timeout", type=float, default=600.0)
+    args = parser.parse_args()
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    session = Session(out)
+
+    if args.api_key:
+        reactor = Reactor(args.model, api_key=args.api_key)
+    else:
+        reactor = Reactor(args.model, local=True)
+    reactor.on("message", session.on_message)
+
+    print("connecting ...")
+    started = time.monotonic()
+    await reactor.connect()
+    print(f"status={reactor.status} after {time.monotonic() - started:.1f}s "
+          f"session={reactor.session_id}")
+
+    try:
+        video = reactor.tracks.with_direction("recvonly").with_kind("video").one()
+        audio = reactor.tracks.with_direction("recvonly").with_kind("audio").one()
+        video.on_frame(session.on_video)
+        audio.on_frame(session.on_audio)
+
+        state = payload(await reactor.send_command("get_state", {}))
+        print("state:", json.dumps(state))
+
+        if args.seconds:
+            reply = payload(
+                await reactor.send_command("set_clip_seconds", {"seconds": args.seconds})
+            )
+            print("clip length accepted:", reply)
+
+        # --- enqueue two clips, metadata carrying this client's own record ---
+        clips = []
+        for index, prompt in enumerate(PROMPTS):
+            reply = payload(await reactor.send_command(
+                "enqueue",
+                {"prompt": prompt, "metadata": json.dumps({"requested_by": "queue-client", "n": index})},
+            ))
+            clip = reply["clip"]
+            clips.append({"info": clip, "enqueued_at": time.monotonic()})
+            print(f"enqueued {clip['clip_id'][:8]} frames={clip['frames']} "
+                  f"seed={clip['seed']} ready={clip['ready']}")
+
+        first_id = clips[0]["info"]["clip_id"]
+        second_id = clips[1]["info"]["clip_id"]
+
+        # --- wait for clip 1 to build, then play it to the end ---------------
+        await session.wait_for(
+            "queue_update",
+            timeout=args.ready_timeout,
+            predicate=lambda d: any(c["clip_id"] == first_id and c["ready"] for c in d["clips"]),
+        )
+        ready_after = time.monotonic() - clips[0]["enqueued_at"]
+        print(f"clip 1 ready after {ready_after:.1f}s")
+
+        play_at = time.monotonic()
+        await reactor.send_command("play", {})
+        started_data = await session.wait_for("clip_started", timeout=30)
+        assert started_data["clip"]["clip_id"] == first_id, "play must take the oldest ready clip"
+        finished = await session.wait_for(
+            "clip_finished", timeout=clips[0]["info"]["seconds"] + 60
+        )
+        print(f"clip 1 finished; seconds_sent={finished['seconds_sent']}")
+
+        # --- the stream holds on black: nothing may play on its own ----------
+        stray_before = session.stray_frames
+        await asyncio.sleep(2.0)
+        print(f"frames while idle: {session.stray_frames - stray_before} (flush tail is tolerated)")
+
+        # --- play clip 2 by UUID, then stop it mid-play -----------------------
+        await session.wait_for(
+            "queue_update",
+            timeout=args.ready_timeout,
+            predicate=lambda d: any(c["clip_id"] == second_id and c["ready"] for c in d["clips"]),
+        )
+        await reactor.send_command("play", {"clip_id": second_id})
+        await session.wait_for(
+            "clip_started", timeout=30, predicate=lambda d: d["clip"]["clip_id"] == second_id
+        )
+        await asyncio.sleep(4.0)
+        await reactor.send_command("stop", {})
+        stopped = await session.wait_for("clip_stopped", timeout=15)
+        print(f"clip 2 stopped mid-play; seconds_sent={stopped['seconds_sent']}")
+
+        queue = payload(await reactor.send_command("get_queue", {}))
+        print("queue after run:", json.dumps(queue))
+
+        # --- save what was received ------------------------------------------
+        for index, clip_id in enumerate((first_id, second_id), start=1):
+            capture = session.captures.get(clip_id)
+            if capture:
+                ttff = (
+                    capture.first_frame_at - play_at
+                    if index == 1 and capture.first_frame_at
+                    else None
+                )
+                print(f"clip{index}: {save_clip(out, f'clip{index}', capture)}"
+                      + (f" ttff={ttff:.2f}s" if ttff else ""))
+        report = {
+            "clip1_ready_after_s": round(ready_after, 2),
+            "clip1_frames": len(session.captures[first_id].frames)
+            if first_id in session.captures else 0,
+            "clip2_frames": len(session.captures[second_id].frames)
+            if second_id in session.captures else 0,
+            "stray_frames_while_idle": session.stray_frames,
+            "messages": len(session.messages),
+        }
+        (out / "report.json").write_text(json.dumps(report, indent=2))
+        print("report:", json.dumps(report))
+    finally:
+        await reactor.disconnect()
+        session.log.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/models/fasth3/client/requirements.txt
+++ b/models/fasth3/client/requirements.txt
@@ -1,0 +1,2 @@
+reactor-sdk>=1.1.1
+numpy

--- a/models/fasth3/fasth3.py
+++ b/models/fasth3/fasth3.py
@@ -51,6 +51,7 @@ from fasth3_queue import ClipEntry, ClipQueue
 from fasth3_types import (
     MAX_METADATA_CHARS,
     MAX_PROMPT_CHARS,
+    AutoplayAccepted,
     CanvasAccepted,
     ClipFailed,
     ClipFinished,
@@ -150,6 +151,8 @@ class FastH3(ReactorModel):
         self._clip_frames: int = self.config.clip_frames
         self._seed: int = self.config.seed
         self._aspect: str = self.config.aspect
+        # Off by default: playback waits for an explicit `play`.
+        self._autoplay: bool = False
 
         # The queue, and the playout lifecycle around it. `_play_request` is a
         # clip taken off the queue and armed for the run loop; `_playing` is
@@ -187,6 +190,7 @@ class FastH3(ReactorModel):
             clip_seconds_min=clip_plan.MIN_SECONDS_PUBLISHED,
             clip_seconds_max=clip_plan.MAX_SECONDS_PUBLISHED,
             seed=self._seed,
+            autoplay=self._autoplay,
             aspect=self._aspect,
             width=width,
             height=height,
@@ -263,11 +267,13 @@ class FastH3(ReactorModel):
             "Queue one clip generation. The prompt is what the clip will show; "
             "the metadata is an opaque string echoed back on every message that "
             "references the clip, for frontends to carry their own tracking "
-            "data. The clip's length and seed are the session's conditions as "
-            "they stand now. Builds run through the queue in order; watch "
-            "`queue_update` for the clip turning ready. Replies `clip_queued` "
-            "with the clip's UUID and emits `queue_update` and `state_update`, "
-            "or `command_error` when the queue is full or the prompt is empty."
+            "data. The clip's length and canvas are the session's conditions "
+            "as they stand now, and the seed is either the one passed here or "
+            "the session's advancing default. Builds run through the queue in "
+            "order; watch `queue_update` for the clip turning ready. Replies "
+            "`clip_queued` with the clip's UUID and emits `queue_update` and "
+            "`state_update`, or `command_error` when the queue is full or the "
+            "prompt is empty."
         ),
     )
     async def enqueue(
@@ -292,6 +298,15 @@ class FastH3(ReactorModel):
                 "which group it belongs to, display text."
             ),
         ),
+        seed: int | None = InputField(
+            default=None,
+            ge=0,
+            description=(
+                "Seed for this clip. Omitted or null, the session's default is "
+                "used and advances by one; passing a seed leaves the default "
+                "untouched, so explicit and automatic seeding do not interfere."
+            ),
+        ),
     ) -> ClipQueued:
         """Append one generation request to the queue."""
         prompt = prompt.strip()
@@ -304,13 +319,16 @@ class FastH3(ReactorModel):
                 f"The queue is full ({self._queue.capacity} clips); play or `reset` first.",
             )
             return None
+        if not isinstance(seed, int):
+            # None on the wire; the InputField sentinel when called directly.
+            seed = self._seed
+            self._seed += 1
         entry = self._queue.enqueue(
             prompt=prompt,
             metadata=metadata,
             frames=self._clip_frames,
-            seed=self._seed,
+            seed=seed,
         )
-        self._seed += 1
         await self._send_queue_update()
         await self._send_state_update()
         return ClipQueued(clip=entry.snapshot())
@@ -371,9 +389,11 @@ class FastH3(ReactorModel):
             "Cut the clip that is playing. Whatever is queued on the output "
             "tracks is dropped, the picture goes to black within a fraction of "
             "a second, and the session is back where a finished clip leaves it "
-            "— the queue is untouched and the next `play` starts clean. Emits "
-            "`clip_stopped` and `state_update`, or `command_error` when no "
-            "clip is playing."
+            "— the queue is untouched and the next `play` starts clean. With "
+            "autoplay on this acts as a skip: the next ready clip starts on "
+            "its own, so send `set_autoplay` off first to hold the stream. "
+            "Emits `clip_stopped` and `state_update`, or `command_error` when "
+            "no clip is playing."
         ),
     )
     async def stop(self) -> None:
@@ -432,11 +452,11 @@ class FastH3(ReactorModel):
     @event(
         name="set_seed",
         description=(
-            "Set the seed the next enqueued clip uses; each `enqueue` advances "
-            "it by one, so re-enqueuing the same prompts in the same order "
-            "reproduces the same clips. Clips already in the queue keep the "
-            "seed they were enqueued with. Emits `seed_accepted` and "
-            "`state_update`."
+            "Set the default seed — the one an `enqueue` without a seed of its "
+            "own uses, advancing it by one, so re-enqueuing the same prompts "
+            "in the same order reproduces the same clips. Clips already in "
+            "the queue keep the seed they were enqueued with. Emits "
+            "`seed_accepted` and `state_update`."
         ),
     )
     async def set_seed(
@@ -445,16 +465,43 @@ class FastH3(ReactorModel):
             default=1000,
             ge=0,
             description=(
-                "Seed the next enqueued clip generates from. Reproduction is "
+                "Default seed for enqueues that carry none. Reproduction is "
                 "close rather than exact: the deployment runs fused kernels "
                 "that can reorder arithmetic."
             ),
         ),
     ) -> SeedAccepted:
-        """Set the seed the next enqueued clip snapshots."""
+        """Set the default seed for enqueues that carry none."""
         self._seed = int(seed)
         await self._send_state_update()
         return SeedAccepted(seed=self._seed)
+
+    @event(
+        name="set_autoplay",
+        description=(
+            "Turn autoplay on or off. On, the oldest ready clip starts on its "
+            "own whenever nothing is playing — right after a clip finishes, or "
+            "the moment a build completes while the stream is idle — so a "
+            "steadily fed queue plays through without a `play` per clip. Off "
+            "(the default), the stream holds on black until an explicit "
+            "`play`. Takes effect immediately and lasts for the session. Emits "
+            "`autoplay_accepted` and `state_update`."
+        ),
+    )
+    async def set_autoplay(
+        self,
+        enabled: bool = InputField(
+            default=False,
+            description=(
+                "True plays ready clips on their own, oldest first; false "
+                "holds the stream after each clip until `play`."
+            ),
+        ),
+    ) -> AutoplayAccepted:
+        """Set whether ready clips start without an explicit `play`."""
+        self._autoplay = bool(enabled)
+        await self._send_state_update()
+        return AutoplayAccepted(enabled=self._autoplay)
 
     @event(
         name="set_canvas",
@@ -524,6 +571,7 @@ class FastH3(ReactorModel):
         self._clip_frames = self.config.clip_frames
         self._seed = self.config.seed
         self._aspect = self.config.aspect
+        self._autoplay = False
         self.output.flush()
         await self._send_queue_update()
         await self._send_state_update()
@@ -567,6 +615,19 @@ class FastH3(ReactorModel):
         while self.connected.is_set():
             try:
                 await self._pump_builds()
+                if (
+                    self._autoplay
+                    and self._play_request is None
+                    and self._playing is None
+                ):
+                    # Autoplay is a standing `play`: whenever nothing is on the
+                    # tracks and a built clip waits, the oldest one starts.
+                    ready = self._queue.next_ready()
+                    if ready is not None:
+                        self._queue.remove(ready)
+                        self._play_request = ready
+                        await self._send_queue_update()
+                        await self._send_state_update()
                 entry = self._play_request
                 if entry is not None:
                     self._play_request = None
@@ -601,11 +662,9 @@ class FastH3(ReactorModel):
             else:
                 entry.video, entry.audio = job.result
                 logger.info(
-                    "clip ready",
-                    clip=entry.clip_id,
-                    frames=entry.frames,
-                    build_wait_s=round(time.monotonic() - submitted, 2),
-                    queued=len(self._queue),
+                    f"clip ready: {entry.clip_id} ({entry.frames}f) "
+                    f"{time.monotonic() - submitted:.2f}s after submit, "
+                    f"{len(self._queue)} queued"
                 )
                 await self._send_queue_update()
                 await self._send_state_update()
@@ -615,10 +674,8 @@ class FastH3(ReactorModel):
                 height, width = self._canvas()
                 pending.building = True
                 logger.info(
-                    "clip build submitted",
-                    clip=pending.clip_id,
-                    frames=pending.frames,
-                    queued=len(self._queue),
+                    f"clip build submitted: {pending.clip_id} ({pending.frames}f), "
+                    f"{len(self._queue)} queued"
                 )
                 self._build = (
                     pending,

--- a/models/fasth3/fasth3.py
+++ b/models/fasth3/fasth3.py
@@ -56,6 +56,7 @@ from fasth3_types import (
     ClipFailed,
     ClipFinished,
     ClipLengthAccepted,
+    ClipPopped,
     ClipQueued,
     ClipStarted,
     ClipStopped,
@@ -401,6 +402,43 @@ class FastH3(ReactorModel):
         self._play_request = entry
         await self._send_queue_update()
         await self._send_state_update()
+
+    @event(
+        name="pop",
+        description=(
+            "Remove one clip from the queue by its UUID, freeing its slot for "
+            "something else. Works on built and still-generating clips alike; "
+            "a build already running for it is discarded when it completes. "
+            "The clip that is playing is not in the queue — `stop` is the "
+            "command that cuts it. Emits `clip_popped`, `queue_update` and "
+            "`state_update`, or `command_error` when no queued clip has that "
+            "id."
+        ),
+    )
+    async def pop(
+        self,
+        clip_id: str = InputField(
+            default="",
+            description="UUID of the queued clip to remove, from `clip_queued` or `queue_update`.",
+        ),
+    ) -> ClipPopped:
+        """Take one clip out of the queue and free its slot."""
+        entry = self._queue.get(clip_id) if clip_id else None
+        if entry is None:
+            reason = (
+                f"No queued clip has id {clip_id!r}."
+                if clip_id
+                else "Pass the `clip_id` of the queued clip to remove."
+            )
+            await self._refuse("pop", reason)
+            return None
+        self._queue.remove(entry)
+        if self._build is not None and self._build[0] is entry:
+            _entry, job, _submitted = self._build
+            job.cancelled = True
+        await self._send_queue_update()
+        await self._send_state_update()
+        return ClipPopped(clip=entry.snapshot())
 
     @event(
         name="stop",

--- a/models/fasth3/fasth3.py
+++ b/models/fasth3/fasth3.py
@@ -267,9 +267,10 @@ class FastH3(ReactorModel):
             "Queue one clip generation. The prompt is what the clip will show; "
             "the metadata is an opaque string echoed back on every message that "
             "references the clip, for frontends to carry their own tracking "
-            "data. The clip's length and canvas are the session's conditions "
-            "as they stand now, and the seed is either the one passed here or "
-            "the session's advancing default. Builds run through the queue in "
+            "data. The clip's canvas is the session's; its length is the "
+            "`seconds` passed here (snapped to what the model can produce) or "
+            "the session default, and its seed is the one passed here or the "
+            "session's advancing default. Builds run through the queue in "
             "order; watch `queue_update` for the clip turning ready. Replies "
             "`clip_queued` with the clip's UUID and emits `queue_update` and "
             "`state_update`, or `command_error` when the queue is full or the "
@@ -307,6 +308,19 @@ class FastH3(ReactorModel):
                 "untouched, so explicit and automatic seeding do not interfere."
             ),
         ),
+        seconds: float | None = InputField(
+            default=None,
+            ge=clip_plan.MIN_SECONDS_PUBLISHED,
+            le=clip_plan.MAX_SECONDS_PUBLISHED,
+            description=(
+                f"Length of this clip in seconds, between {_CLIP_RANGE}, "
+                "snapped to the nearest length the model can produce; the "
+                "clip's structure reports the effective value. Omitted or "
+                "null, the session default applies. A length the deployment "
+                "has not built before pays a one-off compile cost on its "
+                "first build."
+            ),
+        ),
     ) -> ClipQueued:
         """Append one generation request to the queue."""
         prompt = prompt.strip()
@@ -323,10 +337,15 @@ class FastH3(ReactorModel):
             # None on the wire; the InputField sentinel when called directly.
             seed = self._seed
             self._seed += 1
+        frames = (
+            clip_plan.frames_for_seconds(float(seconds))
+            if isinstance(seconds, (int, float))
+            else self._clip_frames
+        )
         entry = self._queue.enqueue(
             prompt=prompt,
             metadata=metadata,
-            frames=self._clip_frames,
+            frames=frames,
             seed=seed,
         )
         await self._send_queue_update()
@@ -419,12 +438,13 @@ class FastH3(ReactorModel):
     @event(
         name="set_clip_seconds",
         description=(
-            "Set how long newly enqueued clips are. The value is snapped to "
-            "the nearest length the model can produce, so read the effective "
-            "one back from `clip_length_accepted`. Clips already in the queue "
-            "keep the length they were enqueued with. Longer clips carry a "
-            "scene further; shorter ones build faster. Emits "
-            "`clip_length_accepted` and `state_update`."
+            "Set the default length for enqueues that carry no `seconds` of "
+            "their own. The value is snapped to the nearest length the model "
+            "can produce, so read the effective one back from "
+            "`clip_length_accepted`. Clips already in the queue keep the "
+            "length they were enqueued with. Longer clips carry a scene "
+            "further; shorter ones build faster. Emits `clip_length_accepted` "
+            "and `state_update`."
         ),
     )
     async def set_clip_seconds(

--- a/models/fasth3/fasth3.py
+++ b/models/fasth3/fasth3.py
@@ -1,6 +1,6 @@
 """FastH3 as a Reactor model: a queue of prompt-driven video-and-audio clips.
 
-FastH3 is MiniMax-H3 distilled to four transformer forwards, and on eight
+FastH3 is MiniMax-H3 distilled to four transformer forwards, and on a few
 Blackwell GPUs it builds video about as fast as the video plays. This model
 puts a queue in front of that: clients `enqueue` generation requests — a prompt
 plus opaque metadata, each answered with a UUID — builds run through the queue
@@ -28,6 +28,7 @@ Layout:
 from __future__ import annotations
 
 import asyncio
+import time
 from pathlib import Path
 
 from reactor_runtime import (
@@ -99,7 +100,9 @@ class FastH3(ReactorModel):
     def __init__(self) -> None:
         """Create the model shell; everything session-scoped arrives in load()."""
         super().__init__()
-        self._build: tuple[ClipEntry, ClipJob] | None = None
+        # The build in flight: its entry, its job handle, and when it was
+        # submitted (monotonic), so readiness latency is a measured number.
+        self._build: tuple[ClipEntry, ClipJob, float] | None = None
 
     # ------------------------------------------------------------------ load
 
@@ -139,7 +142,7 @@ class FastH3(ReactorModel):
         because its entry no longer lives in the queue.
         """
         if self._build is not None:
-            _entry, job = self._build
+            _entry, job, _submitted = self._build
             job.cancelled = True
             self._build = None
 
@@ -238,7 +241,7 @@ class FastH3(ReactorModel):
         self._stop_playout = True
         self._play_request = None
         if self._build is not None:
-            _entry, job = self._build
+            _entry, job, _submitted = self._build
             job.cancelled = True
         self._queue.clear()
 
@@ -516,7 +519,7 @@ class FastH3(ReactorModel):
         if self._playing is not None:
             self._stop_playout = True
         if self._build is not None:
-            _entry, job = self._build
+            _entry, job, _submitted = self._build
             job.cancelled = True
         self._clip_frames = self.config.clip_frames
         self._seed = self.config.seed
@@ -583,7 +586,7 @@ class FastH3(ReactorModel):
         discarded silently; the queue owns what exists.
         """
         if self._build is not None:
-            entry, job = self._build
+            entry, job, submitted = self._build
             if not job.done.is_set():
                 return
             self._build = None
@@ -597,6 +600,13 @@ class FastH3(ReactorModel):
                 await self._send_state_update()
             else:
                 entry.video, entry.audio = job.result
+                logger.info(
+                    "clip ready",
+                    clip=entry.clip_id,
+                    frames=entry.frames,
+                    build_wait_s=round(time.monotonic() - submitted, 2),
+                    queued=len(self._queue),
+                )
                 await self._send_queue_update()
                 await self._send_state_update()
         if self._build is None:
@@ -604,6 +614,12 @@ class FastH3(ReactorModel):
             if pending is not None:
                 height, width = self._canvas()
                 pending.building = True
+                logger.info(
+                    "clip build submitted",
+                    clip=pending.clip_id,
+                    frames=pending.frames,
+                    queued=len(self._queue),
+                )
                 self._build = (
                     pending,
                     self.backend.submit(
@@ -613,6 +629,7 @@ class FastH3(ReactorModel):
                         height=height,
                         width=width,
                     ),
+                    time.monotonic(),
                 )
 
     async def _play_clip(self, entry: ClipEntry) -> None:

--- a/models/fasth3/fasth3.py
+++ b/models/fasth3/fasth3.py
@@ -1,34 +1,35 @@
-"""FastH3 as a Reactor platform model: an endless, prompt-driven A/V channel.
+"""FastH3 as a Reactor model: a queue of prompt-driven video-and-audio clips.
 
 FastH3 is MiniMax-H3 distilled to four transformer forwards, and on eight
-Blackwell GPUs it builds video faster than the video plays. This model turns
-that into a continuous stream: it always builds the next clip while the current
-one is on the wire, so `main_video` and `main_audio` never run dry.
+Blackwell GPUs it builds video about as fast as the video plays. This model
+puts a queue in front of that: clients `enqueue` generation requests — a prompt
+plus opaque metadata, each answered with a UUID — builds run through the queue
+in order, and playback is a separate, explicit step. `play` streams one built
+clip on `main_video` and `main_audio`; when it ends (or `stop` cuts it) the
+stream flushes to black and holds until the next `play`. Nothing plays on its
+own.
 
 The unit of work is a whole clip, not a frame, which is why this subclasses
 ``ReactorModel`` and owns its own ``run()`` loop rather than using
 ``ReactorPipeline``. Command handlers then run on their own coroutines
-concurrent with ``run()``, so `pause` and `stop` answer immediately even while a
-clip is being built.
+concurrent with ``run()``, so `enqueue` and `stop` answer immediately even
+while a clip is being built or played.
 
 Layout:
-  * ``fasth3_types.py``        — everything a client sees (tracks and messages).
-  * ``fasth3_clip_plan.py``    — clip geometry (lengths, frame counts, canvases).
+  * ``fasth3_types.py``         — everything a client sees (tracks, `ClipInfo`, messages).
+  * ``fasth3_queue.py``         — the bounded clip queue and its entries.
+  * ``fasth3_backend.py``       — the FastVideo engine and its worker thread.
+  * ``fasth3_assets.py``        — config parsing and weights validation.
+  * ``fasth3_clip_plan.py``     — clip geometry (lengths, frame counts, canvases).
   * ``fasth3_session_rules.py`` — which commands each state accepts.
-  * ``fasth3.yaml``            — the generation recipe and the weight layout.
+  * ``fasth3.yaml``             — the generation recipe, queue size, and weight layout.
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
-import queue
-import threading
-import time
 from pathlib import Path
-from typing import Any
 
-import yaml
 from reactor_runtime import (
     ClientInfo,
     InputField,
@@ -43,22 +44,24 @@ from reactor_runtime.log import get_logger
 
 import fasth3_clip_plan as clip_plan
 import fasth3_session_rules as session_rules
+from fasth3_assets import load_config, require_weights, resolve_model_path
+from fasth3_backend import OUTPUT_SAMPLE_RATE, ClipJob, FastH3Backend
+from fasth3_queue import ClipEntry, ClipQueue
 from fasth3_types import (
+    MAX_METADATA_CHARS,
     MAX_PROMPT_CHARS,
     CanvasAccepted,
-    ChannelFailed,
-    ChannelPaused,
-    ChannelReset,
-    ChannelResumed,
-    ChannelStarted,
-    ChannelStopped,
-    ClipComplete,
+    ClipFailed,
+    ClipFinished,
     ClipLengthAccepted,
+    ClipQueued,
     ClipStarted,
+    ClipStopped,
     CommandError,
     FastH3Output,
-    PromptAccepted,
+    QueueUpdate,
     SeedAccepted,
+    SessionReset,
     StateUpdate,
 )
 
@@ -70,465 +73,113 @@ FRAME_RATE = clip_plan.FPS
 # bounds can never disagree.
 _CLIP_RANGE = f"{clip_plan.MIN_SECONDS_PUBLISHED:g} and {clip_plan.MAX_SECONDS_PUBLISHED:g}"
 
-# WebRTC-native rate every clip's waveform is resampled to. The checkpoint's
-# audio decoder is 32 kHz; the wire is 48 kHz.
-OUTPUT_SAMPLE_RATE = 48_000
-NATIVE_SAMPLE_RATE = 32_000
-
 # Frames per emitted slice. The runtime recorder's feed queue cannot absorb
 # one-second bursts, and the emitter is a metronome either way, so smaller
 # slices cost nothing.
 EMIT_FRAMES = 3
 
-# How often the arm loop and the pause hold re-check. Both run on the event
-# loop, so this is a scheduling granularity, not a busy-wait.
+# How often the idle loop re-checks for a play request and a finished build.
+# Runs on the event loop, so this is a scheduling granularity, not a busy-wait.
 POLL_SECONDS = 0.05
-WORKER_POLL_SECONDS = 0.1
-
-# What the warm-up builds. Never reaches a client: warm-up output is discarded,
-# and its only job is to be a syntactically ordinary prompt.
-WARMUP_PROMPT = "A slow cinematic shot of sunlight moving across a quiet room."
-
-# The HF snapshot directory inside the weights bundle.
-DEFAULT_CHECKPOINT_DIR = "FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree"
-
-# Component directories the T2VA pipeline loads. An incomplete bundle must kill
-# startup, not surface as a loader traceback on the first clip.
-REQUIRED_COMPONENTS = (
-    "transformer",
-    "text_encoder",
-    "tokenizer",
-    "processor",
-    "vae",
-    "audio_vae",
-    "scheduler",
-    "audio_scheduler",
-)
-
-
-class _ChannelStopped(Exception):
-    """Internal: the generation worker noticed the channel should wind down."""
-
-
-class _Job:
-    """One unit of work for the generation worker, and its outcome.
-
-    The error is carried back rather than only logged: ``load()`` waits on the
-    warm-up through this, and a warm-up that failed silently would let the pod
-    report ready and then die on its first real clip.
-    """
-
-    __slots__ = ("done", "error", "fn")
-
-    def __init__(self, fn) -> None:
-        self.fn = fn
-        self.done = threading.Event()
-        self.error: BaseException | None = None
-
-
-def _require_weights(root: Path, model_path: Path) -> None:
-    """Fail startup loudly when the weights bundle is incomplete."""
-    problems: list[str] = []
-    if not model_path.is_dir():
-        problems.append(f"checkpoint directory is missing: {model_path}")
-    else:
-        index = model_path / "modular_model_index.json"
-        if not index.is_file():
-            problems.append(f"modular_model_index.json is missing: {index}")
-        for component in REQUIRED_COMPONENTS:
-            if not (model_path / component).is_dir():
-                problems.append(f"component directory is missing: {model_path / component}")
-    if problems:
-        raise FileNotFoundError(
-            f"FastH3 weights bundle under {root} is incomplete:\n  " + "\n  ".join(problems)
-        )
 
 
 class FastH3(ReactorModel):
-    """Stream an endless video-and-audio channel from a text prompt."""
+    """Queue prompt-driven clip generations and play them back one at a time."""
 
-    # Pinned: `_emit_paced` is a strict 24 fps metronome and every emit omits
+    # Pinned: `_emit_clip` is a strict 24 fps metronome and every emit omits
     # `compute_time`, which is exactly the "unmeasured" path this rate tags.
     # Measuring instead re-estimates the rate from observed timing, whose wobble
     # both drops chunks while converging and drifts video against the
     # sample-clocked audio.
     fps = FRAME_RATE
-    # Two seconds of transport-side tolerance at 24 fps, so a clip that lands
-    # late dents the buffer instead of dropping frames.
+    # Two seconds of transport-side tolerance at 24 fps, so a hiccup dents the
+    # buffer instead of dropping frames.
     buffer_size = 48
+
+    def __init__(self) -> None:
+        """Create the model shell; everything session-scoped arrives in load()."""
+        super().__init__()
+        self._build: tuple[ClipEntry, ClipJob] | None = None
 
     # ------------------------------------------------------------------ load
 
     def load(self, config_path: Path | None) -> None:
-        """Build the eight-GPU generator and warm every clip shape.
+        """Parse the config, validate the weights, and build the warm engine.
 
         Runs once at startup, before any session. The runtime marks the pod
-        ready only when this returns, so the warm-up below means a deployed pod
-        never serves a cold clip.
+        ready only when this returns, so the backend's warm-up means a deployed
+        pod never builds a cold clip.
 
         Args:
             config_path: Path to ``fasth3.yaml``; its ``inference`` block is the
-                generation recipe and its ``runtime`` block holds the weight
-                layout and the engine shape.
+                generation recipe and the queue size, and its ``runtime`` block
+                holds the weight layout and the engine shape.
         """
-        document: dict[str, Any] = {}
-        if config_path is not None:
-            document = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
-        self.inference_cfg: dict[str, Any] = document.get("inference") or {}
-        runtime: dict[str, Any] = document.get("runtime") or {}
-        self.runtime_cfg = runtime
-
-        self.default_aspect = str(self.inference_cfg.get("aspect", "16:9"))
-        if self.default_aspect not in clip_plan.ASPECT_CHOICES:
-            raise ValueError(
-                f"inference.aspect must be one of {list(clip_plan.ASPECT_CHOICES)}, "
-                f"got {self.default_aspect!r}"
-            )
-        self.default_clip_frames = clip_plan.frames_for_seconds(
-            float(self.inference_cfg.get("clip_seconds", clip_plan.MAX_SECONDS))
-        )
-        # Time-to-first-frame ramp: the channel opens with these clip lengths
-        # before settling on the steady one. Each entry is a distinct shape the
-        # warm-up must cover, so keep the list short. An empty list means a
-        # uniform cadence from clip zero.
-        self.ramp_frames = clip_plan.parse_ramp(
-            self.inference_cfg.get("ramp_seconds", [clip_plan.MIN_SECONDS])
-        )
-        self.default_seed = int(self.inference_cfg.get("seed", 1000))
-        # Sigma-grid POINTS, not transformer forwards: the distilled schedule is
-        # five points and exactly four forwards.
-        self.num_inference_steps = int(self.inference_cfg.get("num_inference_steps", 5))
-
-        # Must happen before the generator is built: the engine spawns worker
-        # processes, which inherit os.environ, and these select the attention
-        # backend and the sparse kernel.
-        self._apply_profile_environment()
-        self._validate_profile_dependencies()
-
+        self.config = load_config(config_path)
         weights = get_weights_path()
-        self.model_path = weights / str(runtime.get("checkpoint_dir", DEFAULT_CHECKPOINT_DIR))
-        _require_weights(weights, self.model_path)
+        model_path = resolve_model_path(self.config, weights)
+        require_weights(weights, model_path)
 
-        self.num_gpus = int(runtime.get("num_gpus", 8))
-        logger.info(
-            "building fasth3 generator",
-            model_path=str(self.model_path),
-            num_gpus=self.num_gpus,
-            clip_frames=self.default_clip_frames,
-            ramp=list(self.ramp_frames),
-        )
-
-        from fastvideo import VideoGenerator
-
-        self.generator = VideoGenerator.from_config(self._generator_config())
-
-        # Session-scoped state. A ReactorPipeline would get a fresh `self.state`
-        # per session from the runtime; a ReactorModel owns that itself, so the
-        # defaults live in one reset function called here (so a command racing
-        # ahead of `session_started` reads defaults, never another session's
-        # values) and again from the `@session_started` hook.
+        self.backend = FastH3Backend(self.config, model_path)
+        # Session-scoped state exists before the first session, so a command
+        # racing ahead of `@session_started` reads defaults, never garbage.
         self._reset_session_state()
-
-        # One persistent worker thread runs every clip. The GPU work itself
-        # lives in the spawned engine processes; this thread exists to serialise
-        # submissions and to give teardown a single handle to wait on.
-        self._jobs: queue.Queue = queue.Queue()
-        self._worker = threading.Thread(
-            target=self._worker_loop, name="fasth3-generation", daemon=True
-        )
-        self._worker.start()
-        self._preload_native_imports()
-        self._run_on_worker(self._warmup)
-        logger.info("fasth3 loaded")
-
-    @staticmethod
-    def _preload_native_imports() -> None:
-        """Touch every deferred native import the emit path needs.
-
-        ``_to_wire_audio`` and ``_emit_paced`` import torch, torchaudio and
-        numpy lazily so that rendering the schema needs none of them. Lazy means
-        the first import happens on the first real clip — after load, after
-        warm-up, after the pod reports ready — where a linkage failure is a dead
-        session rather than a startup error. The resample below is a real call,
-        so it fails here or not at all.
-        """
-        import numpy  # noqa: F401
-        import torch
-        import torchaudio.functional as AF
-
-        AF.resample(torch.zeros(2, NATIVE_SAMPLE_RATE // 10), NATIVE_SAMPLE_RATE, OUTPUT_SAMPLE_RATE)
-
-    # --------------------------------------------------------------- profile
-
-    def _apply_profile_environment(self) -> None:
-        """Set the FastH3 profile environment, exactly as the reference CLI does.
-
-        Mirrors ``examples/inference/basic/basic_fasth3.py:profile_environment``.
-        Values are explicit even for disabled features, so a shell's inherited
-        experiment settings cannot silently change the profile a pod serves.
-        """
-        cfg = self.inference_cfg
-        vsa_kernel = str(cfg.get("vsa_kernel", "sm100a"))
-        fusions = "all" if bool(cfg.get("h3_fusions", True)) else "0"
-        environment: dict[str, str | None] = {
-            "FASTVIDEO_ATTENTION_BACKEND": "VIDEO_SPARSE_ATTN_H3",
-            "FASTVIDEO_VSA_SM100A": "1" if vsa_kernel == "sm100a" else "0",
-            "FASTVIDEO_VSA_CUTEDSL": "0",
-            # A non-empty path enables the diagnostic probe; it must stay unset.
-            "FASTVIDEO_H3_VSA_PROBE": None,
-            "FASTVIDEO_DISABLE_ATTENTION_COMPILE": "0",
-            "FASTVIDEO_FA4": "1" if bool(cfg.get("fa4", True)) else "0",
-            "FASTVIDEO_NVFP4_FA4": "0",
-            "FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN": "0",
-            "FASTVIDEO_MINIMAX_H3_FUSIONS": fusions,
-            "FASTVIDEO_INFERENCE_TORCH_COMPILE": (
-                "1" if bool(cfg.get("inference_torch_compile", True)) else "0"
-            ),
-            "FASTVIDEO_VAE_PARALLEL_DECODE": (
-                "1" if bool(cfg.get("vae_parallel_decode", True)) else "0"
-            ),
-            "FASTVIDEO_VAE_PARALLEL_ENCODE": "0",
-            "FASTVIDEO_VAE_PARALLEL_DECODE_STRATEGY": "gather",
-            "FASTVIDEO_ULYSSES_A2A": str(cfg.get("ulysses_a2a", "off")),
-            "FASTVIDEO_STAGE_LOGGING": "1",
-        }
-        for name, value in environment.items():
-            if value is None:
-                os.environ.pop(name, None)
-            else:
-                os.environ[name] = value
-        logger.info("fasth3 profile", **{k: (v or "<unset>") for k, v in environment.items()})
-
-    def _validate_profile_dependencies(self) -> None:
-        """Fail before the 148 GB load when the selected fast route is absent."""
-        import importlib.util
-
-        cfg = self.inference_cfg
-        if bool(cfg.get("fa4", True)):
-            try:
-                present = importlib.util.find_spec("flash_attn.cute") is not None
-            except (ImportError, ModuleNotFoundError):
-                present = False
-            if not present:
-                raise RuntimeError(
-                    "FastH3's FA4 route needs the pinned flash-attn-4 package. Install it, "
-                    "or set inference.fa4: false in fasth3.yaml."
-                )
-        if str(cfg.get("vsa_kernel", "sm100a")) == "sm100a":
-            try:
-                from fastvideo_kernel import block_sparse_attn_sm100a
-            except ImportError:
-                present = False
-            else:
-                present = bool(getattr(block_sparse_attn_sm100a, "_HAS_VSA_SM100A", False))
-            if not present:
-                raise RuntimeError(
-                    "FastH3's sm100a route needs fastvideo-kernel built with the Blackwell VSA "
-                    "extension. Install a matching wheel, or set inference.vsa_kernel: triton."
-                )
-
-    def _generator_config(self):
-        """The engine shape, mirroring ``basic_fasth3.py:build_generator_config``."""
-        from fastvideo.api import (
-            CompileConfig,
-            ComponentConfig,
-            EngineConfig,
-            GeneratorConfig,
-            OffloadConfig,
-            ParallelismConfig,
-            PipelineSelection,
-        )
-
-        cfg = self.inference_cfg
-        runtime = self.runtime_cfg
-        num_gpus = int(runtime.get("num_gpus", 8))
-        # The checkpoint's own contract (fastvideo_inference.json) shards the
-        # transformer with FSDP. Sharding is what frees the VRAM to keep the
-        # text encoder resident, which is the deployment this model wants.
-        replicated_dit = bool(runtime.get("replicated_dit", False))
-        return GeneratorConfig(
-            model_path=str(self.model_path),
-            pipeline=PipelineSelection(
-                components=ComponentConfig(),
-                experimental={
-                    "attention_backend": "VIDEO_SPARSE_ATTN_H3",
-                    "VSA_sparsity": float(cfg.get("vsa_sparsity", 0.9)),
-                    "VSA_tile_size": int(cfg.get("vsa_tile_size", 64)),
-                    "inference_torch_compile": bool(cfg.get("inference_torch_compile", True)),
-                    "vae_parallel_decode": bool(cfg.get("vae_parallel_decode", True)),
-                    "vae_parallel_decode_strategy": "gather",
-                },
-            ),
-            engine=EngineConfig(
-                num_gpus=num_gpus,
-                use_fsdp_inference=num_gpus > 1 and not replicated_dit,
-                parallelism=ParallelismConfig(tp_size=1, sp_size=num_gpus),
-                offload=OffloadConfig(
-                    dit=False,
-                    dit_layerwise=False,
-                    text_encoder=bool(runtime.get("offload_text_encoder", False)),
-                    vae=bool(runtime.get("offload_vae", False)),
-                    pin_cpu_memory=bool(runtime.get("pin_cpu_memory", False)),
-                ),
-                compile=CompileConfig(
-                    enabled=False,
-                    mode=None,
-                    vae_enabled=bool(cfg.get("compile_vae", True)),
-                ),
-            ),
-        )
-
-    # ---------------------------------------------------------- gpu plumbing
-
-    def _worker_loop(self) -> None:
-        """Run submitted jobs, one at a time, forever.
-
-        The waiter is always released, even when the job died: a completion
-        event that never arrives is indistinguishable from a hang, and this
-        thread is the only one that will ever set it.
-        """
-        logger.info("generation worker ready")
-        while True:
-            job = self._jobs.get()
-            try:
-                job.fn()
-            except BaseException as error:  # noqa: BLE001 — handed to the waiter
-                job.error = error
-                logger.exception("generation worker job raised")
-            finally:
-                job.done.set()
-
-    def _submit(self, fn) -> _Job:
-        """Queue work on the generation worker and hand back its handle."""
-        job = _Job(fn)
-        self._jobs.put(job)
-        return job
-
-    def _run_on_worker(self, fn) -> None:
-        """Run work on the worker, block until it finishes, and re-raise its failure.
-
-        Used only by ``load()``. Blocking here is the point: the runtime marks
-        the pod ready when ``load()`` returns, so a failed warm-up has to stop
-        startup rather than being discovered by the first client.
-        """
-        job = self._submit(fn)
-        while not job.done.wait(timeout=WORKER_POLL_SECONDS):
-            pass
-        if job.error is not None:
-            raise job.error
-
-    # ------------------------------------------------------------- warm-up
-
-    def _warmup(self) -> None:
-        """Build one throwaway clip per shape, before the pod reports ready.
-
-        Every distinct frame count and canvas is a separate one-time cost —
-        regional compile, sparse-kernel autotune, allocator growth — and paying
-        it here means the first real clip streams at warm speed. Results are
-        discarded: `return_frames=False, save_video=False` skips the whole
-        post-decode path, so a warm-up costs generation time and nothing else.
-        """
-        aspects = self.inference_cfg.get("warmup_aspects") or [self.default_aspect]
-        shapes = list(dict.fromkeys([*self.ramp_frames, self.default_clip_frames]))
-        cold = [a for a in clip_plan.ASPECT_CHOICES if a not in aspects]
-        if cold:
-            logger.info(
-                "aspects left cold; their first clip pays a one-off compile stall", aspects=cold
-            )
-        for aspect in aspects:
-            height, width = clip_plan.canvas_for_choice(str(aspect))
-            for frames in shapes:
-                started = time.monotonic()
-                self.generator.generate(
-                    self._request(
-                        frames=frames,
-                        prompt=WARMUP_PROMPT,
-                        seed=self.default_seed,
-                        height=height,
-                        width=width,
-                        keep_output=False,
-                    )
-                )
-                logger.info(
-                    "warmed clip shape",
-                    aspect=aspect,
-                    frames=frames,
-                    height=height,
-                    width=width,
-                    seconds=round(time.monotonic() - started, 2),
-                )
+        self.backend.load()
+        logger.info("fasth3 loaded", queue_capacity=self.config.queue_size)
 
     # -------------------------------------------------------- session state
 
     def _reset_session_state(self) -> None:
         """Return every session-scoped field to its default.
 
-        The replacement for a runtime-built ``InputState``: the same fields with
-        the same defaults, as plain attributes. Called once at ``load()`` and at
-        every ``@session_started``, which is what keeps one session from ever
-        observing another's conditions.
+        Called once at ``load()`` and at every ``@session_started``, which is
+        what keeps one session from ever observing another's queue or
+        conditions. A build still in flight for the old session is cancelled;
+        its result, if it completes anyway, is discarded by ``_pump_builds``
+        because its entry no longer lives in the queue.
         """
-        # Client-settable conditions. The prompt starts empty on purpose: the
-        # channel is whatever the client asks for, so `start` waits for one
-        # rather than falling back to a stock scene nobody chose.
-        self._prompt: str = ""
-        self._clip_frames: int = self.default_clip_frames
-        self._seed: int = self.default_seed
-        self._aspect: str = self.default_aspect
+        if self._build is not None:
+            _entry, job = self._build
+            job.cancelled = True
+            self._build = None
 
-        # Channel lifecycle. `_started` arms the run loop; `_running` is true
-        # while a channel is live; `_do_reset` asks it to wind down; `_stop_only`
-        # marks that wind-down as a `stop` (conditions kept) rather than a reset.
-        self._started: bool = False
-        self._running: bool = False
-        self._do_reset: bool = False
-        self._stop_only: bool = False
-        self._paused: bool = False
+        # Conditions newly enqueued clips snapshot.
+        self._clip_frames: int = self.config.clip_frames
+        self._seed: int = self.config.seed
+        self._aspect: str = self.config.aspect
+
+        # The queue, and the playout lifecycle around it. `_play_request` is a
+        # clip taken off the queue and armed for the run loop; `_playing` is
+        # the clip whose frames are on the wire; `_stop_playout` asks the
+        # emitter to cut it.
+        self._queue = ClipQueue(self.config.queue_size)
+        self._play_request: ClipEntry | None = None
+        self._playing: ClipEntry | None = None
+        self._stop_playout: bool = False
 
         # Progress, mirrored so a `state_update` is a complete snapshot.
-        self._clip_index: int = -1
-        self._clips_sent: int = 0
+        self._clips_played: int = 0
         self._frames_sent: int = 0
         self._seconds_sent: float = 0.0
-        self._clip_start_seconds: float = 0.0
-        self._current_clip_seconds: float = 0.0
 
     def _canvas(self) -> tuple[int, int]:
         """The `(height, width)` this session generates at."""
         return clip_plan.canvas_for_choice(self._aspect)
 
-    def _frames_for_clip(self, index: int) -> int:
-        """Frame count for clip ``index``, ramp included."""
-        return clip_plan.clip_frames(index, self._clip_frames, self.ramp_frames)
-
-    def _prompt_effective(self) -> tuple[int, float]:
-        """Which clip the current prompt lands on, and how far away that is.
-
-        The channel always has one clip in flight, so a prompt set now applies to
-        the next clip *submitted* — never the one already being built.
-        """
-        if not self._running:
-            return 0, 0.0
-        if self._clip_index < 0:
-            # Clip 0 is being built with the prompt as it stood at `start`; a
-            # prompt set now is the first one that can land, on clip 1.
-            return 1, round(clip_plan.seconds_for_frames(self._frames_for_clip(0)), 2)
-        played = self._seconds_sent - self._clip_start_seconds
-        remaining = max(0.0, self._current_clip_seconds - played)
-        queued = clip_plan.seconds_for_frames(self._frames_for_clip(self._clip_index + 1))
-        return self._clip_index + 2, round(remaining + queued, 2)
+    def _current_clip(self) -> ClipEntry | None:
+        """The clip on (or headed for) the output tracks, if any."""
+        return self._playing or self._play_request
 
     def _snapshot(self) -> StateUpdate:
         """Everything a client can observe, in one message.
 
         The single source of the snapshot: `state_update` broadcasts it, a
-        joining client is greeted with it, and `get_state` answers with it. Built
-        once here so those three can never disagree.
+        joining client is greeted with it, and `get_state` answers with it.
+        Built once here so those three can never disagree.
         """
         height, width = self._canvas()
-        effective_index, effective_seconds = self._prompt_effective()
+        current = self._current_clip()
         return StateUpdate(
-            prompt=self._prompt or None,
             clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
             clip_seconds_min=clip_plan.MIN_SECONDS_PUBLISHED,
             clip_seconds_max=clip_plan.MAX_SECONDS_PUBLISHED,
@@ -536,22 +187,27 @@ class FastH3(ReactorModel):
             aspect=self._aspect,
             width=width,
             height=height,
-            ready=bool(self._prompt),
-            running=self._running,
-            paused=self._paused,
-            clip_index=self._clip_index,
-            clips_sent=self._clips_sent,
+            playing=current is not None,
+            playing_clip_id=current.clip_id if current is not None else None,
+            queued=len(self._queue),
+            queue_capacity=self._queue.capacity,
+            clips_played=self._clips_played,
             seconds_sent=round(self._seconds_sent, 2),
-            prompt_effective_clip_index=effective_index,
-            prompt_effective_in_seconds=effective_seconds,
             valid_commands=session_rules.valid_commands(
-                running=self._running, paused=self._paused, ready=bool(self._prompt)
+                playing=current is not None,
+                queued=len(self._queue),
+                ready=self._queue.ready_count(),
+                capacity=self._queue.capacity,
             ),
         )
 
     async def _send_state_update(self) -> None:
         """Broadcast the snapshot to every connected client."""
         await self.send(self._snapshot())
+
+    async def _send_queue_update(self) -> None:
+        """Broadcast the queue's contents to every connected client."""
+        await self.send(QueueUpdate(clips=self._queue.snapshot()))
 
     async def _refuse(self, command: str, reason: str) -> None:
         """Reject a command: tell every client, and leave its reply bodyless.
@@ -573,69 +229,179 @@ class FastH3(ReactorModel):
 
     @session_started
     async def on_session_started(self) -> None:
-        """Clear every condition so a new session never inherits an old one."""
+        """Clear the queue and every condition so a new session inherits nothing."""
         self._reset_session_state()
 
     @session_ended
     async def on_session_ended(self) -> None:
-        """Wind the channel down; the only hook guaranteed to fire on every path."""
-        self._started = False
-        self._do_reset = True
+        """Drop the session's work; the only hook guaranteed to fire on every path."""
+        self._stop_playout = True
+        self._play_request = None
+        if self._build is not None:
+            _entry, job = self._build
+            job.cancelled = True
+        self._queue.clear()
 
     @connected
     async def on_connect(self, client: ClientInfo) -> None:
-        """Greet the joining client with the full state, so it can render at once.
+        """Greet the joining client with the full state and the queue.
 
-        Addressed rather than broadcast: the clients already watching have this
-        state, and a late joiner needs it without replaying every command.
+        Addressed rather than broadcast: the clients already watching have
+        this, and a late joiner needs it without replaying every command.
         """
         await client.send(self._snapshot())
+        await client.send(QueueUpdate(clips=self._queue.snapshot()))
 
     # ------------------------------------------------------------- commands
 
     @event(
-        name="set_prompt",
+        name="enqueue",
         description=(
-            "Set what the channel shows. Required before `start`; an empty text "
-            "clears it again. Valid at any time: while idle it applies to the "
-            "next `start`, and while streaming it applies to a later clip, "
-            "because the model always builds one clip ahead. Emits "
-            "`prompt_accepted` and `state_update`, both of which report the clip "
-            "this prompt lands on and how much already-built video plays first."
+            "Queue one clip generation. The prompt is what the clip will show; "
+            "the metadata is an opaque string echoed back on every message that "
+            "references the clip, for frontends to carry their own tracking "
+            "data. The clip's length and seed are the session's conditions as "
+            "they stand now. Builds run through the queue in order; watch "
+            "`queue_update` for the clip turning ready. Replies `clip_queued` "
+            "with the clip's UUID and emits `queue_update` and `state_update`, "
+            "or `command_error` when the queue is full or the prompt is empty."
         ),
     )
-    async def set_prompt(
+    async def enqueue(
         self,
         prompt: str = InputField(
             default="",
             max_length=MAX_PROMPT_CHARS,
+            moderate=True,
             description=(
-                "What the channel should show, up to 800 characters. Read when "
-                "the model starts building a clip, so a change reaches the "
-                "viewer a clip or two later rather than immediately. Blank text "
-                "clears it, and `start` is then rejected until one is set again."
+                "What the clip should show, up to 800 characters. Fixed once "
+                "enqueued; a different scene is a new `enqueue`."
             ),
         ),
-    ) -> PromptAccepted:
-        """Set the prompt used from the next clip the model starts."""
-        self._prompt = prompt.strip()
-        effective_index, effective_seconds = self._prompt_effective()
-        await self._send_state_update()
-        return PromptAccepted(
-            prompt=self._prompt or None,
-            effective_clip_index=effective_index,
-            effective_in_seconds=effective_seconds,
+        metadata: str = InputField(
+            default="",
+            max_length=MAX_METADATA_CHARS,
+            moderate=True,
+            description=(
+                "Free-form string stored with the clip and echoed back on every "
+                "message that references it. The model never reads it; use it "
+                "to correlate clips with your own records — who asked for it, "
+                "which group it belongs to, display text."
+            ),
+        ),
+    ) -> ClipQueued:
+        """Append one generation request to the queue."""
+        prompt = prompt.strip()
+        if not prompt:
+            await self._refuse("enqueue", "The prompt is empty; a clip needs one.")
+            return None
+        if self._queue.full:
+            await self._refuse(
+                "enqueue",
+                f"The queue is full ({self._queue.capacity} clips); play or `reset` first.",
+            )
+            return None
+        entry = self._queue.enqueue(
+            prompt=prompt,
+            metadata=metadata,
+            frames=self._clip_frames,
+            seed=self._seed,
         )
+        self._seed += 1
+        await self._send_queue_update()
+        await self._send_state_update()
+        return ClipQueued(clip=entry.snapshot())
+
+    @event(
+        name="play",
+        description=(
+            "Play one built clip from the queue. Blank `clip_id` plays the "
+            "oldest ready clip; a UUID plays that specific clip. Playing "
+            "consumes the entry: it leaves the queue, `clip_started` marks its "
+            "first frames, and when it ends the stream holds on black until "
+            "the next `play`. Emits `queue_update` and `state_update`, or "
+            "`command_error` when a clip is already playing, the id is "
+            "unknown, or the clip is not ready yet."
+        ),
+    )
+    async def play(
+        self,
+        clip_id: str = InputField(
+            default="",
+            description=(
+                "UUID of the clip to play, from `clip_queued` or `queue_update`. "
+                "Blank plays the oldest clip that is ready."
+            ),
+        ),
+    ) -> None:
+        """Take one ready clip off the queue and hand it to the playout loop."""
+        if self._current_clip() is not None:
+            await self._refuse("play", "A clip is already playing; send `stop` first.")
+            return
+        if clip_id:
+            entry = self._queue.get(clip_id)
+            if entry is None:
+                await self._refuse("play", f"No queued clip has id {clip_id!r}.")
+                return
+            if not entry.ready:
+                await self._refuse(
+                    "play",
+                    "That clip is still generating; wait for `queue_update` to report it ready.",
+                )
+                return
+        else:
+            entry = self._queue.next_ready()
+            if entry is None:
+                await self._refuse(
+                    "play",
+                    "No clip is ready to play; `enqueue` one and wait for `queue_update`.",
+                )
+                return
+        self._queue.remove(entry)
+        self._play_request = entry
+        await self._send_queue_update()
+        await self._send_state_update()
+
+    @event(
+        name="stop",
+        description=(
+            "Cut the clip that is playing. Whatever is queued on the output "
+            "tracks is dropped, the picture goes to black within a fraction of "
+            "a second, and the session is back where a finished clip leaves it "
+            "— the queue is untouched and the next `play` starts clean. Emits "
+            "`clip_stopped` and `state_update`, or `command_error` when no "
+            "clip is playing."
+        ),
+    )
+    async def stop(self) -> None:
+        """Ask the playout loop to cut the current clip."""
+        if self._current_clip() is None:
+            await self._refuse("stop", "No clip is playing.")
+            return
+        self._stop_playout = True
+
+    @event(
+        name="get_queue",
+        description=(
+            "Return the queue's contents: every clip's UUID, prompt, metadata, "
+            "length in frames and seconds, seed, and whether it is built and "
+            "ready to play. The same payload the model broadcasts as "
+            "`queue_update`. Valid at any time."
+        ),
+    )
+    async def get_queue(self) -> QueueUpdate:
+        """Answer with the same payload `queue_update` broadcasts."""
+        return QueueUpdate(clips=self._queue.snapshot())
 
     @event(
         name="set_clip_seconds",
         description=(
-            "Set how long each clip is. The value is snapped to the nearest "
-            "length the model can produce, so read the effective one back from "
-            "`clip_length_accepted`. Valid at any time; while streaming it "
-            "applies from the next clip the model starts. Longer clips cut less "
-            "often, shorter clips let a new prompt reach the viewer sooner. "
-            "Emits `clip_length_accepted` and `state_update`."
+            "Set how long newly enqueued clips are. The value is snapped to "
+            "the nearest length the model can produce, so read the effective "
+            "one back from `clip_length_accepted`. Clips already in the queue "
+            "keep the length they were enqueued with. Longer clips carry a "
+            "scene further; shorter ones build faster. Emits "
+            "`clip_length_accepted` and `state_update`."
         ),
     )
     async def set_clip_seconds(
@@ -652,7 +418,7 @@ class FastH3(ReactorModel):
             ),
         ),
     ) -> ClipLengthAccepted:
-        """Set the steady-state clip length."""
+        """Set the length newly enqueued clips snapshot."""
         self._clip_frames = clip_plan.frames_for_seconds(float(seconds))
         await self._send_state_update()
         return ClipLengthAccepted(
@@ -663,10 +429,11 @@ class FastH3(ReactorModel):
     @event(
         name="set_seed",
         description=(
-            "Set the seed the channel starts from; each clip advances it by "
-            "one, so a channel is reproducible end to end while its clips still "
-            "differ. Valid at any time; applies from the next clip the model "
-            "starts. Emits `seed_accepted` and `state_update`."
+            "Set the seed the next enqueued clip uses; each `enqueue` advances "
+            "it by one, so re-enqueuing the same prompts in the same order "
+            "reproduces the same clips. Clips already in the queue keep the "
+            "seed they were enqueued with. Emits `seed_accepted` and "
+            "`state_update`."
         ),
     )
     async def set_seed(
@@ -675,13 +442,13 @@ class FastH3(ReactorModel):
             default=1000,
             ge=0,
             description=(
-                "Seed for the next channel. The clip at index `n` uses this "
-                "value plus `n`. Reproduction is close rather than exact: the "
-                "deployment runs fused kernels that can reorder arithmetic."
+                "Seed the next enqueued clip generates from. Reproduction is "
+                "close rather than exact: the deployment runs fused kernels "
+                "that can reorder arithmetic."
             ),
         ),
     ) -> SeedAccepted:
-        """Set the seed the next channel run starts from."""
+        """Set the seed the next enqueued clip snapshots."""
         self._seed = int(seed)
         await self._send_state_update()
         return SeedAccepted(seed=self._seed)
@@ -689,12 +456,12 @@ class FastH3(ReactorModel):
     @event(
         name="set_canvas",
         description=(
-            "Choose the aspect ratio of `main_video`. The video track keeps one "
-            "size for the whole channel, so this is only valid while nothing is "
-            "streaming — send it before `start` or after `stop`. Emits "
+            "Choose the aspect ratio of `main_video`. The video track keeps "
+            "one size and queued clips are built at it, so this is only valid "
+            "while the queue is empty and nothing is playing. Emits "
             "`canvas_accepted`, carrying the exact pixel size, and "
-            "`state_update`, or `command_error` if a channel is streaming or the "
-            "ratio is not one this model offers."
+            "`state_update`, or `command_error` while clips are queued or "
+            "playing, or when the ratio is not one this model offers."
         ),
     )
     async def set_canvas(
@@ -703,17 +470,18 @@ class FastH3(ReactorModel):
             default="16:9",
             choices=list(clip_plan.ASPECT_CHOICES),
             description=(
-                "Aspect ratio of `main_video`, fixed for the whole channel. "
-                "`canvas_accepted` and `state_update` report the width and "
-                "height in pixels it resolves to."
+                "Aspect ratio of `main_video`. `canvas_accepted` and "
+                "`state_update` report the width and height in pixels it "
+                "resolves to."
             ),
         ),
     ) -> CanvasAccepted:
-        """Set the session's canvas; refused once a channel is live."""
-        if self._running:
+        """Set the session's canvas; refused while any clip depends on the old one."""
+        if self._current_clip() is not None or len(self._queue) > 0:
             await self._refuse(
                 "set_canvas",
-                "The video size is fixed for the life of a channel; send `stop` first.",
+                "The canvas is fixed while clips are queued or playing; "
+                "`reset` or play the queue out first.",
             )
             return None
         try:
@@ -726,126 +494,46 @@ class FastH3(ReactorModel):
         return CanvasAccepted(aspect=aspect, width=width, height=height)
 
     @event(
-        name="start",
-        description=(
-            "Start the channel. Valid only while nothing is streaming, and only "
-            "once a prompt is set; everything else has a default. Emits "
-            "`channel_started` and `state_update` at once, then a `clip_started` "
-            "as each clip reaches the output tracks. The first clip has to be "
-            "built before anything can stream, so expect several seconds of no "
-            "video, or `command_error` if a channel is already streaming or no "
-            "prompt is set."
-        ),
-    )
-    async def start(self) -> None:
-        """Arm the channel loop; it begins on its next poll."""
-        if self._running:
-            await self._refuse(
-                "start", "A channel is already streaming; send `stop` to end it first."
-            )
-            return
-        if not self._prompt:
-            await self._refuse("start", "No prompt is set; send `set_prompt` first.")
-            return
-        self._started = True
-        self._do_reset = False
-        await self._send_state_update()
-
-    @event(
-        name="pause",
-        description=(
-            "Freeze the output stream on its current frame. Valid only while a "
-            "channel is streaming and not already paused. The model keeps "
-            "building ahead, so `resume` continues instantly. Emits "
-            "`channel_paused` and `state_update`, or `command_error` if no "
-            "channel is streaming or it is already paused."
-        ),
-    )
-    async def pause(self) -> ChannelPaused:
-        """Hold the stream; the channel itself is unaffected."""
-        if not self._running:
-            await self._refuse("pause", "No channel is streaming.")
-            return None
-        if self._paused:
-            await self._refuse("pause", "The stream is already paused.")
-            return None
-        self._paused = True
-        await self._send_state_update()
-        return ChannelPaused(seconds_sent=round(self._seconds_sent, 2))
-
-    @event(
-        name="resume",
-        description=(
-            "Continue a paused stream exactly where it froze, with no warm-up "
-            "and without skipping ahead to catch up. Valid only while paused. "
-            "Emits `channel_resumed` and `state_update`, or `command_error` if "
-            "the stream is not paused."
-        ),
-    )
-    async def resume(self) -> ChannelResumed:
-        """Release a paused stream."""
-        if not self._paused:
-            await self._refuse("resume", "The stream is not paused.")
-            return None
-        self._paused = False
-        await self._send_state_update()
-        return ChannelResumed(seconds_sent=round(self._seconds_sent, 2))
-
-    @event(
-        name="stop",
-        description=(
-            "End the channel, keeping every condition, so `start` begins a "
-            "fresh one with the same setup. Valid only while a channel is "
-            "streaming. The stream stops within about a second, but the clip "
-            "already being built cannot be cancelled, so `state_update.running` "
-            "can stay true for a few seconds longer. Emits `channel_stopped` "
-            "and `state_update`, or `command_error` if no channel is streaming."
-        ),
-    )
-    async def stop(self) -> None:
-        """Wind the channel down, keeping the conditions."""
-        if not self._running:
-            await self._refuse("stop", "No channel is streaming.")
-            return
-        self._started = False
-        self._stop_only = True
-        self._do_reset = True
-        self._paused = False
-        await self._send_state_update()
-
-    @event(
         name="reset",
         description=(
-            "Return every condition to its default and clear whatever is queued "
-            "on the output tracks. Stops the channel first if one is streaming. "
-            "Valid at any time. Emits `channel_reset` and `state_update`."
+            "Return every condition to its default, drop every queued clip, "
+            "and clear the output tracks. A clip that is playing is cut, with "
+            "a `clip_stopped` to mark it. Valid at any time. Replies "
+            "`session_reset` and emits `queue_update` and `state_update`."
         ),
     )
-    async def reset(self) -> ChannelReset:
+    async def reset(self) -> SessionReset:
         """Clear the session back to its defaults."""
-        was_running = self._running
-        self._started = False
-        self._stop_only = False
-        # Only ask a live channel to wind down; see `_wait_until_armed`.
-        self._do_reset = was_running
-        self._prompt = ""
-        self._clip_frames = self.default_clip_frames
-        self._seed = self.default_seed
-        self._aspect = self.default_aspect
-        self._paused = False
+        current = self._current_clip()
+        was_playing = current is not None
+        cleared = self._queue.clear()
+        # A pending play request is a clip already off the queue; dropping it
+        # here counts it with the cleared ones. A clip mid-play is cut by the
+        # playout loop, which owns its `clip_stopped`.
+        if self._play_request is not None:
+            self._play_request = None
+            cleared += 1
+        if self._playing is not None:
+            self._stop_playout = True
+        if self._build is not None:
+            _entry, job = self._build
+            job.cancelled = True
+        self._clip_frames = self.config.clip_frames
+        self._seed = self.config.seed
+        self._aspect = self.config.aspect
         self.output.flush()
+        await self._send_queue_update()
         await self._send_state_update()
-        return ChannelReset(was_running=was_running)
+        return SessionReset(cleared_clips=cleared, was_playing=was_playing)
 
     @event(
         name="get_state",
         description=(
-            "Return a snapshot of everything the session exposes: the "
-            "conditions in force, the lifecycle flags, progress through the "
-            "channel, and the commands that are valid right now. The same "
-            "payload the model broadcasts as `state_update`, so a client can "
-            "render its whole interface from this one message. Valid at any "
-            "time."
+            "Return a snapshot of everything the session exposes except the "
+            "queue's contents (`get_queue` carries those): the conditions in "
+            "force, what is playing, progress counters, and the commands that "
+            "are valid right now. The same payload the model broadcasts as "
+            "`state_update`. Valid at any time."
         ),
     )
     async def get_state(self) -> StateUpdate:
@@ -855,376 +543,153 @@ class FastH3(ReactorModel):
     # ------------------------------------------------------------- run loop
 
     async def run(self) -> None:
-        """The model's control loop: wait for an audience, arm, stream, repeat.
+        """The model's control loop: park without an audience, serve with one.
 
         Nothing here may raise: an exception out of ``run()`` is an
-        unrecoverable crash of the whole model loop, not the end of one session,
-        so ``_run_channel`` owns its own failure reporting.
+        unrecoverable crash of the whole model loop, not the end of one
+        session, so ``_serve`` owns its own failure reporting.
         """
         while True:
             await self.connected.wait()
-            if await self._wait_until_armed():
-                await self._run_channel()
+            await self._serve()
 
-    async def _wait_until_armed(self) -> bool:
-        """Wait for `start`; False if the audience left first."""
-        while True:
-            # Deliberately not gated on `_do_reset`: `reset` while idle sets
-            # it and nothing would ever clear it, which would wedge this loop
-            # forever. `_run_channel` clears it as it starts, and `stop`/`reset`
-            # drop `_started`, so a stale flag cannot start a doomed channel.
-            if self._started and self._prompt:
-                return True
-            if not self.connected.is_set():
-                return False
-            await asyncio.sleep(POLL_SECONDS)
+    async def _serve(self) -> None:
+        """Pump builds and play armed clips while an audience is connected.
 
-    def _should_abort(self) -> bool:
-        """Whether the channel must wind down now.
-
-        `_do_reset` is `stop`/`reset`/session end; a lost audience is the other
-        reason. Every abort check — the worker, the emitter — reads this rather
-        than the flag alone.
+        Generation is gated on having an audience: with nobody connected no new
+        build is submitted, and the loop parks back in ``run()``. A build
+        already on the worker finishes into the queue either way, because a
+        clip cannot be cancelled mid-build.
         """
-        return self._do_reset or not self.connected.is_set()
+        while self.connected.is_set():
+            try:
+                await self._pump_builds()
+                entry = self._play_request
+                if entry is not None:
+                    self._play_request = None
+                    await self._play_clip(entry)
+                else:
+                    await asyncio.sleep(POLL_SECONDS)
+            except Exception:  # noqa: BLE001 — the model loop must survive anything
+                logger.exception("error in the fasth3 serve loop")
+                await asyncio.sleep(POLL_SECONDS)
 
-    async def _run_channel(self) -> None:
-        """Stream clips back to back, always building one ahead."""
-        height, width = self._canvas()
-        self._running = True
-        self._do_reset = False
-        self._stop_only = False
-        self._paused = False
-        self._clip_index = -1
-        self._clips_sent = 0
-        self._frames_sent = 0
-        self._seconds_sent = 0.0
-        self._clip_start_seconds = 0.0
-        self._current_clip_seconds = 0.0
-        channel_started_at = time.monotonic()
+    async def _pump_builds(self) -> None:
+        """Apply a finished build and keep the worker fed, without blocking.
 
-        # Depth 1 is the lookahead: the worker can be at most one finished clip
-        # ahead of the transport, which is exactly the backpressure that keeps
-        # a prompt change from being buried behind a deep queue.
-        results: queue.Queue = queue.Queue(maxsize=1)
-        pending: _Job | None = None
-        # Emission pacing carried across clips, so a clip seam costs no time.
-        pacer = {"clock_start": None, "frames_paced": 0}
-
-        def submit(index: int) -> _Job:
-            """Queue clip ``index``, capturing the conditions as they stand now."""
-            frames = self._frames_for_clip(index)
-            prompt = self._prompt
-            seed = self._seed + index
-
-            def job() -> None:
-                try:
-                    if self._should_abort():
-                        raise _ChannelStopped
-                    built = self._generate_clip(index, frames, prompt, seed, height, width)
-                    if self._should_abort():
-                        raise _ChannelStopped
-                    results.put(("clip", index, prompt, built))
-                except _ChannelStopped:
-                    results.put(("stopped", index, prompt, None))
-                except BaseException as error:  # noqa: BLE001 — reported to the client
-                    logger.exception("clip generation failed", clip=index)
-                    results.put(("error", index, prompt, error))
-
-            return self._submit(job)
-
-        try:
-            await self.send(
-                ChannelStarted(
-                    width=width,
-                    height=height,
-                    clip_seconds=round(clip_plan.seconds_for_frames(self._clip_frames), 3),
-                    first_clip_seconds=round(
-                        clip_plan.seconds_for_frames(self._frames_for_clip(0)), 3
+        Called from the idle loop and from every playout slice, so clips keep
+        building while another one streams. A finished build whose entry is no
+        longer in the queue — a `reset` or a session end removed it — is
+        discarded silently; the queue owns what exists.
+        """
+        if self._build is not None:
+            entry, job = self._build
+            if not job.done.is_set():
+                return
+            self._build = None
+            entry.building = False
+            if job.cancelled or entry not in self._queue:
+                pass
+            elif job.error is not None:
+                self._queue.remove(entry)
+                await self.send(ClipFailed(clip=entry.snapshot(), reason=str(job.error)))
+                await self._send_queue_update()
+                await self._send_state_update()
+            else:
+                entry.video, entry.audio = job.result
+                await self._send_queue_update()
+                await self._send_state_update()
+        if self._build is None:
+            pending = self._queue.next_to_build()
+            if pending is not None:
+                height, width = self._canvas()
+                pending.building = True
+                self._build = (
+                    pending,
+                    self.backend.submit(
+                        frames=pending.frames,
+                        prompt=pending.prompt,
+                        seed=pending.seed,
+                        height=height,
+                        width=width,
                     ),
                 )
-            )
-            await self._send_state_update()
 
-            pending = submit(0)
-            while True:
-                kind, index, prompt, payload = await asyncio.to_thread(results.get)
-                if kind == "error":
-                    raise payload
-                if kind == "stopped":
-                    break
-
-                frames_list, samples = payload
-                if index == 0:
-                    logger.info(
-                        "first clip ready",
-                        ttff_s=round(time.monotonic() - channel_started_at, 2),
-                    )
-                # Submit the next clip BEFORE emitting this one, so it is built
-                # while this one plays. This is what makes the channel endless.
-                pending = submit(index + 1)
-
-                self._clip_index = index
-                self._current_clip_seconds = clip_plan.seconds_for_frames(len(frames_list))
-                self._clip_start_seconds = self._seconds_sent
-                await self.send(
-                    ClipStarted(
-                        clip_index=index,
-                        clip_seconds=round(self._current_clip_seconds, 3),
-                        prompt=prompt,
-                    )
-                )
+    async def _play_clip(self, entry: ClipEntry) -> None:
+        """Stream one built clip, then flush to black and report how it ended."""
+        self._playing = entry
+        outcome = "stopped"
+        try:
+            if not self._stop_playout:
+                await self.send(ClipStarted(clip=entry.snapshot()))
                 await self._send_state_update()
-
-                await self._emit_paced(frames_list, samples, pacer)
-                if self._should_abort():
-                    break
-
-                self._clips_sent = index + 1
-                await self.send(
-                    ClipComplete(clip_index=index, seconds_sent=round(self._seconds_sent, 2))
-                )
-                await self._send_state_update()
-
-            if self._stop_only:
-                await self.send(
-                    ChannelStopped(
-                        seconds_sent=round(self._seconds_sent, 2), clips_sent=self._clips_sent
-                    )
-                )
-                logger.info(
-                    "channel stopped", clips=self._clips_sent, seconds=round(self._seconds_sent, 2)
-                )
-        except (Exception, SystemExit) as error:
-            logger.exception("channel failed")
-            # Disarm before reporting. `run()` re-enters the arm loop the moment
-            # this returns, and `_started` is what it gates on — leaving it set
-            # would restart the channel straight into the same failure, over and
-            # over, at eight GPUs a go. The client is told to `start` again.
-            self._started = False
-            try:
-                await self.send(
-                    ChannelFailed(reason=str(error), seconds_sent=round(self._seconds_sent, 2))
-                )
-            except Exception:  # noqa: BLE001 — reporting must not crash run()
-                logger.exception("failed to report the channel failure")
+                outcome = await self._emit_clip(entry)
         finally:
-            self._running = False
-            self._paused = False
-            self._stop_only = False
-            self._drain_until_finished(results, pending)
-            self._do_reset = False
-            try:
-                await self._send_state_update()
-            except Exception:  # noqa: BLE001 — teardown must not crash run()
-                logger.exception("failed to send the closing state update")
-
-    def _drain_until_finished(self, results: queue.Queue, pending: _Job | None) -> None:
-        """Ask the in-flight clip to stop and drain its handoff until it returns.
-
-        A clip cannot be cancelled once it is being built, so this waits it out —
-        blocking, not awaiting, because it also runs under cancellation. Draining
-        while it winds down is what keeps a blocked ``put`` from deadlocking, and
-        waiting is not optional: a job left blocked on a full queue would stall
-        every later channel behind it.
-        """
-        if pending is None or pending.done.is_set():
-            return
-        self._do_reset = True
-        deadline = 300
-        while not pending.done.is_set() and deadline > 0:
-            try:
-                while True:
-                    results.get_nowait()
-            except queue.Empty:
-                pass
-            if not self._worker.is_alive():
-                logger.error("generation worker is gone; no further channel can be served")
-                return
-            pending.done.wait(timeout=1)
-            deadline -= 1
-        if not pending.done.is_set():
-            logger.error("clip did not wind down within 300s; later channels will queue behind it")
+            # Black between clips, always: whatever the transport still holds
+            # of this clip is dropped, so the next `play` starts clean.
+            self.output.flush()
+            self._playing = None
+            self._stop_playout = False
+        self._clips_played += 1
+        if outcome == "finished":
+            await self.send(
+                ClipFinished(clip=entry.snapshot(), seconds_sent=round(self._seconds_sent, 2))
+            )
+        elif outcome == "stopped":
+            await self.send(
+                ClipStopped(clip=entry.snapshot(), seconds_sent=round(self._seconds_sent, 2))
+            )
+        # A lost audience ends the playout with nobody to tell; the state
+        # update below is a harmless no-op in that case.
+        await self._send_state_update()
 
     # -------------------------------------------------------------- emitter
 
-    async def _emit_paced(self, frames_list, samples, pacer: dict) -> None:
+    async def _emit_clip(self, entry: ClipEntry) -> str:
         """Emit one clip as paced slices on a 24 fps metronome.
 
-        - Paced by FRAMES, not slices: a clip's tail slice is short, and charging
-          it a full slot would open a hole in the cadence.
-        - The clock carries across clips through ``pacer``, so a seam costs no
-          time as long as the next clip was ready.
-        - Never burst to catch up: if a clip landed late, re-anchor instead. A
-          catch-up burst only overflows the transport queue. `seam late` is the
-          log line that says the channel is not keeping up.
+        - Paced by FRAMES, not slices: a clip's tail slice is short, and
+          charging it a full slot would open a hole in the cadence.
+        - Never burst to catch up: if the transport held a slice back,
+          re-anchor instead. A catch-up burst only overflows the queue.
         - Emits omit ``compute_time``, so every slice is tagged at the pinned
           24 fps — the rate the audio is already sample-clocked against.
-        - `pause` holds by awaiting a sleep; handlers dispatch on their own
-          coroutine, so this starves nothing.
+        - Builds keep moving: every slice pumps the worker, so a clip
+          generating behind this one is ready sooner.
+
+        Returns:
+            ``"finished"`` when the whole clip went out, ``"stopped"`` when
+            `stop` or `reset` cut it, ``"gone"`` when the audience left.
         """
         import numpy as np
 
+        frames_list, samples = entry.video, entry.audio
         samples_per_frame = OUTPUT_SAMPLE_RATE / FRAME_RATE
         total = len(frames_list)
+        clock_start: float | None = None
+        frames_paced = 0
         for lo in range(0, total, EMIT_FRAMES):
-            while self._paused and not self._should_abort():
-                await asyncio.sleep(POLL_SECONDS)
-            if self._should_abort():
-                return
+            await self._pump_builds()
+            if self._stop_playout:
+                return "stopped"
+            if not self.connected.is_set():
+                return "gone"
             hi = min(lo + EMIT_FRAMES, total)
             alo = round(lo * samples_per_frame)
             ahi = round(hi * samples_per_frame)
 
             now = asyncio.get_running_loop().time()
-            if pacer["clock_start"] is None:
-                pacer["clock_start"] = now
-            content_pos = pacer["frames_paced"] / FRAME_RATE
-            late = now - (pacer["clock_start"] + content_pos)
-            if lo == 0 and late > 0.05:
-                logger.info("seam late", clip=self._clip_index, late_s=round(late, 2))
-            pacer["clock_start"] = max(pacer["clock_start"], now - content_pos)
-            delay = pacer["clock_start"] + content_pos - now
+            if clock_start is None:
+                clock_start = now
+            content_pos = frames_paced / FRAME_RATE
+            clock_start = max(clock_start, now - content_pos)
+            delay = clock_start + content_pos - now
             if delay > 0:
                 await asyncio.sleep(delay)
 
-            pacer["frames_paced"] += hi - lo
+            frames_paced += hi - lo
             self._frames_sent += hi - lo
             self._seconds_sent = self._frames_sent / FRAME_RATE
             video = np.ascontiguousarray(np.stack(frames_list[lo:hi]))
-            await self.emit(
-                FastH3Output(main_video=video, main_audio=samples[:, alo:ahi])
-            )
-
-    # ------------------------------------------------------------ generation
-
-    def _request(
-        self,
-        *,
-        frames: int,
-        prompt: str,
-        seed: int,
-        height: int,
-        width: int,
-        keep_output: bool,
-    ):
-        """Build one generation request.
-
-        Mirrors ``basic_fasth3.py:build_request``. ``keep_output=False`` is the
-        warm-up shape: it skips the whole post-decode path, so a warm-up costs
-        generation time and nothing else.
-        """
-        from fastvideo.api import GenerationRequest, OutputConfig, SamplingConfig
-
-        return GenerationRequest(
-            prompt=prompt,
-            # MiniMax-H3 is guidance-distilled, so there is no negative branch
-            # to steer and no CFG pass to pay for.
-            negative_prompt="",
-            sampling=SamplingConfig(
-                height=height,
-                width=width,
-                num_frames=frames,
-                fps=FRAME_RATE,
-                num_inference_steps=self.num_inference_steps,
-                guidance_scale=1.0,
-                batch_cfg=False,
-                seed=seed,
-            ),
-            output=OutputConfig(save_video=False, return_frames=keep_output),
-        )
-
-    def _generate_clip(
-        self, index: int, frames: int, prompt: str, seed: int, height: int, width: int
-    ):
-        """Build one clip and convert it to what the output tracks want.
-
-        Returns ``(frames_list, samples)``: a list of RGB uint8 ``[h, w, 3]``
-        arrays and int16 ``[1, samples]`` at 48 kHz, trimmed to exactly
-        ``len(frames_list) / 24`` seconds so the two tracks stay in lockstep.
-        """
-        started = time.monotonic()
-        result = self.generator.generate(
-            self._request(
-                frames=frames,
-                prompt=prompt,
-                seed=seed,
-                height=height,
-                width=width,
-                keep_output=True,
-            )
-        )
-        built = time.monotonic() - started
-
-        frames_list = result.frames
-        if not frames_list:
-            raise RuntimeError("the generator returned no frames")
-        samples = self._to_wire_audio(result.audio, result.audio_sample_rate, len(frames_list))
-        logger.info(
-            "clip built",
-            clip=index,
-            frames=len(frames_list),
-            content_s=round(len(frames_list) / FRAME_RATE, 2),
-            build_s=round(built, 2),
-            stages=self._stage_times(result),
-        )
-        return frames_list, samples
-
-    @staticmethod
-    def _stage_times(result) -> dict:
-        """Per-stage seconds from the generator, for the clip log line.
-
-        This is where a regression shows up first: post-decode frame processing
-        scales with resolution x frames and competes with the channel's slack.
-        """
-        try:
-            stages = getattr(getattr(result, "logging_info", None), "stages", None)
-            if not stages:
-                return {}
-            return {
-                name: round(float(metrics["execution_time"]), 3)
-                for name, metrics in stages.items()
-                if metrics.get("execution_time") is not None
-            }
-        except Exception:  # noqa: BLE001 — a log line must never fail a clip
-            logger.exception("could not read the generator stage timings")
-            return {}
-
-    def _to_wire_audio(self, audio, sample_rate, frames: int):
-        """Resample, downmix and quantize one clip's waveform for the wire.
-
-        Mono at the source is deliberate: the transport mean-downmixes before
-        the wire anyway, and the runtime recorder flattens two channels by
-        concatenation, so a stereo emit only corrupts recordings. Averaging here,
-        in float and before the int16 scale, is the same downmix one step
-        earlier.
-        """
-        import torch
-        import torchaudio.functional as AF
-
-        if audio is None:
-            raise RuntimeError("the generator returned no audio")
-        waveform = audio if torch.is_tensor(audio) else torch.as_tensor(audio)
-        waveform = waveform.detach().float().cpu()
-        # The decoder hands back [samples, channels]; the wire wants channel-major.
-        if waveform.ndim == 1:
-            waveform = waveform.unsqueeze(0)
-        elif waveform.shape[0] > waveform.shape[1]:
-            waveform = waveform.transpose(0, 1)
-        waveform = waveform.contiguous()
-
-        rate = int(sample_rate or NATIVE_SAMPLE_RATE)
-        if rate != OUTPUT_SAMPLE_RATE:
-            waveform = AF.resample(waveform, rate, OUTPUT_SAMPLE_RATE)
-        if waveform.shape[0] > 1:
-            waveform = waveform.mean(dim=0, keepdim=True)
-
-        want = round(frames / FRAME_RATE * OUTPUT_SAMPLE_RATE)
-        if waveform.shape[-1] > want:
-            waveform = waveform[:, :want]
-        elif waveform.shape[-1] < want:
-            pad = torch.zeros(
-                (waveform.shape[0], want - waveform.shape[-1]), dtype=waveform.dtype
-            )
-            waveform = torch.cat([waveform, pad], dim=-1)
-        return (waveform.clamp(-1, 1) * 32767).to(torch.int16).numpy()
+            await self.emit(FastH3Output(main_video=video, main_audio=samples[:, alo:ahi]))
+        return "finished"

--- a/models/fasth3/fasth3.yaml
+++ b/models/fasth3/fasth3.yaml
@@ -34,12 +34,16 @@ inference:
   # leaves the trained schedule and is not supported by the checkpoint.
   num_inference_steps: 5
 
-  # Video Sparse Attention. 0.9 / tile 64 / sm100a is the checkpoint's trained
-  # and measured policy (fastvideo_inference.json). `triton` is the portable
-  # fallback for a non-Blackwell box and is much slower.
+  # Video Sparse Attention, 0.9 sparsity on tile 64 — the checkpoint's trained
+  # policy (fastvideo_inference.json). The kernel is `triton`, the portable
+  # route: fastvideo-kernel 0.3.5's `sm100a` CUDA kernel fails to launch on
+  # this stack (`block_sparse_sm100a launch failed: invalid argument`, eager
+  # and compiled alike, driver 595 / CUDA 13.1 / B200). Switch back to
+  # `sm100a` when an upstream kernel release fixes it — it is the measured
+  # fast route, roughly 2.5x quicker per clip.
   vsa_sparsity: 0.9
   vsa_tile_size: 64
-  vsa_kernel: sm100a
+  vsa_kernel: triton
 
   # FA4 for the dense (text and audio) attention paths, and the inference-only
   # H3 fusions. Both are part of the measured profile. The fusions change
@@ -49,9 +53,11 @@ inference:
   h3_fusions: true
 
   # Regional compile of the transformer blocks, and an independently compiled
-  # video VAE decoder. Both are in the measured profile. Regional compile is
-  # shape-keyed, which is why every clip length and canvas has to be warmed.
-  inference_torch_compile: true
+  # video VAE decoder. Regional compile supports only the sm100a VSA route, so
+  # it is off while the kernel above is `triton`; turn both back on together.
+  # It is shape-keyed, which is why every clip length and canvas has to be
+  # warmed.
+  inference_torch_compile: false
   compile_vae: true
 
   # Sequence-parallel all-to-all route. `off` reproduces the measured profile;
@@ -69,15 +75,18 @@ inference:
 
 runtime:
   # Weight bundle layout, relative to the mounted weights root. One HF snapshot
-  # directory carries every component: transformer, text encoder, both VAEs,
-  # both schedulers, tokenizer and processor.
-  checkpoint_dir: FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree
+  # carries every component — transformer, text encoder, both VAEs, both
+  # schedulers, tokenizer and processor. "." means the components sit directly
+  # under the weights root, which is how `reactor weights upload` lays the
+  # bundle out; name a subdirectory here when the snapshot is nested instead.
+  checkpoint_dir: "."
 
   # Sequence parallelism spans every GPU (sp_size == num_gpus, tp_size 1).
-  # Eight is what keeps the queue responsive: the published build time for a
-  # 15 s clip is 12.88 s on eight B200s against 15.5 s on four, so a queued
-  # prompt is playable in well under its own duration.
-  num_gpus: 8
+  # Four matches FastVideo's tested default for this checkpoint: a 15 s clip
+  # builds in about 15.5 s (12.9 s on eight). Playback is explicit and clips
+  # are pre-built, so the count only moves the enqueue-to-ready wait; it must
+  # divide H3's 56 attention heads.
+  num_gpus: 4
 
   # false shards the transformer with FSDP, matching the checkpoint's own
   # contract. Sharding is what frees the VRAM to keep the text encoder resident
@@ -85,12 +94,13 @@ runtime:
   # denoise; A/B them on the target hardware.
   replicated_dit: false
 
-  # Offload policy. The text encoder is ~69 GB and every rank loads its own
-  # copy, so CPU-offloading it on eight ranks would want ~550 GB of host memory
-  # AND pay a host-to-device transfer on every clip. Keeping it resident is both
-  # cheaper and faster once the transformer is sharded — flip these back on only
-  # if VRAM measurements say otherwise.
-  offload_text_encoder: false
+  # Offload policy. The text encoder is ~63 GB and every rank loads its own
+  # copy; offloading it to the host costs ~250 GB of host memory (four ranks —
+  # size resources.memory in reactor.yaml with it) plus a transfer per clip,
+  # and drops the per-GPU footprint from ~92 GB to ~30 GB. On dedicated GPUs
+  # flipping it off is faster; it is on so the model also fits beside other
+  # tenants on a shared machine.
+  offload_text_encoder: true
   offload_vae: false
 
   # Pinned host buffers speed up device-to-host transfer but make the

--- a/models/fasth3/fasth3.yaml
+++ b/models/fasth3/fasth3.yaml
@@ -1,33 +1,32 @@
-# FastH3 — continuous channel configuration.
+# FastH3 — clip queue configuration.
 #
-# `inference` is the generation recipe; `runtime` is the weight layout and the
-# engine shape. fasth3.py reads this file itself (the runtime hands over the path
-# and does not parse it).
+# `inference` is the generation recipe and the queue's shape; `runtime` is the
+# weight layout and the engine shape. fasth3_assets.py reads this file (the
+# runtime hands over the path and does not parse it).
 
 inference:
-  # Aspect the session starts at. `set_canvas` can change it while idle, to any
-  # entry in clip_plan.ASPECT_CHOICES. 16:9 resolves to 1344x768 — the canvas
-  # every published FastH3 number was measured at.
+  # Aspect the session starts at. `set_canvas` can change it while the queue is
+  # empty and nothing plays, to any entry in clip_plan.ASPECT_CHOICES. 16:9
+  # resolves to 1344x768 — the canvas every published FastH3 number was
+  # measured at.
   aspect: "16:9"
 
-  # Steady-state clip length in seconds. 14.375 s is the longest the checkpoint
-  # will generate: 15.0 s is 360 frames, which aligns up to 362 (15.083 s) and is
-  # then rejected for exceeding the duration cap, so 345 frames is the ceiling.
-  #
-  # Longer is better for the channel. Build cost is sublinear in length, so a
-  # long clip has the most slack between "built" and "needed", and it cuts least
-  # often. The trade is that a new prompt takes longer to reach the viewer.
+  # Default clip length in seconds; `set_clip_seconds` changes it per session
+  # and each `enqueue` snapshots the value in force. 14.375 s is the longest
+  # the checkpoint will generate: 15.0 s is 360 frames, which aligns up to 362
+  # (15.083 s) and is then rejected for exceeding the duration cap, so 345
+  # frames is the ceiling.
   clip_seconds: 14.375
 
-  # Time-to-first-frame ramp: the clip lengths the channel opens with before
-  # settling on `clip_seconds`. A short first clip builds proportionally faster,
-  # so video starts in about a third of the time. Every entry is a distinct
-  # tensor shape the warm-up must cover, so keep the list short; [] disables the
-  # ramp for a uniform cadence from clip zero.
-  ramp_seconds: [5.167]
+  # Most clips the queue holds; `enqueue` is refused beyond it. Every entry can
+  # hold a fully built clip in host memory — about 1 GB of uint8 pixels at the
+  # 16:9 canvas and the longest length — so this bound is also the model's
+  # host-memory budget for built clips. Size `resources.memory` in the manifest
+  # together with it.
+  queue_size: 10
 
-  # Seed the channel starts from; each clip advances it by one. `set_seed`
-  # overrides per session.
+  # Seed the first `enqueue` of a session uses; each one advances it by one.
+  # `set_seed` overrides per session.
   seed: 1000
 
   # Sigma-grid POINTS, not transformer forwards. The distilled schedule is
@@ -60,10 +59,12 @@ inference:
   # supports it.
   ulysses_a2a: "off"
 
-  # Canvases warmed at load, one full build per clip shape each. Adding an entry
-  # costs pod-boot time; leaving one out means its first clip pays a one-off
-  # compile stall mid-channel. Start with the default only and widen once the
-  # boot cost is measured.
+  # Canvases warmed at load, one full build each at the default clip length.
+  # Adding an entry costs pod-boot time; leaving one out means the first clip
+  # built at that canvas pays a one-off compile stall. A non-default
+  # `set_clip_seconds` is a new shape too and pays the same stall on its first
+  # build. Start with the default only and widen once the boot cost is
+  # measured.
   warmup_aspects: ["16:9"]
 
 runtime:
@@ -73,9 +74,9 @@ runtime:
   checkpoint_dir: FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree
 
   # Sequence parallelism spans every GPU (sp_size == num_gpus, tp_size 1).
-  # Eight is what makes the channel work: the published build time for a 15 s
-  # clip is 12.88 s on eight B200s against 15.5 s on four, and only the former
-  # is faster than the video plays.
+  # Eight is what keeps the queue responsive: the published build time for a
+  # 15 s clip is 12.88 s on eight B200s against 15.5 s on four, so a queued
+  # prompt is playable in well under its own duration.
   num_gpus: 8
 
   # false shards the transformer with FSDP, matching the checkpoint's own

--- a/models/fasth3/fasth3.yaml
+++ b/models/fasth3/fasth3.yaml
@@ -34,16 +34,14 @@ inference:
   # leaves the trained schedule and is not supported by the checkpoint.
   num_inference_steps: 5
 
-  # Video Sparse Attention, 0.9 sparsity on tile 64 — the checkpoint's trained
-  # policy (fastvideo_inference.json). The kernel is `triton`, the portable
-  # route: fastvideo-kernel 0.3.5's `sm100a` CUDA kernel fails to launch on
-  # this stack (`block_sparse_sm100a launch failed: invalid argument`, eager
-  # and compiled alike, driver 595 / CUDA 13.1 / B200). Switch back to
-  # `sm100a` when an upstream kernel release fixes it — it is the measured
-  # fast route, roughly 2.5x quicker per clip.
+  # Video Sparse Attention. 0.9 / tile 64 / sm100a is the checkpoint's trained
+  # and measured policy (fastvideo_inference.json); the sm100a kernel is built
+  # from source at image build time (see requirements.txt) because the
+  # published wheel's binary cannot launch on this driver. `triton` is the
+  # portable fallback for a non-Blackwell box and is much slower.
   vsa_sparsity: 0.9
   vsa_tile_size: 64
-  vsa_kernel: triton
+  vsa_kernel: sm100a
 
   # FA4 for the dense (text and audio) attention paths, and the inference-only
   # H3 fusions. Both are part of the measured profile. The fusions change
@@ -53,11 +51,9 @@ inference:
   h3_fusions: true
 
   # Regional compile of the transformer blocks, and an independently compiled
-  # video VAE decoder. Regional compile supports only the sm100a VSA route, so
-  # it is off while the kernel above is `triton`; turn both back on together.
-  # It is shape-keyed, which is why every clip length and canvas has to be
-  # warmed.
-  inference_torch_compile: false
+  # video VAE decoder. Both are in the measured profile. Regional compile is
+  # shape-keyed, which is why every clip length and canvas has to be warmed.
+  inference_torch_compile: true
   compile_vae: true
 
   # Sequence-parallel all-to-all route. `off` reproduces the measured profile;
@@ -88,11 +84,12 @@ runtime:
   # divide H3's 56 attention heads.
   num_gpus: 4
 
-  # false shards the transformer with FSDP, matching the checkpoint's own
-  # contract. Sharding is what frees the VRAM to keep the text encoder resident
-  # below. true replicates it instead (~70 GB per GPU) for the fastest measured
-  # denoise; A/B them on the target hardware.
-  replicated_dit: false
+  # true replicates the transformer on every rank (~66 GB per GPU) — the
+  # configuration FastVideo's published numbers were measured at, and the
+  # fastest denoise (FSDP sharding halves the per-GPU weight cost but roughly
+  # doubles the denoise time gathering layers). The offloaded text encoder
+  # below is what leaves the VRAM for it.
+  replicated_dit: true
 
   # Offload policy. The text encoder is ~63 GB and every rank loads its own
   # copy; offloading it to the host costs ~250 GB of host memory (four ranks —
@@ -103,8 +100,7 @@ runtime:
   offload_text_encoder: true
   offload_vae: false
 
-  # Pinned host buffers speed up device-to-host transfer but make the
-  # per-clip pixel allocations expensive to acquire and release. With nothing
-  # offloaded there is little left to pin, so this stays off; turn it on
-  # together with the offload flags above.
-  pin_cpu_memory: false
+  # Pinned host buffers make the per-clip text-encoder page-in several times
+  # faster than pageable memory. On together with the offload above; the cost
+  # is pinning ~63 GB of host memory per rank at load.
+  pin_cpu_memory: true

--- a/models/fasth3/fasth3_assets.py
+++ b/models/fasth3/fasth3_assets.py
@@ -97,8 +97,16 @@ def load_config(config_path: Path | None) -> FastH3Config:
 
 
 def resolve_model_path(config: FastH3Config, weights_root: Path) -> Path:
-    """The checkpoint directory inside the mounted weights bundle."""
-    return weights_root / str(config.runtime.get("checkpoint_dir", DEFAULT_CHECKPOINT_DIR))
+    """The checkpoint directory inside the mounted weights bundle.
+
+    ``checkpoint_dir: "."`` means the snapshot's components sit directly under
+    the weights root, which is how ``reactor weights upload`` lays a bundle out
+    when the snapshot itself is uploaded.
+    """
+    subdir = str(config.runtime.get("checkpoint_dir", DEFAULT_CHECKPOINT_DIR))
+    if subdir in ("", "."):
+        return weights_root
+    return weights_root / subdir
 
 
 def require_weights(root: Path, model_path: Path) -> None:

--- a/models/fasth3/fasth3_assets.py
+++ b/models/fasth3/fasth3_assets.py
@@ -1,0 +1,129 @@
+"""Config parsing and weights-bundle validation for FastH3.
+
+``fasth3.yaml`` is read here and nowhere else: ``load_config`` turns it into
+one validated :class:`FastH3Config`, and ``require_weights`` fails startup
+loudly when the bundle on disk is incomplete. Pure file and dict work — no
+torch, no fastvideo — so the schema renders and the tests run on any machine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+import fasth3_clip_plan as clip_plan
+
+# The HF snapshot directory inside the weights bundle.
+DEFAULT_CHECKPOINT_DIR = "FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree"
+
+# Component directories the T2VA pipeline loads. An incomplete bundle must kill
+# startup, not surface as a loader traceback on the first clip.
+REQUIRED_COMPONENTS = (
+    "transformer",
+    "text_encoder",
+    "tokenizer",
+    "processor",
+    "vae",
+    "audio_vae",
+    "scheduler",
+    "audio_scheduler",
+)
+
+
+@dataclass(frozen=True)
+class FastH3Config:
+    """Everything ``fasth3.yaml`` configures, validated once at load.
+
+    The session-level fields are the defaults a fresh session starts from and
+    the queue's fixed capacity. ``inference`` and ``runtime`` are the raw
+    blocks; the backend reads its engine knobs (attention kernels, compile
+    flags, parallelism, offload policy) straight from them.
+    """
+
+    aspect: str
+    clip_frames: int
+    seed: int
+    num_inference_steps: int
+    queue_size: int
+    warmup_aspects: tuple[str, ...]
+    inference: dict[str, Any]
+    runtime: dict[str, Any]
+
+
+def load_config(config_path: Path | None) -> FastH3Config:
+    """Parse ``fasth3.yaml`` into a validated :class:`FastH3Config`.
+
+    Args:
+        config_path: Path the runtime hands over from ``runtime.config`` in
+            ``reactor.yaml``, or ``None`` when the manifest names no config.
+
+    Raises:
+        ValueError: If the configured aspect is not one this model offers, or
+            the queue size is not positive.
+    """
+    document: dict[str, Any] = {}
+    if config_path is not None:
+        document = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    inference: dict[str, Any] = document.get("inference") or {}
+    runtime: dict[str, Any] = document.get("runtime") or {}
+
+    aspect = str(inference.get("aspect", "16:9"))
+    if aspect not in clip_plan.ASPECT_CHOICES:
+        raise ValueError(
+            f"inference.aspect must be one of {list(clip_plan.ASPECT_CHOICES)}, got {aspect!r}"
+        )
+
+    queue_size = int(inference.get("queue_size", 10))
+    if queue_size < 1:
+        raise ValueError(f"inference.queue_size must be positive, got {queue_size}")
+
+    return FastH3Config(
+        aspect=aspect,
+        clip_frames=clip_plan.frames_for_seconds(
+            float(inference.get("clip_seconds", clip_plan.MAX_SECONDS))
+        ),
+        seed=int(inference.get("seed", 1000)),
+        # Sigma-grid POINTS, not transformer forwards: the distilled schedule is
+        # five points and exactly four forwards.
+        num_inference_steps=int(inference.get("num_inference_steps", 5)),
+        queue_size=queue_size,
+        warmup_aspects=tuple(str(a) for a in (inference.get("warmup_aspects") or [aspect])),
+        inference=inference,
+        runtime=runtime,
+    )
+
+
+def resolve_model_path(config: FastH3Config, weights_root: Path) -> Path:
+    """The checkpoint directory inside the mounted weights bundle."""
+    return weights_root / str(config.runtime.get("checkpoint_dir", DEFAULT_CHECKPOINT_DIR))
+
+
+def require_weights(root: Path, model_path: Path) -> None:
+    """Fail startup loudly when the weights bundle is incomplete."""
+    problems: list[str] = []
+    if not model_path.is_dir():
+        problems.append(f"checkpoint directory is missing: {model_path}")
+    else:
+        index = model_path / "modular_model_index.json"
+        if not index.is_file():
+            problems.append(f"modular_model_index.json is missing: {index}")
+        for component in REQUIRED_COMPONENTS:
+            if not (model_path / component).is_dir():
+                problems.append(f"component directory is missing: {model_path / component}")
+    if problems:
+        raise FileNotFoundError(
+            f"FastH3 weights bundle under {root} is incomplete:\n  " + "\n  ".join(problems)
+        )
+
+
+__all__ = [
+    "DEFAULT_CHECKPOINT_DIR",
+    "REQUIRED_COMPONENTS",
+    "FastH3Config",
+    "load_config",
+    "require_weights",
+    "resolve_model_path",
+]

--- a/models/fasth3/fasth3_backend.py
+++ b/models/fasth3/fasth3_backend.py
@@ -1,0 +1,471 @@
+"""The FastVideo engine behind FastH3: GPU work, and nothing client-facing.
+
+One :class:`FastH3Backend` owns the eight-GPU ``VideoGenerator``, the
+environment profile it must be built under, the load-time warm-up, and a single
+persistent worker thread that builds clips one at a time. ``fasth3.py`` submits
+work with :meth:`FastH3Backend.submit` and polls the returned
+:class:`ClipJob`; nothing in here knows about commands, tracks, or the queue.
+
+torch, torchaudio and fastvideo are imported lazily inside methods, so
+importing this module — which rendering the schema does — needs none of them.
+"""
+
+from __future__ import annotations
+
+import os
+import queue
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from reactor_runtime.log import get_logger
+
+import fasth3_clip_plan as clip_plan
+from fasth3_assets import FastH3Config
+
+logger = get_logger(__name__)
+
+FRAME_RATE = clip_plan.FPS
+
+# WebRTC-native rate every clip's waveform is resampled to. The checkpoint's
+# audio decoder is 32 kHz; the wire is 48 kHz.
+OUTPUT_SAMPLE_RATE = 48_000
+NATIVE_SAMPLE_RATE = 32_000
+
+# How often a blocking wait on the worker re-checks. Used only during load().
+_WORKER_POLL_SECONDS = 0.1
+
+# What the warm-up builds. Never reaches a client: warm-up output is discarded,
+# and its only job is to be a syntactically ordinary prompt.
+WARMUP_PROMPT = "A slow cinematic shot of sunlight moving across a quiet room."
+
+
+class ClipJob:
+    """The handle to one submitted build: its inputs, outcome, and completion.
+
+    The error is carried back rather than only logged, so the submitter can
+    report the failed clip to clients. ``cancelled`` set before the worker
+    reaches the job skips the build entirely; set after, the build runs to
+    completion and the submitter discards the result.
+    """
+
+    __slots__ = ("cancelled", "done", "error", "fn", "result")
+
+    def __init__(self, fn) -> None:
+        self.fn = fn
+        self.done = threading.Event()
+        self.error: BaseException | None = None
+        self.result: tuple[list[Any], Any] | None = None
+        self.cancelled = False
+
+
+class FastH3Backend:
+    """Build FastH3 clips on demand, serialised on one worker thread.
+
+    The GPU work itself lives in the engine processes FastVideo spawns; the
+    thread exists to serialise submissions and to give teardown a single handle
+    to wait on.
+    """
+
+    def __init__(self, config: FastH3Config, model_path: Path) -> None:
+        """Remember the recipe and the weights location; nothing loads yet."""
+        self._config = config
+        self._model_path = model_path
+        self._jobs: queue.Queue[ClipJob] = queue.Queue()
+        self._worker: threading.Thread | None = None
+        self.generator: Any = None
+
+    # ------------------------------------------------------------------ load
+
+    def load(self) -> None:
+        """Build the eight-GPU generator and warm every configured clip shape.
+
+        Runs once at startup. The caller's ``load()`` returning is what marks
+        the pod ready, so everything that can fail — missing kernels, a broken
+        native linkage, a cold compile — must fail here, not on the first
+        client's clip.
+        """
+        # Must happen before the generator is built: the engine spawns worker
+        # processes, which inherit os.environ, and these select the attention
+        # backend and the sparse kernel.
+        self._apply_profile_environment()
+        self._validate_profile_dependencies()
+
+        runtime = self._config.runtime
+        num_gpus = int(runtime.get("num_gpus", 8))
+        logger.info(
+            "building fasth3 generator",
+            model_path=str(self._model_path),
+            num_gpus=num_gpus,
+            clip_frames=self._config.clip_frames,
+        )
+
+        from fastvideo import VideoGenerator
+
+        self.generator = VideoGenerator.from_config(self._generator_config())
+
+        self._worker = threading.Thread(
+            target=self._worker_loop, name="fasth3-generation", daemon=True
+        )
+        self._worker.start()
+        self._preload_native_imports()
+        self._run_blocking(self._warmup)
+        logger.info("fasth3 backend loaded")
+
+    @staticmethod
+    def _preload_native_imports() -> None:
+        """Touch every deferred native import the build path needs.
+
+        Lazy imports mean the first import would otherwise happen on the first
+        real clip — after load, after warm-up, after the pod reports ready —
+        where a linkage failure is a dead session rather than a startup error.
+        The resample below is a real call, so it fails here or not at all.
+        """
+        import numpy  # noqa: F401
+        import torch
+        import torchaudio.functional as AF
+
+        AF.resample(torch.zeros(2, NATIVE_SAMPLE_RATE // 10), NATIVE_SAMPLE_RATE, OUTPUT_SAMPLE_RATE)
+
+    # --------------------------------------------------------------- profile
+
+    def _apply_profile_environment(self) -> None:
+        """Set the FastH3 profile environment, exactly as the reference CLI does.
+
+        Mirrors ``examples/inference/basic/basic_fasth3.py:profile_environment``.
+        Values are explicit even for disabled features, so a shell's inherited
+        experiment settings cannot silently change the profile a pod serves.
+        """
+        cfg = self._config.inference
+        vsa_kernel = str(cfg.get("vsa_kernel", "sm100a"))
+        fusions = "all" if bool(cfg.get("h3_fusions", True)) else "0"
+        environment: dict[str, str | None] = {
+            "FASTVIDEO_ATTENTION_BACKEND": "VIDEO_SPARSE_ATTN_H3",
+            "FASTVIDEO_VSA_SM100A": "1" if vsa_kernel == "sm100a" else "0",
+            "FASTVIDEO_VSA_CUTEDSL": "0",
+            # A non-empty path enables the diagnostic probe; it must stay unset.
+            "FASTVIDEO_H3_VSA_PROBE": None,
+            "FASTVIDEO_DISABLE_ATTENTION_COMPILE": "0",
+            "FASTVIDEO_FA4": "1" if bool(cfg.get("fa4", True)) else "0",
+            "FASTVIDEO_NVFP4_FA4": "0",
+            "FASTVIDEO_MINIMAX_H3_FA4_PACKED_VARLEN": "0",
+            "FASTVIDEO_MINIMAX_H3_FUSIONS": fusions,
+            "FASTVIDEO_INFERENCE_TORCH_COMPILE": (
+                "1" if bool(cfg.get("inference_torch_compile", True)) else "0"
+            ),
+            "FASTVIDEO_VAE_PARALLEL_DECODE": (
+                "1" if bool(cfg.get("vae_parallel_decode", True)) else "0"
+            ),
+            "FASTVIDEO_VAE_PARALLEL_ENCODE": "0",
+            "FASTVIDEO_VAE_PARALLEL_DECODE_STRATEGY": "gather",
+            "FASTVIDEO_ULYSSES_A2A": str(cfg.get("ulysses_a2a", "off")),
+            "FASTVIDEO_STAGE_LOGGING": "1",
+        }
+        for name, value in environment.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        logger.info("fasth3 profile", **{k: (v or "<unset>") for k, v in environment.items()})
+
+    def _validate_profile_dependencies(self) -> None:
+        """Fail before the 148 GB load when the selected fast route is absent."""
+        import importlib.util
+
+        cfg = self._config.inference
+        if bool(cfg.get("fa4", True)):
+            try:
+                present = importlib.util.find_spec("flash_attn.cute") is not None
+            except (ImportError, ModuleNotFoundError):
+                present = False
+            if not present:
+                raise RuntimeError(
+                    "FastH3's FA4 route needs the pinned flash-attn-4 package. Install it, "
+                    "or set inference.fa4: false in fasth3.yaml."
+                )
+        if str(cfg.get("vsa_kernel", "sm100a")) == "sm100a":
+            try:
+                from fastvideo_kernel import block_sparse_attn_sm100a
+            except ImportError:
+                present = False
+            else:
+                present = bool(getattr(block_sparse_attn_sm100a, "_HAS_VSA_SM100A", False))
+            if not present:
+                raise RuntimeError(
+                    "FastH3's sm100a route needs fastvideo-kernel built with the Blackwell VSA "
+                    "extension. Install a matching wheel, or set inference.vsa_kernel: triton."
+                )
+
+    def _generator_config(self):
+        """The engine shape, mirroring ``basic_fasth3.py:build_generator_config``."""
+        from fastvideo.api import (
+            CompileConfig,
+            ComponentConfig,
+            EngineConfig,
+            GeneratorConfig,
+            OffloadConfig,
+            ParallelismConfig,
+            PipelineSelection,
+        )
+
+        cfg = self._config.inference
+        runtime = self._config.runtime
+        num_gpus = int(runtime.get("num_gpus", 8))
+        # The checkpoint's own contract (fastvideo_inference.json) shards the
+        # transformer with FSDP. Sharding is what frees the VRAM to keep the
+        # text encoder resident, which is the deployment this model wants.
+        replicated_dit = bool(runtime.get("replicated_dit", False))
+        return GeneratorConfig(
+            model_path=str(self._model_path),
+            pipeline=PipelineSelection(
+                components=ComponentConfig(),
+                experimental={
+                    "attention_backend": "VIDEO_SPARSE_ATTN_H3",
+                    "VSA_sparsity": float(cfg.get("vsa_sparsity", 0.9)),
+                    "VSA_tile_size": int(cfg.get("vsa_tile_size", 64)),
+                    "inference_torch_compile": bool(cfg.get("inference_torch_compile", True)),
+                    "vae_parallel_decode": bool(cfg.get("vae_parallel_decode", True)),
+                    "vae_parallel_decode_strategy": "gather",
+                },
+            ),
+            engine=EngineConfig(
+                num_gpus=num_gpus,
+                use_fsdp_inference=num_gpus > 1 and not replicated_dit,
+                parallelism=ParallelismConfig(tp_size=1, sp_size=num_gpus),
+                offload=OffloadConfig(
+                    dit=False,
+                    dit_layerwise=False,
+                    text_encoder=bool(runtime.get("offload_text_encoder", False)),
+                    vae=bool(runtime.get("offload_vae", False)),
+                    pin_cpu_memory=bool(runtime.get("pin_cpu_memory", False)),
+                ),
+                compile=CompileConfig(
+                    enabled=False,
+                    mode=None,
+                    vae_enabled=bool(cfg.get("compile_vae", True)),
+                ),
+            ),
+        )
+
+    # ---------------------------------------------------------------- worker
+
+    def _worker_loop(self) -> None:
+        """Run submitted jobs, one at a time, forever.
+
+        The waiter is always released, even when the job died: a completion
+        event that never arrives is indistinguishable from a hang, and this
+        thread is the only one that will ever set it.
+        """
+        logger.info("generation worker ready")
+        while True:
+            job = self._jobs.get()
+            try:
+                if not job.cancelled:
+                    job.result = job.fn()
+            except BaseException as error:  # noqa: BLE001 — handed to the submitter
+                job.error = error
+                logger.exception("generation worker job raised")
+            finally:
+                job.done.set()
+
+    def submit(self, *, frames: int, prompt: str, seed: int, height: int, width: int) -> ClipJob:
+        """Queue one clip build and hand back its job handle.
+
+        Returns immediately; the caller polls ``job.done`` and reads
+        ``job.result`` — ``(frames_list, samples)``, RGB uint8 frames and an
+        int16 ``[1, samples]`` waveform at the wire rate — or ``job.error``.
+        """
+        job = ClipJob(
+            lambda: self._generate_clip(
+                frames=frames, prompt=prompt, seed=seed, height=height, width=width
+            )
+        )
+        self._jobs.put(job)
+        return job
+
+    def _run_blocking(self, fn) -> None:
+        """Run work on the worker, block until it finishes, and re-raise its failure.
+
+        Used only by ``load()``. Blocking here is the point: the runtime marks
+        the pod ready when the model's ``load()`` returns, so a failed warm-up
+        has to stop startup rather than being discovered by the first client.
+        """
+        job = ClipJob(fn)
+        self._jobs.put(job)
+        while not job.done.wait(timeout=_WORKER_POLL_SECONDS):
+            pass
+        if job.error is not None:
+            raise job.error
+
+    # --------------------------------------------------------------- warm-up
+
+    def _warmup(self) -> None:
+        """Build one throwaway clip per shape, before the pod reports ready.
+
+        Every distinct frame count and canvas is a separate one-time cost —
+        regional compile, sparse-kernel autotune, allocator growth — and paying
+        it here means the first real clip builds at warm speed. Results are
+        discarded: ``return_frames=False, save_video=False`` skips the whole
+        post-decode path, so a warm-up costs generation time and nothing else.
+        """
+        aspects = self._config.warmup_aspects
+        cold = [a for a in clip_plan.ASPECT_CHOICES if a not in aspects]
+        if cold:
+            logger.info(
+                "aspects left cold; their first clip pays a one-off compile stall", aspects=cold
+            )
+        for aspect in aspects:
+            height, width = clip_plan.canvas_for_choice(aspect)
+            started = time.monotonic()
+            self.generator.generate(
+                self._request(
+                    frames=self._config.clip_frames,
+                    prompt=WARMUP_PROMPT,
+                    seed=self._config.seed,
+                    height=height,
+                    width=width,
+                    keep_output=False,
+                )
+            )
+            logger.info(
+                "warmed clip shape",
+                aspect=aspect,
+                frames=self._config.clip_frames,
+                height=height,
+                width=width,
+                seconds=round(time.monotonic() - started, 2),
+            )
+
+    # ------------------------------------------------------------ generation
+
+    def _request(
+        self,
+        *,
+        frames: int,
+        prompt: str,
+        seed: int,
+        height: int,
+        width: int,
+        keep_output: bool,
+    ):
+        """Build one generation request.
+
+        Mirrors ``basic_fasth3.py:build_request``. ``keep_output=False`` is the
+        warm-up shape: it skips the whole post-decode path, so a warm-up costs
+        generation time and nothing else.
+        """
+        from fastvideo.api import GenerationRequest, OutputConfig, SamplingConfig
+
+        return GenerationRequest(
+            prompt=prompt,
+            # MiniMax-H3 is guidance-distilled, so there is no negative branch
+            # to steer and no CFG pass to pay for.
+            negative_prompt="",
+            sampling=SamplingConfig(
+                height=height,
+                width=width,
+                num_frames=frames,
+                fps=FRAME_RATE,
+                num_inference_steps=self._config.num_inference_steps,
+                guidance_scale=1.0,
+                batch_cfg=False,
+                seed=seed,
+            ),
+            output=OutputConfig(save_video=False, return_frames=keep_output),
+        )
+
+    def _generate_clip(self, *, frames: int, prompt: str, seed: int, height: int, width: int):
+        """Build one clip and convert it to what the output tracks want.
+
+        Returns ``(frames_list, samples)``: a list of RGB uint8 ``[h, w, 3]``
+        arrays and int16 ``[1, samples]`` at 48 kHz, trimmed to exactly
+        ``len(frames_list) / 24`` seconds so the two tracks stay in lockstep.
+        """
+        started = time.monotonic()
+        result = self.generator.generate(
+            self._request(
+                frames=frames,
+                prompt=prompt,
+                seed=seed,
+                height=height,
+                width=width,
+                keep_output=True,
+            )
+        )
+        built = time.monotonic() - started
+
+        frames_list = result.frames
+        if not frames_list:
+            raise RuntimeError("the generator returned no frames")
+        samples = self._to_wire_audio(result.audio, result.audio_sample_rate, len(frames_list))
+        logger.info(
+            "clip built",
+            frames=len(frames_list),
+            content_s=round(len(frames_list) / FRAME_RATE, 2),
+            build_s=round(built, 2),
+            stages=self._stage_times(result),
+        )
+        return frames_list, samples
+
+    @staticmethod
+    def _stage_times(result) -> dict:
+        """Per-stage seconds from the generator, for the clip log line.
+
+        This is where a regression shows up first: post-decode frame processing
+        scales with resolution x frames and competes with the build budget.
+        """
+        try:
+            stages = getattr(getattr(result, "logging_info", None), "stages", None)
+            if not stages:
+                return {}
+            return {
+                name: round(float(metrics["execution_time"]), 3)
+                for name, metrics in stages.items()
+                if metrics.get("execution_time") is not None
+            }
+        except Exception:  # noqa: BLE001 — a log line must never fail a clip
+            logger.exception("could not read the generator stage timings")
+            return {}
+
+    def _to_wire_audio(self, audio, sample_rate, frames: int):
+        """Resample, downmix and quantize one clip's waveform for the wire.
+
+        Mono at the source is deliberate: the transport mean-downmixes before
+        the wire anyway, and the runtime recorder flattens two channels by
+        concatenation, so a stereo emit only corrupts recordings. Averaging here,
+        in float and before the int16 scale, is the same downmix one step
+        earlier.
+        """
+        import torch
+        import torchaudio.functional as AF
+
+        if audio is None:
+            raise RuntimeError("the generator returned no audio")
+        waveform = audio if torch.is_tensor(audio) else torch.as_tensor(audio)
+        waveform = waveform.detach().float().cpu()
+        # The decoder hands back [samples, channels]; the wire wants channel-major.
+        if waveform.ndim == 1:
+            waveform = waveform.unsqueeze(0)
+        elif waveform.shape[0] > waveform.shape[1]:
+            waveform = waveform.transpose(0, 1)
+        waveform = waveform.contiguous()
+
+        rate = int(sample_rate or NATIVE_SAMPLE_RATE)
+        if rate != OUTPUT_SAMPLE_RATE:
+            waveform = AF.resample(waveform, rate, OUTPUT_SAMPLE_RATE)
+        if waveform.shape[0] > 1:
+            waveform = waveform.mean(dim=0, keepdim=True)
+
+        want = round(frames / FRAME_RATE * OUTPUT_SAMPLE_RATE)
+        if waveform.shape[-1] > want:
+            waveform = waveform[:, :want]
+        elif waveform.shape[-1] < want:
+            pad = torch.zeros(
+                (waveform.shape[0], want - waveform.shape[-1]), dtype=waveform.dtype
+            )
+            waveform = torch.cat([waveform, pad], dim=-1)
+        return (waveform.clamp(-1, 1) * 32767).to(torch.int16).numpy()
+
+
+__all__ = ["OUTPUT_SAMPLE_RATE", "ClipJob", "FastH3Backend"]

--- a/models/fasth3/fasth3_backend.py
+++ b/models/fasth3/fasth3_backend.py
@@ -40,6 +40,15 @@ _WORKER_POLL_SECONDS = 0.1
 # and its only job is to be a syntactically ordinary prompt.
 WARMUP_PROMPT = "A slow cinematic shot of sunlight moving across a quiet room."
 
+# Every prompt is padded (or token-truncated) to exactly this many tokens
+# before it reaches the engine. Regional torch.compile is keyed on the packed
+# sequence length, which includes the prompt's token count, so a novel prompt
+# length would otherwise recompile — measured at ~23 s against ~15 s for the
+# clip itself. One fixed length means one compiled shape, captured by the
+# warm-up and reused by every clip. 256 comfortably holds the 800-character
+# prompt cap.
+PROMPT_TOKENS = 256
+
 
 class ClipJob:
     """The handle to one submitted build: its inputs, outcome, and completion.
@@ -104,6 +113,7 @@ class FastH3Backend:
         from fastvideo import VideoGenerator
 
         self.generator = VideoGenerator.from_config(self._generator_config())
+        self._load_tokenizer()
 
         self._worker = threading.Thread(
             target=self._worker_loop, name="fasth3-generation", daemon=True
@@ -112,6 +122,48 @@ class FastH3Backend:
         self._preload_native_imports()
         self._run_blocking(self._warmup)
         logger.info("fasth3 backend loaded")
+
+    def _load_tokenizer(self) -> None:
+        """Load the bundle's tokenizer and calibrate the one-token pad filler.
+
+        Padding must land on an exact token count, so the filler is verified to
+        cost exactly one token at load rather than assumed.
+        """
+        from transformers import AutoTokenizer
+
+        self._tokenizer = AutoTokenizer.from_pretrained(str(self._model_path / "tokenizer"))
+        for candidate in (" .", ".", " a"):
+            base = len(self._tokenizer.encode(WARMUP_PROMPT, add_special_tokens=False))
+            padded = len(
+                self._tokenizer.encode(WARMUP_PROMPT + candidate, add_special_tokens=False)
+            )
+            if padded == base + 1:
+                self._pad_filler = candidate
+                return
+        raise RuntimeError("no single-token pad filler found for this tokenizer")
+
+    def _pad_prompt(self, prompt: str) -> str:
+        """Return *prompt* at exactly ``PROMPT_TOKENS`` tokens.
+
+        Shorter prompts gain trailing filler tokens; a longer one (past the
+        800-character cap only in pathological tokenizations) is truncated at
+        the token boundary. The client-facing prompt — what `ClipInfo` echoes —
+        is the original; only the engine sees this form.
+        """
+        encode = lambda text: len(self._tokenizer.encode(text, add_special_tokens=False))  # noqa: E731
+        ids = self._tokenizer.encode(prompt, add_special_tokens=False)
+        if ids and len(ids) >= PROMPT_TOKENS:
+            return self._tokenizer.decode(ids[:PROMPT_TOKENS])
+        padded = prompt + self._pad_filler * (PROMPT_TOKENS - len(ids))
+        # Filler cost is calibrated, but a prompt's own tail can merge with the
+        # first filler token; correct by measurement rather than assumption.
+        while encode(padded) > PROMPT_TOKENS:
+            padded = padded[: -len(self._pad_filler)]
+        while encode(padded) < PROMPT_TOKENS:
+            padded += self._pad_filler
+        if encode(padded) != PROMPT_TOKENS:
+            logger.warning(f"prompt padded to {encode(padded)} tokens, not {PROMPT_TOKENS}")
+        return padded
 
     @staticmethod
     def _preload_native_imports() -> None:
@@ -358,7 +410,9 @@ class FastH3Backend:
         from fastvideo.api import GenerationRequest, OutputConfig, SamplingConfig
 
         return GenerationRequest(
-            prompt=prompt,
+            # Padded to the fixed token length so one compiled shape serves
+            # every prompt; ClipInfo keeps echoing the original text.
+            prompt=self._pad_prompt(prompt),
             # MiniMax-H3 is guidance-distilled, so there is no negative branch
             # to steer and no CFG pass to pay for.
             negative_prompt="",

--- a/models/fasth3/fasth3_backend.py
+++ b/models/fasth3/fasth3_backend.py
@@ -401,16 +401,14 @@ class FastH3Backend:
         samples = self._to_wire_audio(result.audio, result.audio_sample_rate, len(frames_list))
         # The line to evaluate the deployment by: build seconds against content
         # seconds (realtime_x > 1 means the clip built faster than it plays) on
-        # the GPU count that produced it, with the per-stage split.
+        # the GPU count that produced it, with the per-stage split. The numbers
+        # live in the message itself so every log formatter carries them.
         content = len(frames_list) / FRAME_RATE
+        gpus = int(self._config.runtime.get("num_gpus", 8))
         logger.info(
-            "clip built",
-            frames=len(frames_list),
-            content_s=round(content, 2),
-            build_s=round(built, 2),
-            realtime_x=round(content / built, 2) if built > 0 else None,
-            gpus=int(self._config.runtime.get("num_gpus", 8)),
-            stages=self._stage_times(result),
+            f"clip built: {len(frames_list)}f ({content:.2f}s content) in {built:.2f}s "
+            f"= {content / built:.2f}x realtime on {gpus} gpus, "
+            f"stages={self._stage_times(result)}"
         )
         return frames_list, samples
 

--- a/models/fasth3/fasth3_backend.py
+++ b/models/fasth3/fasth3_backend.py
@@ -399,11 +399,17 @@ class FastH3Backend:
         if not frames_list:
             raise RuntimeError("the generator returned no frames")
         samples = self._to_wire_audio(result.audio, result.audio_sample_rate, len(frames_list))
+        # The line to evaluate the deployment by: build seconds against content
+        # seconds (realtime_x > 1 means the clip built faster than it plays) on
+        # the GPU count that produced it, with the per-stage split.
+        content = len(frames_list) / FRAME_RATE
         logger.info(
             "clip built",
             frames=len(frames_list),
-            content_s=round(len(frames_list) / FRAME_RATE, 2),
+            content_s=round(content, 2),
             build_s=round(built, 2),
+            realtime_x=round(content / built, 2) if built > 0 else None,
+            gpus=int(self._config.runtime.get("num_gpus", 8)),
             stages=self._stage_times(result),
         )
         return frames_list, samples

--- a/models/fasth3/fasth3_clip_plan.py
+++ b/models/fasth3/fasth3_clip_plan.py
@@ -136,29 +136,6 @@ def canvas_for_choice(aspect: str) -> tuple[int, int]:
     return canvas_for_aspect(*ratio)
 
 
-def clip_frames(index: int, steady_frames: int, ramp_frames: tuple[int, ...]) -> int:
-    """Frame count for clip ``index`` of a channel run.
-
-    The ramp exists purely for time-to-first-frame: the channel opens with one or
-    more short clips (which generate proportionally faster) and then settles on
-    ``steady_frames``. An empty ramp means a uniform cadence from clip zero.
-    """
-    if index < 0:
-        raise ValueError(f"clip index must be non-negative, got {index}")
-    if index < len(ramp_frames):
-        return ramp_frames[index]
-    return steady_frames
-
-
-def parse_ramp(seconds: object) -> tuple[int, ...]:
-    """Turn a config list of clip lengths in seconds into snapped frame counts."""
-    if seconds is None:
-        return ()
-    if not isinstance(seconds, list | tuple):
-        raise TypeError(f"ramp must be a list of seconds, got {type(seconds).__name__}")
-    return tuple(frames_for_seconds(float(value)) for value in seconds)
-
-
 __all__ = [
     "ASPECT_CHOICES",
     "FPS",
@@ -171,8 +148,6 @@ __all__ = [
     "align_frames",
     "canvas_for_aspect",
     "canvas_for_choice",
-    "clip_frames",
     "frames_for_seconds",
-    "parse_ramp",
     "seconds_for_frames",
 ]

--- a/models/fasth3/fasth3_queue.py
+++ b/models/fasth3/fasth3_queue.py
@@ -1,0 +1,159 @@
+"""The clip queue: every generation a client has asked for, in order.
+
+Pure bookkeeping — no torch, no fastvideo, no runtime imports — so the queue's
+behaviour is testable on any machine. ``fasth3.py`` owns when entries move
+(builds are submitted and applied on the model's event loop); this module owns
+what an entry is and what the queue guarantees: bounded capacity, stable order,
+and one wire form (`ClipInfo` in ``fasth3_types.py``) reported everywhere a
+clip is mentioned.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+
+import fasth3_clip_plan as clip_plan
+
+
+@dataclass
+class ClipEntry:
+    """One enqueued generation, from request to built payload.
+
+    The client-facing fields are frozen at enqueue time: the prompt and
+    metadata as the client sent them, and the frame count and seed as the
+    session's conditions stood. ``video`` and ``audio`` are filled in when the
+    build completes; ``ready`` is derived from their presence.
+    """
+
+    clip_id: str
+    prompt: str
+    metadata: str
+    frames: int
+    seed: int
+    # Set while a build for this entry is in flight, so the scheduler never
+    # submits the same entry twice.
+    building: bool = False
+    # The built payload: decoded RGB frames and the wire-ready waveform.
+    video: list[Any] | None = None
+    audio: Any = None
+
+    @property
+    def ready(self) -> bool:
+        """Whether the clip is built and can be played."""
+        return self.video is not None
+
+    @property
+    def seconds(self) -> float:
+        """Exact playout length, derived from the frame count."""
+        return clip_plan.seconds_for_frames(self.frames)
+
+    def snapshot(self) -> dict[str, Any]:
+        """The clip's wire form — the `ClipInfo` structure, as a plain mapping.
+
+        Every message that references a clip carries this whole structure, so a
+        client never has to join an id against an earlier message. A mapping
+        rather than a dataclass instance, because the wire encoder accepts only
+        JSON-representable values; ``ClipInfo`` in ``fasth3_types.py`` is the
+        schema-side declaration of this exact shape.
+        """
+        return {
+            "clip_id": self.clip_id,
+            "prompt": self.prompt,
+            "metadata": self.metadata,
+            "frames": self.frames,
+            "seconds": round(self.seconds, 3),
+            "seed": self.seed,
+            "ready": self.ready,
+        }
+
+
+@dataclass
+class ClipQueue:
+    """A bounded, ordered queue of :class:`ClipEntry`.
+
+    Order is enqueue order and never changes; builds run through it front to
+    back, so ready entries always form a prefix of the pending ones. Capacity
+    comes from the deployment config (``inference.queue_size``) — every entry
+    can hold a fully built clip in host memory, so the bound is also the memory
+    budget.
+    """
+
+    capacity: int
+    _entries: list[ClipEntry] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.capacity < 1:
+            raise ValueError(f"queue capacity must be positive, got {self.capacity}")
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __contains__(self, entry: ClipEntry) -> bool:
+        return any(existing is entry for existing in self._entries)
+
+    @property
+    def full(self) -> bool:
+        """Whether another enqueue would exceed the capacity."""
+        return len(self._entries) >= self.capacity
+
+    def enqueue(self, *, prompt: str, metadata: str, frames: int, seed: int) -> ClipEntry:
+        """Append one generation request and return its entry.
+
+        Raises:
+            ValueError: If the queue is already at capacity.
+        """
+        if self.full:
+            raise ValueError(f"the queue is full ({self.capacity} clips)")
+        entry = ClipEntry(
+            clip_id=str(uuid.uuid4()),
+            prompt=prompt,
+            metadata=metadata,
+            frames=frames,
+            seed=seed,
+        )
+        self._entries.append(entry)
+        return entry
+
+    def get(self, clip_id: str) -> ClipEntry | None:
+        """The entry with *clip_id*, or ``None`` when no queued clip has it."""
+        for entry in self._entries:
+            if entry.clip_id == clip_id:
+                return entry
+        return None
+
+    def next_to_build(self) -> ClipEntry | None:
+        """The oldest entry that is neither built nor being built."""
+        for entry in self._entries:
+            if not entry.ready and not entry.building:
+                return entry
+        return None
+
+    def next_ready(self) -> ClipEntry | None:
+        """The oldest entry that is built and playable."""
+        for entry in self._entries:
+            if entry.ready:
+                return entry
+        return None
+
+    def ready_count(self) -> int:
+        """How many queued clips are built and playable right now."""
+        return sum(1 for entry in self._entries if entry.ready)
+
+    def remove(self, entry: ClipEntry) -> None:
+        """Take *entry* out of the queue; playing a clip consumes its entry."""
+        self._entries = [existing for existing in self._entries if existing is not entry]
+
+    def clear(self) -> int:
+        """Drop every entry, built payloads included, and return how many."""
+        cleared = len(self._entries)
+        self._entries = []
+        return cleared
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        """Every entry's wire form, oldest first — the `queue_update` payload."""
+        return [entry.snapshot() for entry in self._entries]
+
+
+__all__ = ["ClipEntry", "ClipQueue"]

--- a/models/fasth3/fasth3_session_rules.py
+++ b/models/fasth3/fasth3_session_rules.py
@@ -9,27 +9,30 @@ of re-deriving these rules.
 from __future__ import annotations
 
 # Always available: they only ever record a value or report one.
-_ALWAYS = ("set_prompt", "set_clip_seconds", "set_seed", "reset", "get_state")
+_ALWAYS = ("set_clip_seconds", "set_seed", "get_queue", "get_state", "reset")
 
 
-def valid_commands(*, running: bool, paused: bool, ready: bool) -> list[str]:
+def valid_commands(*, playing: bool, queued: int, ready: int, capacity: int) -> list[str]:
     """Name every command the session would accept in this state.
 
     Args:
-        running: A channel is live and streaming clips.
-        paused: The output stream is held; only meaningful while ``running``.
-        ready: A prompt is set, so ``start`` has everything it needs.
+        playing: A clip is streaming on the output tracks.
+        queued: Clips in the queue, built and still generating alike.
+        ready: Clips in the queue that are built and playable.
+        capacity: Most clips the queue holds.
     """
     commands = list(_ALWAYS)
-    if running:
-        commands.append("resume" if paused else "pause")
+    if queued < capacity:
+        commands.append("enqueue")
+    if playing:
         commands.append("stop")
     else:
-        # The canvas fixes the video track's geometry, so it can only change
-        # while nothing is streaming.
-        commands.append("set_canvas")
-        if ready:
-            commands.append("start")
+        if ready > 0:
+            commands.append("play")
+        # The canvas fixes the video track's geometry and the shape queued
+        # clips were built at, so it can only change while both are empty.
+        if queued == 0:
+            commands.append("set_canvas")
     return sorted(commands)
 
 

--- a/models/fasth3/fasth3_session_rules.py
+++ b/models/fasth3/fasth3_session_rules.py
@@ -24,6 +24,8 @@ def valid_commands(*, playing: bool, queued: int, ready: int, capacity: int) -> 
     commands = list(_ALWAYS)
     if queued < capacity:
         commands.append("enqueue")
+    if queued > 0:
+        commands.append("pop")
     if playing:
         commands.append("stop")
     else:

--- a/models/fasth3/fasth3_session_rules.py
+++ b/models/fasth3/fasth3_session_rules.py
@@ -9,7 +9,7 @@ of re-deriving these rules.
 from __future__ import annotations
 
 # Always available: they only ever record a value or report one.
-_ALWAYS = ("set_clip_seconds", "set_seed", "get_queue", "get_state", "reset")
+_ALWAYS = ("set_clip_seconds", "set_seed", "set_autoplay", "get_queue", "get_state", "reset")
 
 
 def valid_commands(*, playing: bool, queued: int, ready: int, capacity: int) -> list[str]:

--- a/models/fasth3/fasth3_types.py
+++ b/models/fasth3/fasth3_types.py
@@ -70,7 +70,10 @@ class StateUpdate(ModelMessage):
     """
 
     clip_seconds: float = MessageField(
-        description="Length every newly enqueued clip will have, in seconds."
+        description=(
+            "Length a newly enqueued clip gets when `enqueue` carries no "
+            "`seconds` of its own."
+        )
     )
     clip_seconds_min: float = MessageField(
         description="Shortest clip length `set_clip_seconds` accepts."

--- a/models/fasth3/fasth3_types.py
+++ b/models/fasth3/fasth3_types.py
@@ -79,7 +79,16 @@ class StateUpdate(ModelMessage):
         description="Longest clip length `set_clip_seconds` accepts."
     )
     seed: int = MessageField(
-        description="Seed the next enqueued clip will use; each `enqueue` advances it by one."
+        description=(
+            "Seed the next enqueued clip will use when `enqueue` carries none; "
+            "each such enqueue advances it by one."
+        )
+    )
+    autoplay: bool = MessageField(
+        description=(
+            "Ready clips start on their own whenever nothing is playing. Off "
+            "by default: playback waits for an explicit `play`."
+        )
     )
     aspect: str = MessageField(description="Aspect ratio in effect, e.g. `16:9`.")
     width: int = MessageField(description="Width of every frame on `main_video`.")
@@ -195,7 +204,17 @@ class ClipLengthAccepted(ModelMessage):
 class SeedAccepted(ModelMessage):
     """Emitted when `set_seed` is accepted."""
 
-    seed: int = MessageField(description="Seed the next enqueued clip will use.")
+    seed: int = MessageField(
+        description="Seed the next enqueued clip will use when `enqueue` carries none."
+    )
+
+
+class AutoplayAccepted(ModelMessage):
+    """Emitted when `set_autoplay` is accepted."""
+
+    enabled: bool = MessageField(
+        description="Whether ready clips now start on their own when nothing is playing."
+    )
 
 
 class CanvasAccepted(ModelMessage):

--- a/models/fasth3/fasth3_types.py
+++ b/models/fasth3/fasth3_types.py
@@ -182,6 +182,16 @@ class ClipStopped(ModelMessage):
     )
 
 
+class ClipPopped(ModelMessage):
+    """Emitted when `pop` removes a clip from the queue.
+
+    The clip's slot is free again immediately. A build already running for it
+    is discarded when it completes; the GPUs cannot abandon it mid-build.
+    """
+
+    clip: ClipInfo = MessageField(description="The clip that left the queue.")
+
+
 class ClipFailed(ModelMessage):
     """Emitted when a clip's generation fails.
 

--- a/models/fasth3/fasth3_types.py
+++ b/models/fasth3/fasth3_types.py
@@ -1,17 +1,19 @@
 """Client-facing types for the FastH3 Reactor model.
 
-Everything a client can see lives here: the outbound video and audio tracks and
-the typed messages the model sends. ``fasth3.py`` imports these; a frontend
-developer reads this file to learn the whole API without opening the inference
-code.
+Everything a client can see lives here: the outbound video and audio tracks,
+the `ClipInfo` structure every clip-referencing message embeds, and the typed
+messages the model sends. ``fasth3.py`` imports these; a frontend developer
+reads this file to learn the whole API without opening the inference code.
 
-The conditions behind the `set_*` commands are not here. A ``ReactorModel`` owns
-its session state itself, so they are plain attributes on ``FastH3`` reset in
-``_reset_session_state``; their client-facing text lives on each handler's own
-``InputField`` declaration.
+The conditions behind the `set_*` commands are not here. A ``ReactorModel``
+owns its session state itself, so they are plain attributes on ``FastH3`` reset
+in ``_reset_session_state``; their client-facing text lives on each handler's
+own ``InputField`` declaration.
 """
 
 from __future__ import annotations
+
+from dataclasses import dataclass
 
 from reactor_runtime import (
     Audio,
@@ -22,30 +24,53 @@ from reactor_runtime import (
 )
 
 MAX_PROMPT_CHARS = 800
+MAX_METADATA_CHARS = 2000
 
 
 class FastH3Output(Output):
-    """The generated video and its synchronized audio, streamed continuously."""
+    """The generated video and its synchronized audio, streamed per clip."""
 
     main_video: Video
     main_audio: Audio
 
 
+@dataclass(frozen=True)
+class ClipInfo:
+    """One queued generation, as every clip-referencing message reports it.
+
+    Whole and self-contained on purpose: `clip_queued`, `queue_update`,
+    `clip_started`, `clip_finished`, `clip_stopped` and `clip_failed` all carry
+    this same structure, so a client never has to join a clip id against an
+    earlier message to know what a clip is.
+
+    ``clip_id`` is the UUID the session assigned at `enqueue`; every later
+    reference to the clip uses it. ``prompt`` and ``metadata`` are exactly what
+    the client enqueued — the metadata is an opaque string the model never
+    reads, for frontends to carry their own tracking data. ``frames`` and
+    ``seconds`` are the clip's length in both units, fixed when it was
+    enqueued. ``seed`` is the value this clip generates from. ``ready`` is
+    whether the clip is built and can be played.
+    """
+
+    clip_id: str
+    prompt: str
+    metadata: str
+    frames: int
+    seconds: float
+    seed: int
+    ready: bool
+
+
 class StateUpdate(ModelMessage):
     """Emitted on connect and after every change to the session's state.
 
-    One snapshot of everything observable, so a client can render its whole UI
-    from this alone instead of accumulating the individual messages below.
+    One snapshot of everything observable except the queue's contents (those
+    travel as `queue_update`), so a client can render its whole UI from this
+    alone instead of accumulating the individual messages below.
     """
 
-    prompt: str | None = MessageField(
-        description=(
-            "Prompt in effect for the next clip the model starts, or null when "
-            "none is set."
-        )
-    )
     clip_seconds: float = MessageField(
-        description="Length of each clip the channel produces, in seconds."
+        description="Length every newly enqueued clip will have, in seconds."
     )
     clip_seconds_min: float = MessageField(
         description="Shortest clip length `set_clip_seconds` accepts."
@@ -53,34 +78,27 @@ class StateUpdate(ModelMessage):
     clip_seconds_max: float = MessageField(
         description="Longest clip length `set_clip_seconds` accepts."
     )
-    seed: int = MessageField(description="Seed the channel started from; each clip advances it by one.")
+    seed: int = MessageField(
+        description="Seed the next enqueued clip will use; each `enqueue` advances it by one."
+    )
     aspect: str = MessageField(description="Aspect ratio in effect, e.g. `16:9`.")
     width: int = MessageField(description="Width of every frame on `main_video`.")
     height: int = MessageField(description="Height of every frame on `main_video`.")
-    ready: bool = MessageField(description="A prompt is set, so `start` is valid.")
-    running: bool = MessageField(description="The channel is live and streaming clips.")
-    paused: bool = MessageField(
-        description="The output stream is held; `resume` continues it instantly."
+    playing: bool = MessageField(description="A clip is streaming on the output tracks.")
+    playing_clip_id: str | None = MessageField(
+        description="UUID of the clip now playing, or null when the stream is idle."
     )
-    clip_index: int = MessageField(
-        description="Zero-based index of the clip currently streaming, or -1 before the first."
+    queued: int = MessageField(
+        description="Clips in the queue right now, built and still generating alike."
     )
-    clips_sent: int = MessageField(description="Clips fully streamed since `start`.")
+    queue_capacity: int = MessageField(
+        description="Most clips the queue holds; `enqueue` is refused beyond it."
+    )
+    clips_played: int = MessageField(
+        description="Clips that finished playing or were stopped since the session began."
+    )
     seconds_sent: float = MessageField(
-        description="Seconds of video and audio sent since `start`."
-    )
-    prompt_effective_clip_index: int = MessageField(
-        description=(
-            "Clip the prompt shown here will first appear on. The model always "
-            "builds one clip ahead, so a prompt changed mid-channel lands two "
-            "clips out, not on the next one."
-        )
-    )
-    prompt_effective_in_seconds: float = MessageField(
-        description=(
-            "Seconds of already-built video still to play before the prompt "
-            "shown here starts. Zero while the channel is idle."
-        )
+        description="Seconds of video and audio sent since the session began."
     )
     valid_commands: list[str] = MessageField(
         description=(
@@ -91,22 +109,76 @@ class StateUpdate(ModelMessage):
     )
 
 
-class PromptAccepted(ModelMessage):
-    """Emitted when `set_prompt` is accepted."""
+class QueueUpdate(ModelMessage):
+    """Emitted on connect and whenever the queue changes, and answers `get_queue`.
 
-    prompt: str | None = MessageField(
-        description="Prompt now in effect, or null when it was cleared."
-    )
-    effective_clip_index: int = MessageField(
-        description="Clip this prompt will first appear on."
-    )
-    effective_in_seconds: float = MessageField(
+    The whole queue, oldest first, each entry a complete `ClipInfo`. A change
+    is any of: a clip enqueued, a clip becoming ready, a clip leaving the queue
+    to play, or the queue being cleared by `reset`.
+    """
+
+    clips: list[ClipInfo] = MessageField(
         description=(
-            "Seconds of already-built video still to play before this prompt "
-            "starts. Zero while the channel is idle, so the next `start` uses it "
-            "immediately."
+            "Every clip in the queue, oldest first. Builds run through the "
+            "queue in this order, so entries with `ready: true` always sit at "
+            "the front."
         )
     )
+
+
+class ClipQueued(ModelMessage):
+    """Emitted when `enqueue` accepts a generation request."""
+
+    clip: ClipInfo = MessageField(
+        description=(
+            "The queued clip, UUID included. `ready` is false here; watch "
+            "`queue_update` for it turning true."
+        )
+    )
+
+
+class ClipStarted(ModelMessage):
+    """Emitted as a clip begins streaming on the output tracks."""
+
+    clip: ClipInfo = MessageField(description="The clip now playing.")
+
+
+class ClipFinished(ModelMessage):
+    """Emitted when a clip has been fully sent on the output tracks.
+
+    The stream then holds on black until the next `play`; nothing plays on its
+    own.
+    """
+
+    clip: ClipInfo = MessageField(description="The clip that just finished.")
+    seconds_sent: float = MessageField(
+        description="Seconds of video and audio sent since the session began, this clip included."
+    )
+
+
+class ClipStopped(ModelMessage):
+    """Emitted when `stop` cuts a playing clip.
+
+    The rest of the clip is discarded — a stopped clip cannot be resumed — and
+    the stream holds on black until the next `play`, exactly as after
+    `clip_finished`.
+    """
+
+    clip: ClipInfo = MessageField(description="The clip that was cut.")
+    seconds_sent: float = MessageField(
+        description="Seconds of video and audio sent since the session began."
+    )
+
+
+class ClipFailed(ModelMessage):
+    """Emitted when a clip's generation fails.
+
+    The clip leaves the queue and the queue moves on; nothing else is
+    affected.
+    """
+
+    clip: ClipInfo = MessageField(description="The clip whose build failed.")
+    reason: str = MessageField(description="What went wrong.")
 
 
 class ClipLengthAccepted(ModelMessage):
@@ -117,13 +189,13 @@ class ClipLengthAccepted(ModelMessage):
     """
 
     clip_seconds: float = MessageField(description="Clip length now in effect, in seconds.")
-    frames: int = MessageField(description="Frames each clip will carry on `main_video`.")
+    frames: int = MessageField(description="Frames each newly enqueued clip will carry.")
 
 
 class SeedAccepted(ModelMessage):
     """Emitted when `set_seed` is accepted."""
 
-    seed: int = MessageField(description="Seed the next channel run starts from.")
+    seed: int = MessageField(description="Seed the next enqueued clip will use.")
 
 
 class CanvasAccepted(ModelMessage):
@@ -134,93 +206,18 @@ class CanvasAccepted(ModelMessage):
     height: int = MessageField(description="Height of every frame on `main_video`.")
 
 
-class ChannelStarted(ModelMessage):
-    """Emitted once when `start` is accepted, before any frame is sent.
-
-    The first clip must be built before anything can stream, so expect several
-    seconds of no video. Treat this as the cue to show progress, not to expect
-    frames immediately.
-    """
-
-    width: int = MessageField(description="Width of every frame on `main_video`.")
-    height: int = MessageField(description="Height of every frame on `main_video`.")
-    clip_seconds: float = MessageField(description="Length of each steady-state clip, in seconds.")
-    first_clip_seconds: float = MessageField(
-        description=(
-            "Length of the opening clip. The channel can open with a shorter "
-            "clip so video starts sooner; it equals `clip_seconds` when it does not."
-        )
-    )
-
-
-class ClipStarted(ModelMessage):
-    """Emitted as each clip begins streaming on the output tracks.
-
-    Every clip is an independent piece of video and audio, so the picture and
-    the sound cut at this boundary rather than continuing from the last frame.
-    """
-
-    clip_index: int = MessageField(description="Zero-based index of the clip now streaming.")
-    clip_seconds: float = MessageField(description="Length of this clip, in seconds.")
-    prompt: str = MessageField(description="Prompt this clip was built from.")
-
-
-class ClipComplete(ModelMessage):
-    """Emitted when a clip has been fully sent on the output tracks."""
-
-    clip_index: int = MessageField(description="Zero-based index of the clip just finished.")
-    seconds_sent: float = MessageField(
-        description="Seconds of video and audio sent since `start`, this clip included."
-    )
-
-
-class ChannelPaused(ModelMessage):
-    """Emitted when `pause` is accepted.
-
-    The stream freezes on its current frame while the model keeps building
-    ahead, so `resume` continues without any warm-up.
-    """
-
-    seconds_sent: float = MessageField(description="Seconds streamed before the pause.")
-
-
-class ChannelResumed(ModelMessage):
-    """Emitted when `resume` is accepted. The stream continues where it froze."""
-
-    seconds_sent: float = MessageField(description="Seconds streamed so far.")
-
-
-class ChannelStopped(ModelMessage):
-    """Emitted when `stop` is accepted and the channel ends.
-
-    Every condition is kept, so `start` immediately begins a fresh channel with
-    the same setup. The clip already being built is discarded, so the model can
-    take a few seconds to go idle.
-    """
-
-    seconds_sent: float = MessageField(description="Seconds streamed before the stop.")
-    clips_sent: int = MessageField(description="Clips fully streamed before the stop.")
-
-
-class ChannelFailed(ModelMessage):
-    """Emitted when the channel ends early because something went wrong.
-
-    The model then idles; adjust the conditions and `start` again.
-    """
-
-    reason: str = MessageField(description="What went wrong.")
-    seconds_sent: float = MessageField(description="Seconds streamed before it stopped.")
-
-
-class ChannelReset(ModelMessage):
+class SessionReset(ModelMessage):
     """Emitted when `reset` is accepted.
 
-    Every condition is back to its default, the output stream is cleared, and
-    the model is waiting for new conditions.
+    Every condition is back to its default, the queue is empty, and the output
+    stream is cleared.
     """
 
-    was_running: bool = MessageField(
-        description="A channel was live and has been stopped, so no `channel_stopped` will follow it."
+    cleared_clips: int = MessageField(
+        description="Clips that were dropped from the queue, built and pending alike."
+    )
+    was_playing: bool = MessageField(
+        description="A clip was playing and has been cut; a `clip_stopped` accompanies it."
     )
 
 

--- a/models/fasth3/reactor.yaml
+++ b/models/fasth3/reactor.yaml
@@ -3,7 +3,7 @@ $schema: reactor/v1
 
 model:
   name: fasth3
-  version: v0.2.0
+  version: v0.3.0
   description: |
     Generate 768p video clips with synchronized audio from a queue of prompts.
     MiniMax-H3 (35B), distilled by FastVideo to four transformer forwards with
@@ -78,6 +78,11 @@ build:
   build_env:
     UV_INDEX_STRATEGY: unsafe-best-match
     UV_OVERRIDE: /app/requirements.txt
+    # fastvideo-kernel compiles from source during the build (see
+    # requirements.txt); target only the deployment's arch and parallelize.
+    TORCH_CUDA_ARCH_LIST: "10.0a"
+    CMAKE_BUILD_PARALLEL_LEVEL: "32"
+    MAX_JOBS: "32"
   # Long-lived server allocating a clip's worth of pixels over and over, in two
   # different shapes: the expandable-segments allocator is what stops
   # fragmentation creeping across a multi-hour channel.

--- a/models/fasth3/reactor.yaml
+++ b/models/fasth3/reactor.yaml
@@ -3,22 +3,24 @@ $schema: reactor/v1
 
 model:
   name: fasth3
-  version: v0.1.0
+  version: v0.2.0
   description: |
-    Stream an endless, prompt-driven channel of 768p video with synchronized
-    audio. MiniMax-H3 (35B), distilled by FastVideo to four transformer
-    forwards with 90% sparse video attention, builds the next clip while the
-    current one plays, so the channel never runs dry.
+    Generate 768p video clips with synchronized audio from a queue of prompts.
+    MiniMax-H3 (35B), distilled by FastVideo to four transformer forwards with
+    90% sparse video attention, builds queued clips in order while playback
+    stays a separate, explicit step: enqueue prompts, play any built clip on
+    demand, and the stream holds on black in between.
   # Eight GPUs is load-bearing rather than a performance preference: sequence
   # parallelism spans all eight, and a 15 s clip builds in 12.88 s on eight
-  # B200s against 15.5 s on four. Only the former is faster than the video
-  # plays, which is what makes the channel continuous.
+  # B200s against 15.5 s on four. Only the former keeps a queued prompt
+  # playable in under its own duration.
   #
   # cpu and memory are an opening estimate. With nothing CPU-offloaded the host
-  # holds only the load-time transient of eight ranks streaming a 148 GB bundle
-  # plus one clip's pixel buffers; re-measure on real hardware and tighten. If
-  # the offload flags in fasth3.yaml are turned back on, memory must rise to
-  # several hundred Gi — see the note there.
+  # holds the load-time transient of eight ranks streaming a 148 GB bundle plus
+  # the built-clip buffer — about 1 GB of uint8 pixels per queued clip, bounded
+  # by inference.queue_size in fasth3.yaml — so re-measure on real hardware and
+  # tighten. If the offload flags in fasth3.yaml are turned back on, memory
+  # must rise to several hundred Gi — see the note there.
   resources:
     gpu:
       type: NVIDIA_B200
@@ -35,9 +37,9 @@ runtime:
   config: fasth3.yaml
   # The weights bundle lives here; nothing is downloaded at load.
   weights_path: ~/.cache/reactor_registry/fasth3
-  # Left off deliberately. Every clip is generated independently, so a recording
-  # carries a hard cut in picture and sound at each clip boundary; enable it once
-  # that seam has been looked at.
+  # Left off deliberately. Every clip is generated independently and the stream
+  # holds on black between plays, so a recording carries hard cuts in picture
+  # and sound at each boundary; enable it once that seam has been looked at.
   recording:
     enabled: false
 

--- a/models/fasth3/reactor.yaml
+++ b/models/fasth3/reactor.yaml
@@ -10,13 +10,16 @@ model:
     90% sparse video attention, builds queued clips in order while playback
     stays a separate, explicit step: enqueue prompts, play any built clip on
     demand, and the stream holds on black in between.
-  # Eight GPUs is load-bearing rather than a performance preference: sequence
-  # parallelism spans all eight, and a 15 s clip builds in 12.88 s on eight
-  # B200s against 15.5 s on four. Only the former keeps a queued prompt
-  # playable in under its own duration.
+  # Four B200s is FastVideo's tested default for this checkpoint. Builds run
+  # slightly slower than the clip plays (a 15 s clip in ~15.5 s against
+  # ~12.9 s on eight), which the queue absorbs: playback is explicit and clips
+  # are pre-built, so GPU count only moves the enqueue-to-ready wait. The count
+  # must divide H3's 56 attention heads (1, 2, 4, 7, 8 …), and each rank holds
+  # its own ~63 GB text encoder plus a 66/N GB transformer shard, so fewer
+  # than four wants offloading or very large GPUs.
   #
   # cpu and memory are an opening estimate. With nothing CPU-offloaded the host
-  # holds the load-time transient of eight ranks streaming a 148 GB bundle plus
+  # holds the load-time transient of four ranks streaming a 148 GB bundle plus
   # the built-clip buffer — about 1 GB of uint8 pixels per queued clip, bounded
   # by inference.queue_size in fasth3.yaml — so re-measure on real hardware and
   # tighten. If the offload flags in fasth3.yaml are turned back on, memory
@@ -24,13 +27,16 @@ model:
   resources:
     gpu:
       type: NVIDIA_B200
-      count: 8
+      count: 4
     cpu:
       request: "8"
       limit: "32"
+    # Sized for the offloaded text encoder (fasth3.yaml): four ranks hold
+    # ~63 GB each on the host, plus the built-clip buffer and the load
+    # transient. With the offload turned off, 64Gi/256Gi suffices.
     memory:
-      request: 32Gi
-      limit: 256Gi
+      request: 280Gi
+      limit: 384Gi
 
 runtime:
   import: fasth3:FastH3
@@ -44,7 +50,7 @@ runtime:
     enabled: false
 
 build:
-  runtime_version: "3.2.5"
+  runtime_version: "3.2.6"
   python_requirements: requirements.txt
   # CUDA 13 is the model's requirement, not a preference: the VSA-H3 sparse
   # kernel and the FA4 CuTe kernels are both cu130 builds. Every other model in
@@ -66,8 +72,12 @@ build:
     - ninja-build
   # torch comes from the cu130 index in requirements.txt; let the resolver
   # compare that index with PyPI for everything the index also mirrors.
+  # UV_OVERRIDE feeds the requirements back in as resolver overrides, which is
+  # what lets the runtime's protobuf>=7.35.1 defeat cutlass-dsl's stale <7 cap
+  # — see the protobuf note in requirements.txt.
   build_env:
     UV_INDEX_STRATEGY: unsafe-best-match
+    UV_OVERRIDE: /app/requirements.txt
   # Long-lived server allocating a clip's worth of pixels over and over, in two
   # different shapes: the expandable-segments allocator is what stops
   # fragmentation creeping across a multi-hour channel.

--- a/models/fasth3/requirements.txt
+++ b/models/fasth3/requirements.txt
@@ -17,11 +17,13 @@ torchvision==0.27.1
 # attention backend, and the VideoGenerator engine.
 fastvideo==0.2.1
 
-# The Blackwell sparse-attention kernel. fastvideo pins this exact version
-# transitively; naming it here makes the sm100a dependency explicit, because
-# without a wheel carrying the sm_100a build the model refuses to start rather
-# than silently running the slow route.
-fastvideo-kernel==0.3.5
+# The Blackwell sparse-attention kernel, built from source at the 0.3.5
+# release commit rather than installed as the published wheel: the wheel's
+# sm_100a binary fails every launch on driver 595 with "invalid argument",
+# while the same source compiled by the image's CUDA 13.1 nvcc runs correctly
+# (build_env pins TORCH_CUDA_ARCH_LIST=10.0a for it). The PyPI sdist cannot
+# stand in either — it ships without the CUTLASS/ThunderKittens submodules.
+fastvideo-kernel @ git+https://github.com/hao-ai-lab/FastVideo.git@1aed66737739e1fd6ea7271d3306a615a2a6bd55#subdirectory=fastvideo-kernel
 
 # FA4 CuTe kernels for the dense (text and audio) attention paths. Pinned to
 # the revision FastVideo's own `fasth3` extra selects: it fixes

--- a/models/fasth3/requirements.txt
+++ b/models/fasth3/requirements.txt
@@ -3,11 +3,15 @@
 --extra-index-url https://download.pytorch.org/whl/cu130
 
 # The cu130 builds the sparse-attention and FA4 kernels are compiled against.
-# 2.12.0 is what fastvideo 0.2.1 pins; torchvision and torchaudio are left to
-# the index so it picks the matching build.
+# 2.12.0 is what fastvideo 0.2.1 pins. torchvision and torchaudio are pinned
+# exactly, because UV_OVERRIDE (see below) strips their own torch coupling
+# from resolution: 0.27.x is the torchvision built against torch 2.12, and
+# 2.11.0 is the newest torchaudio the cu130 index carries — fine here, since
+# the only torchaudio surface this model touches (`functional.resample`) is
+# pure torch ops, not its compiled extension.
 torch==2.12.0
-torchaudio
-torchvision
+torchaudio==2.11.0
+torchvision==0.27.1
 
 # The inference stack: pipelines, the MiniMax-H3 model code, the VSA-H3
 # attention backend, and the VideoGenerator engine.
@@ -24,6 +28,13 @@ fastvideo-kernel==0.3.5
 # nvidia-cutlass-dsl at 4.6.0.dev0, and an older cutlass-dsl breaks these
 # kernels at JIT time rather than at import.
 flash-attn-4 @ git+https://github.com/Dao-AILab/flash-attention.git@14c377950125c70b7a9dabf9c561fca53715ac7d#subdirectory=flash_attn/cute
+
+# Pinned because cutlass-dsl caps protobuf at <7 while the Reactor Runtime
+# needs >=7.35.1. The cap is over-conservative: protobuf's cross-version
+# guarantee accepts older gencode on a newer runtime, so cutlass-dsl's 6.x
+# gencode runs fine on 7.35. build_env sets UV_OVERRIDE to this file, which
+# turns this line into the resolver-level override that defeats the cap.
+protobuf>=7.35.1
 
 # fasth3.py parses fasth3.yaml itself: the runtime hands over the path to the
 # file `runtime.config` names and does not read it.

--- a/models/fasth3/tests/test_fasth3.py
+++ b/models/fasth3/tests/test_fasth3.py
@@ -1054,9 +1054,8 @@ def test_the_config_the_runtime_hands_to_load_exists(manifest):
     assert (MODEL_DIR / config).is_file(), f"runtime.config points at a missing {config}"
 
 
-def test_the_runtime_pin_matches_the_rest_of_the_repo(manifest):
-    """Every model here pins the same Reactor Runtime release."""
-    assert manifest["build"]["runtime_version"] == "3.2.5"
+def test_the_runtime_pin_is_current(manifest):
+    assert manifest["build"]["runtime_version"] == "3.2.6"
 
 
 def test_the_runtime_release_is_pinned_once(manifest):

--- a/models/fasth3/tests/test_fasth3.py
+++ b/models/fasth3/tests/test_fasth3.py
@@ -220,7 +220,9 @@ def test_conditions_and_reads_are_always_available():
         commands = session_rules.valid_commands(
             playing=playing, queued=queued, ready=ready, capacity=10
         )
-        assert {"set_clip_seconds", "set_seed", "get_queue", "get_state", "reset"} <= set(commands)
+        assert {
+            "set_clip_seconds", "set_seed", "set_autoplay", "get_queue", "get_state", "reset"
+        } <= set(commands)
 
 
 # --------------------------------------------------------------------- config
@@ -337,6 +339,26 @@ def test_each_enqueue_advances_the_seed(model):
     run(model.reset())
     run(model.set_seed(seed=7))
     assert run(model.enqueue(prompt="p", metadata="")).clip["seed"] == 7
+
+
+def test_an_explicit_seed_leaves_the_default_untouched(model):
+    """Explicit and automatic seeding must not interfere with each other."""
+    explicit = run(model.enqueue(prompt="p", metadata="", seed=42)).clip
+    assert explicit["seed"] == 42
+    assert model._seed == 1000  # the advancing default did not move
+    automatic = run(model.enqueue(prompt="p", metadata="")).clip
+    assert automatic["seed"] == 1000
+    assert model._seed == 1001
+
+
+def test_autoplay_is_a_session_condition(model):
+    assert run(model.get_state()).autoplay is False
+    reply = run(model.set_autoplay(enabled=True))
+    assert reply.enabled is True
+    assert run(model.get_state()).autoplay is True
+    # `reset` returns every condition to its default, autoplay included.
+    run(model.reset())
+    assert run(model.get_state()).autoplay is False
 
 
 def test_a_full_queue_refuses_the_next_enqueue(model):
@@ -761,6 +783,38 @@ def test_the_pacer_holds_24_fps(live):
     assert elapsed["playout"] < content + 0.3
 
 
+def test_autoplay_chains_ready_clips_without_play(live):
+    async def scenario():
+        await live.set_autoplay(enabled=True)
+        await live.enqueue(prompt="a", metadata="")
+        await live.enqueue(prompt="b", metadata="")
+        # No `play` anywhere in this scenario: both clips must stream on
+        # their own, oldest first, once their builds complete.
+        await eventually(
+            lambda: names(live.messages).count("ClipFinished") == 2, timeout=5.0
+        )
+        # The queue is drained and nothing else may start.
+        await asyncio.sleep(0.15)
+
+    drive(live, scenario)
+    started = [m.clip["prompt"] for m in live.messages if type(m).__name__ == "ClipStarted"]
+    assert started == ["a", "b"]
+    frames = sum(output.main_video.shape[0] for output in live.emitted)
+    assert frames == 2 * FRAMES_PER_CLIP
+    assert live.flushes, "the stream still flushes to black at each boundary"
+
+
+def test_without_autoplay_nothing_starts_on_its_own(live):
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 1)
+        await asyncio.sleep(0.2)
+
+    drive(live, scenario)
+    assert "ClipStarted" not in names(live.messages)
+    assert live.emitted == []
+
+
 def test_a_lost_audience_ends_the_playout_quietly(live):
     # A two-second clip, so the disconnect reliably lands mid-play.
     live._clip_frames = 48
@@ -806,6 +860,7 @@ EXPECTED_COMMANDS = {
     "get_state": "StateUpdate",
     "play": None,
     "reset": "SessionReset",
+    "set_autoplay": "AutoplayAccepted",
     "set_canvas": "CanvasAccepted",
     "set_clip_seconds": "ClipLengthAccepted",
     "set_seed": "SeedAccepted",
@@ -813,6 +868,7 @@ EXPECTED_COMMANDS = {
 }
 
 EXPECTED_MESSAGES = {
+    "autoplay_accepted",
     "canvas_accepted",
     "clip_failed",
     "clip_finished",
@@ -912,6 +968,15 @@ def test_free_text_fields_are_marked_for_moderation(schema):
     ]["schema"]["properties"]
     assert properties["prompt"]["x-reactor-moderate"] is True
     assert properties["metadata"]["x-reactor-moderate"] is True
+
+
+def test_the_enqueue_seed_is_optional_on_the_wire(schema):
+    """Omitted or null means the session's advancing default seed."""
+    seed = schema["paths"]["/events/enqueue"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]["seed"]
+    types = seed.get("anyOf") or [seed]
+    assert any(entry.get("type") == "null" for entry in types), seed
 
 
 def test_the_clip_length_bounds_a_client_reads_are_generatable(schema):

--- a/models/fasth3/tests/test_fasth3.py
+++ b/models/fasth3/tests/test_fasth3.py
@@ -199,8 +199,14 @@ def test_an_empty_idle_session_can_only_enqueue_and_configure():
 def test_a_ready_clip_makes_play_valid():
     commands = session_rules.valid_commands(playing=False, queued=1, ready=1, capacity=10)
     assert "play" in commands
+    assert "pop" in commands
     # Queued clips were built at the current canvas, so it is locked.
     assert "set_canvas" not in commands
+
+
+def test_pop_needs_a_queued_clip():
+    commands = session_rules.valid_commands(playing=False, queued=0, ready=0, capacity=10)
+    assert "pop" not in commands
 
 
 def test_playing_offers_stop_and_locks_the_canvas():
@@ -422,6 +428,33 @@ def test_only_one_clip_plays_at_a_time(model):
 
     assert run(model.play(clip_id="")) is None
     assert refusal(model).reason.startswith("A clip is already playing")
+
+
+def test_pop_frees_the_slot(model):
+    kept = run(model.enqueue(prompt="keep", metadata="")).clip
+    victim = run(model.enqueue(prompt="drop", metadata="")).clip
+    reply = run(model.pop(clip_id=victim["clip_id"]))
+    assert reply.clip["clip_id"] == victim["clip_id"]
+    assert [c["clip_id"] for c in model._queue.snapshot()] == [kept["clip_id"]]
+
+    assert run(model.pop(clip_id="nope")) is None
+    assert refusal(model).command == "pop"
+    assert run(model.pop(clip_id="")) is None  # the id is required
+    assert refusal(model).command == "pop"
+
+
+def test_pop_cancels_the_build_in_flight(model):
+    from fasth3_backend import ClipJob
+
+    clip = run(model.enqueue(prompt="building", metadata="")).clip
+    entry = model._queue.get(clip["clip_id"])
+    entry.building = True
+    job = ClipJob(None)
+    model._build = (entry, job, 0.0)
+
+    run(model.pop(clip_id=clip["clip_id"]))
+    assert job.cancelled is True
+    assert len(model._queue) == 0
 
 
 def test_stop_needs_a_playing_clip(model):
@@ -869,6 +902,7 @@ EXPECTED_COMMANDS = {
     "get_queue": "QueueUpdate",
     "get_state": "StateUpdate",
     "play": None,
+    "pop": "ClipPopped",
     "reset": "SessionReset",
     "set_autoplay": "AutoplayAccepted",
     "set_canvas": "CanvasAccepted",
@@ -883,6 +917,7 @@ EXPECTED_MESSAGES = {
     "clip_failed",
     "clip_finished",
     "clip_length_accepted",
+    "clip_popped",
     "clip_queued",
     "clip_started",
     "clip_stopped",
@@ -895,7 +930,7 @@ EXPECTED_MESSAGES = {
 
 # Commands that can be refused. Each one has to say so in its own summary, and
 # name the message a client will actually receive.
-EXPECTED_REJECTIONS = ("enqueue", "play", "stop", "set_canvas")
+EXPECTED_REJECTIONS = ("enqueue", "play", "pop", "stop", "set_canvas")
 
 # The struct every clip-referencing message embeds, and its JSON types.
 EXPECTED_CLIP_INFO = {
@@ -957,7 +992,9 @@ def test_every_message_is_published_once(schema):
 
 def test_every_clip_message_embeds_the_full_struct(schema):
     """`ClipInfo` rides whole on every message that references a clip."""
-    for message in ("ClipQueued", "ClipStarted", "ClipFinished", "ClipStopped", "ClipFailed"):
+    for message in (
+        "ClipQueued", "ClipStarted", "ClipFinished", "ClipStopped", "ClipFailed", "ClipPopped"
+    ):
         clip = schema["components"]["schemas"][message]["properties"]["clip"]
         rendered = {
             name: field["type"] for name, field in clip["properties"].items()

--- a/models/fasth3/tests/test_fasth3.py
+++ b/models/fasth3/tests/test_fasth3.py
@@ -1,8 +1,8 @@
-"""FastH3's clip geometry, command contract, channel loop, schema and manifest.
+"""FastH3's clip geometry, queue, command contract, playout loop, schema and manifest.
 
-Everything here runs on a laptop: the GPU work sits behind ``load()``, which
-these tests never call, and the clip builder is replaced where the channel loop
-itself is under test.
+Everything here runs on a laptop: the GPU work sits behind the backend, which
+these tests replace with a fake that builds instantly, so the real queueing,
+ordering, pacing, emission and teardown all run.
 
 Run from the model folder: ``PYTHONPATH=. python -m pytest tests/ -q``.
 """
@@ -10,9 +10,8 @@ Run from the model folder: ``PYTHONPATH=. python -m pytest tests/ -q``.
 from __future__ import annotations
 
 import asyncio
-import queue
+import dataclasses
 import re
-import threading
 import time
 from pathlib import Path
 
@@ -23,6 +22,10 @@ import yaml
 import fasth3_clip_plan as clip_plan
 import fasth3_session_rules as session_rules
 from fasth3 import EMIT_FRAMES, FastH3
+from fasth3_assets import FastH3Config, load_config
+from fasth3_backend import ClipJob
+from fasth3_queue import ClipQueue
+from fasth3_types import ClipInfo
 
 MODEL_DIR = Path(__file__).resolve().parents[1]
 
@@ -91,18 +94,6 @@ def test_unknown_aspect_is_rejected():
         clip_plan.canvas_for_choice("32:9")
 
 
-def test_ramp_opens_short_then_settles():
-    ramp = clip_plan.parse_ramp([5.167])
-    assert ramp == (124,)
-    assert clip_plan.clip_frames(0, 345, ramp) == 124
-    assert clip_plan.clip_frames(1, 345, ramp) == 345
-    assert clip_plan.clip_frames(9, 345, ramp) == 345
-
-
-def test_empty_ramp_is_a_uniform_cadence():
-    assert clip_plan.clip_frames(0, 345, ()) == 345
-
-
 def test_upstream_constants_have_not_drifted():
     """The duplicated constants must still match FastVideo's own.
 
@@ -130,41 +121,128 @@ def test_upstream_constants_have_not_drifted():
         assert clip_plan.canvas_for_choice(aspect) == packing.resolve_canvas_size(*ratio)
 
 
+# ------------------------------------------------------------------ the queue
+#
+# Pure bookkeeping: order, capacity, and one wire form for every mention.
+
+
+def make_queue(capacity=3) -> ClipQueue:
+    return ClipQueue(capacity)
+
+
+def test_the_queue_keeps_enqueue_order():
+    q = make_queue()
+    a = q.enqueue(prompt="a", metadata="", frames=124, seed=1)
+    b = q.enqueue(prompt="b", metadata="", frames=124, seed=2)
+    assert [entry.prompt for entry in map(q.get, [a.clip_id, b.clip_id])] == ["a", "b"]
+    assert q.snapshot()[0]["clip_id"] == a.clip_id
+    assert q.next_to_build() is a
+
+
+def test_every_clip_gets_a_distinct_uuid():
+    q = make_queue()
+    ids = {q.enqueue(prompt="p", metadata="", frames=124, seed=0).clip_id for _ in range(3)}
+    assert len(ids) == 3
+
+
+def test_the_queue_is_bounded():
+    q = make_queue(capacity=2)
+    q.enqueue(prompt="a", metadata="", frames=124, seed=1)
+    q.enqueue(prompt="b", metadata="", frames=124, seed=2)
+    assert q.full
+    with pytest.raises(ValueError):
+        q.enqueue(prompt="c", metadata="", frames=124, seed=3)
+
+
+def test_ready_is_derived_from_the_built_payload():
+    q = make_queue()
+    entry = q.enqueue(prompt="a", metadata="", frames=124, seed=1)
+    assert entry.ready is False
+    assert q.next_ready() is None
+    entry.video, entry.audio = [np.zeros((2, 2, 3), np.uint8)], np.zeros((1, 10), np.int16)
+    assert entry.ready is True
+    assert q.next_ready() is entry
+    assert q.ready_count() == 1
+
+
+def test_building_entries_are_not_resubmitted():
+    q = make_queue()
+    entry = q.enqueue(prompt="a", metadata="", frames=124, seed=1)
+    entry.building = True
+    assert q.next_to_build() is None
+
+
+def test_the_snapshot_is_exactly_the_published_struct():
+    """`ClipEntry.snapshot()` and the schema's `ClipInfo` must never drift."""
+    q = make_queue()
+    entry = q.enqueue(prompt="a", metadata="m", frames=124, seed=7)
+    snapshot = entry.snapshot()
+    assert list(snapshot) == [field.name for field in dataclasses.fields(ClipInfo)]
+    assert snapshot["seconds"] == pytest.approx(124 / 24, abs=1e-3)
+    assert snapshot["metadata"] == "m"
+    assert snapshot["ready"] is False
+
+
 # --------------------------------------------------------------- session rules
 #
 # The command state machine clients read out of `state_update`.
 
 
-def test_idle_without_a_prompt_cannot_start():
-    commands = session_rules.valid_commands(running=False, paused=False, ready=False)
-    assert "start" not in commands
-    assert "set_prompt" in commands
-
-
-def test_idle_with_a_prompt_can_start_and_set_the_canvas():
-    commands = session_rules.valid_commands(running=False, paused=False, ready=True)
-    assert "start" in commands
+def test_an_empty_idle_session_can_only_enqueue_and_configure():
+    commands = session_rules.valid_commands(playing=False, queued=0, ready=0, capacity=10)
+    assert "enqueue" in commands
     assert "set_canvas" in commands
+    assert "play" not in commands
+    assert "stop" not in commands
 
 
-def test_the_canvas_is_locked_while_streaming():
-    """The video track keeps one size for the life of a channel."""
-    commands = session_rules.valid_commands(running=True, paused=False, ready=True)
+def test_a_ready_clip_makes_play_valid():
+    commands = session_rules.valid_commands(playing=False, queued=1, ready=1, capacity=10)
+    assert "play" in commands
+    # Queued clips were built at the current canvas, so it is locked.
     assert "set_canvas" not in commands
-    assert "start" not in commands
-    assert {"pause", "stop"} <= set(commands)
 
 
-def test_a_paused_channel_offers_resume_not_pause():
-    commands = session_rules.valid_commands(running=True, paused=True, ready=True)
-    assert "resume" in commands
-    assert "pause" not in commands
+def test_playing_offers_stop_and_locks_the_canvas():
+    commands = session_rules.valid_commands(playing=True, queued=0, ready=0, capacity=10)
+    assert "stop" in commands
+    assert "play" not in commands
+    assert "set_canvas" not in commands
 
 
-def test_conditions_and_reset_are_always_available():
-    for running, paused in ((False, False), (True, False), (True, True)):
-        commands = session_rules.valid_commands(running=running, paused=paused, ready=True)
-        assert {"set_prompt", "set_clip_seconds", "set_seed", "reset", "get_state"} <= set(commands)
+def test_a_full_queue_refuses_enqueue():
+    commands = session_rules.valid_commands(playing=False, queued=10, ready=10, capacity=10)
+    assert "enqueue" not in commands
+
+
+def test_conditions_and_reads_are_always_available():
+    for playing, queued, ready in ((False, 0, 0), (True, 3, 1), (False, 10, 10)):
+        commands = session_rules.valid_commands(
+            playing=playing, queued=queued, ready=ready, capacity=10
+        )
+        assert {"set_clip_seconds", "set_seed", "get_queue", "get_state", "reset"} <= set(commands)
+
+
+# --------------------------------------------------------------------- config
+
+
+def test_the_shipped_config_parses(tmp_path):
+    config = load_config(MODEL_DIR / "fasth3.yaml")
+    assert config.queue_size == 10
+    assert config.aspect == "16:9"
+    assert config.clip_frames == clip_plan.MAX_FRAMES
+
+
+def test_a_bad_aspect_or_queue_size_fails_startup(tmp_path):
+    bad_aspect = tmp_path / "aspect.yaml"
+    bad_aspect.write_text("inference:\n  aspect: '32:9'\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_config(bad_aspect)
+
+    bad_queue = tmp_path / "queue.yaml"
+    bad_queue.write_text("inference:\n  queue_size: 0\n", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_config(bad_queue)
 
 
 # ------------------------------------------------------------ command contract
@@ -172,6 +250,19 @@ def test_conditions_and_reset_are_always_available():
 # The real handlers on a model whose ``load()`` never ran: everything they touch
 # is session state and pure arithmetic, so the whole state machine — refusals
 # included — is testable on a laptop.
+
+
+def make_config(queue_size=3) -> FastH3Config:
+    return FastH3Config(
+        aspect="16:9",
+        clip_frames=clip_plan.frames_for_seconds(clip_plan.MAX_SECONDS),
+        seed=1000,
+        num_inference_steps=5,
+        queue_size=queue_size,
+        warmup_aspects=("16:9",),
+        inference={},
+        runtime={},
+    )
 
 
 def run(coro):
@@ -196,12 +287,7 @@ def model():
     instance = FastH3()
     # Loop-bound state the runtime creates when the model loop starts.
     instance._on_loop_ready()
-    # The handful of values load() reads out of fasth3.yaml.
-    instance.default_aspect = "16:9"
-    instance.default_clip_frames = clip_plan.frames_for_seconds(clip_plan.MAX_SECONDS)
-    instance.ramp_frames = (clip_plan.MIN_FRAMES,)
-    instance.default_seed = 1000
-    instance.num_inference_steps = 5
+    instance.config = make_config(queue_size=3)
     instance._reset_session_state()
 
     sent: list = []
@@ -214,36 +300,128 @@ def model():
     return instance
 
 
-def test_start_needs_a_prompt(model):
-    """A fresh session has no prompt, so the channel waits for the client."""
-    assert model._prompt == ""
-    assert run(model.start()) is None
-    assert refusal(model).command == "start"
-    assert model._started is False
+def test_enqueue_returns_the_full_struct(model):
+    reply = run(model.enqueue(prompt="a lighthouse in fog", metadata="req-42"))
+    clip = reply.clip
+    assert clip["prompt"] == "a lighthouse in fog"
+    assert clip["metadata"] == "req-42"
+    assert clip["ready"] is False
+    assert clip["frames"] == model.config.clip_frames
+    assert clip["seconds"] == pytest.approx(clip["frames"] / 24, abs=1e-3)
+    assert clip["clip_id"]
+    # The struct is a plain mapping, because the wire encoder takes only
+    # JSON-representable values; ClipInfo is its schema-side declaration.
+    assert list(clip) == [field.name for field in dataclasses.fields(ClipInfo)]
 
 
-def test_start_arms_the_channel(model):
-    run(model.set_prompt(prompt="a lighthouse in fog"))
-    run(model.start())
-    assert model._started is True
+def test_enqueue_needs_a_prompt(model):
+    assert run(model.enqueue(prompt="   ", metadata="")) is None
+    assert refusal(model).command == "enqueue"
+    assert len(model._queue) == 0
 
 
-def test_start_is_refused_while_a_channel_runs(model):
-    model._running = True
-    assert run(model.start()) is None
-    assert refusal(model).command == "start"
+def test_enqueue_snapshots_the_conditions_in_force(model):
+    run(model.set_clip_seconds(seconds=8.0))
+    first = run(model.enqueue(prompt="a", metadata="")).clip
+    run(model.set_clip_seconds(seconds=14.375))
+    second = run(model.enqueue(prompt="b", metadata="")).clip
+    assert first["frames"] == clip_plan.frames_for_seconds(8.0)
+    assert second["frames"] == clip_plan.frames_for_seconds(14.375)
+    # Clips already queued keep the length they were enqueued with.
+    assert model._queue.get(first["clip_id"]).frames == first["frames"]
 
 
-def test_an_empty_prompt_clears_the_condition(model):
-    run(model.set_prompt(prompt="a lighthouse in fog"))
-    reply = run(model.set_prompt(prompt="   "))
-    # "Unset" is null on the wire, never an empty string — the same convention
-    # `state_update.prompt` uses, so a client reads one shape from both.
-    assert reply.prompt is None
-    assert model._prompt == ""
-    # And `start` goes back to being refused.
-    assert run(model.start()) is None
-    assert refusal(model).command == "start"
+def test_each_enqueue_advances_the_seed(model):
+    seeds = [run(model.enqueue(prompt="p", metadata="")).clip["seed"] for _ in range(2)]
+    assert seeds == [1000, 1001]
+    run(model.reset())
+    run(model.set_seed(seed=7))
+    assert run(model.enqueue(prompt="p", metadata="")).clip["seed"] == 7
+
+
+def test_a_full_queue_refuses_the_next_enqueue(model):
+    for index in range(3):
+        run(model.enqueue(prompt=f"p{index}", metadata=""))
+    assert run(model.enqueue(prompt="overflow", metadata="")) is None
+    assert refusal(model).command == "enqueue"
+    assert len(model._queue) == 3
+
+
+def test_play_needs_a_ready_clip(model):
+    assert run(model.play(clip_id="")) is None
+    assert refusal(model).command == "play"
+
+    queued = run(model.enqueue(prompt="p", metadata="")).clip
+    assert run(model.play(clip_id=queued["clip_id"])) is None  # enqueued, not built
+    assert refusal(model).reason.startswith("That clip is still generating")
+
+    assert run(model.play(clip_id="not-a-real-id")) is None
+    assert "not-a-real-id" in refusal(model).reason
+
+
+def test_play_takes_the_oldest_ready_clip(model):
+    first = run(model.enqueue(prompt="a", metadata="")).clip
+    second = run(model.enqueue(prompt="b", metadata="")).clip
+    for clip_id in (first["clip_id"], second["clip_id"]):
+        entry = model._queue.get(clip_id)
+        entry.video, entry.audio = [np.zeros((2, 2, 3), np.uint8)], np.zeros((1, 10), np.int16)
+
+    run(model.play(clip_id=""))
+    assert model._play_request.clip_id == first["clip_id"]
+    # Playing consumed the entry: the queue now holds only the second clip.
+    assert [clip["clip_id"] for clip in model._queue.snapshot()] == [second["clip_id"]]
+
+
+def test_play_by_id_takes_that_clip(model):
+    run(model.enqueue(prompt="a", metadata=""))
+    second = run(model.enqueue(prompt="b", metadata="")).clip
+    entry = model._queue.get(second["clip_id"])
+    entry.video, entry.audio = [np.zeros((2, 2, 3), np.uint8)], np.zeros((1, 10), np.int16)
+
+    run(model.play(clip_id=second["clip_id"]))
+    assert model._play_request.clip_id == second["clip_id"]
+
+
+def test_only_one_clip_plays_at_a_time(model):
+    queued = run(model.enqueue(prompt="a", metadata="")).clip
+    entry = model._queue.get(queued["clip_id"])
+    entry.video, entry.audio = [np.zeros((2, 2, 3), np.uint8)], np.zeros((1, 10), np.int16)
+    run(model.play(clip_id=""))
+
+    assert run(model.play(clip_id="")) is None
+    assert refusal(model).reason.startswith("A clip is already playing")
+
+
+def test_stop_needs_a_playing_clip(model):
+    assert run(model.stop()) is None
+    assert refusal(model).command == "stop"
+    assert model._stop_playout is False
+
+
+def test_stop_asks_the_playout_loop_to_cut(model):
+    queued = run(model.enqueue(prompt="a", metadata="")).clip
+    entry = model._queue.get(queued["clip_id"])
+    entry.video, entry.audio = [np.zeros((2, 2, 3), np.uint8)], np.zeros((1, 10), np.int16)
+    run(model.play(clip_id=""))
+
+    run(model.stop())
+    assert model._stop_playout is True
+    # The queue is untouched: stop cuts playout, not the queue.
+    assert len(model._queue) == 0  # the played clip had already left it
+
+
+def test_the_canvas_is_locked_while_clips_exist(model):
+    reply = run(model.set_canvas(aspect="9:16"))
+    assert (reply.height, reply.width) == clip_plan.canvas_for_choice("9:16")
+
+    run(model.enqueue(prompt="a", metadata=""))
+    assert run(model.set_canvas(aspect="1:1")) is None
+    assert refusal(model).command == "set_canvas"
+    # The refused command had no effect.
+    assert model._aspect == "9:16"
+
+    run(model.reset())
+    assert run(model.set_canvas(aspect="1:1")) is not None
 
 
 def test_clip_length_snaps_to_something_generatable(model):
@@ -253,105 +431,31 @@ def test_clip_length_snaps_to_something_generatable(model):
     assert model._clip_frames == reply.frames
 
 
-def test_the_canvas_is_locked_once_a_channel_runs(model):
-    reply = run(model.set_canvas(aspect="9:16"))
-    assert (reply.height, reply.width) == clip_plan.canvas_for_choice("9:16")
-    model._running = True
-    assert run(model.set_canvas(aspect="1:1")) is None
-    assert refusal(model).command == "set_canvas"
-    # The refused command had no effect.
-    assert model._aspect == "9:16"
-
-
-def test_pause_and_resume_only_apply_to_a_live_channel(model):
-    assert run(model.pause()) is None
-    assert refusal(model).command == "pause"
-
-    model._running = True
-    assert run(model.pause()) is not None  # accepted: a real reply comes back
-    assert model._paused is True
-    assert run(model.pause()) is None
-    assert refusal(model).command == "pause"
-
-    assert run(model.resume()) is not None
-    assert model._paused is False
-    assert run(model.resume()) is None
-    assert refusal(model).command == "resume"
-
-
-def test_stop_keeps_the_conditions(model):
-    run(model.set_prompt(prompt="a lighthouse in fog"))
-    run(model.set_clip_seconds(seconds=10.0))
-    model._running = True
-    run(model.stop())
-    assert model._started is False
-    assert model._do_reset is True
-    assert model._stop_only is True
-    assert model._prompt == "a lighthouse in fog"
-    assert model._clip_frames == clip_plan.frames_for_seconds(10.0)
-
-
-def test_reset_restores_every_default(model):
-    run(model.set_prompt(prompt="a lighthouse in fog"))
+def test_reset_drops_the_queue_and_restores_every_default(model):
     run(model.set_clip_seconds(seconds=10.0))
     run(model.set_seed(seed=7))
-    run(model.set_canvas(aspect="1:1"))
+    run(model.enqueue(prompt="a", metadata=""))
+    run(model.enqueue(prompt="b", metadata=""))
 
     reply = run(model.reset())
-    assert reply.was_running is False
-    assert model._prompt == ""
-    assert model._clip_frames == model.default_clip_frames
-    assert model._seed == model.default_seed
-    assert model._aspect == model.default_aspect
+    assert reply.cleared_clips == 2
+    assert reply.was_playing is False
+    assert len(model._queue) == 0
+    assert model._clip_frames == model.config.clip_frames
+    assert model._seed == model.config.seed
+    assert model._aspect == model.config.aspect
 
 
-def test_reset_while_idle_does_not_wedge_the_arm_loop(model):
-    """`_do_reset` left set with nothing running would block every later start.
-
-    ``_wait_until_armed`` deliberately does not read the flag, and ``reset``
-    only raises it for a channel that is actually live. Both halves are asserted
-    here because either alone would still hang the model loop.
-    """
-    run(model.reset())
-    assert model._do_reset is False
-
-    run(model.set_prompt(prompt="a lighthouse in fog"))
-    run(model.start())
-    assert model._started and model._prompt
-
-
-def test_a_prompt_set_while_idle_lands_on_the_first_clip(model):
-    reply = run(model.set_prompt(prompt="a lighthouse in fog"))
-    assert reply.effective_clip_index == 0
-    assert reply.effective_in_seconds == 0.0
-
-
-def test_a_prompt_set_before_the_first_clip_lands_on_the_second(model):
-    """Clip 0 is already being built, so the earliest a change can land is clip 1."""
-    model._running = True
-    model._clip_index = -1
-    reply = run(model.set_prompt(prompt="a lighthouse in fog"))
-    assert reply.effective_clip_index == 1
-    # The wait is the whole of clip 0 — the ramp's short opening clip.
-    assert reply.effective_in_seconds == pytest.approx(clip_plan.MIN_FRAMES / 24, abs=0.01)
-
-
-def test_a_prompt_set_mid_channel_lands_two_clips_out(model):
-    """Clip k is playing and clip k+1 is already built, so a change lands on k+2."""
-    model._running = True
-    model._clip_index = 3
-    model._current_clip_seconds = 14.375
-    model._clip_start_seconds = 40.0
-    model._seconds_sent = 44.0  # 4 s into clip 3
-
-    reply = run(model.set_prompt(prompt="a lighthouse in fog"))
-    assert reply.effective_clip_index == 5
-    # 10.375 s left of clip 3, then the whole of clip 4.
-    assert reply.effective_in_seconds == pytest.approx(10.375 + 14.375, abs=0.01)
+def test_get_queue_reports_the_same_payload_that_is_broadcast(model):
+    run(model.enqueue(prompt="a", metadata="m"))
+    direct = run(model.get_queue())
+    broadcasts = [m for m in model.sent if type(m).__name__ == "QueueUpdate"]
+    assert direct.clips == broadcasts[-1].clips
+    assert direct.clips[0]["metadata"] == "m"
 
 
 def test_get_state_reports_the_same_snapshot_that_is_broadcast(model):
-    run(model.set_prompt(prompt="a lighthouse in fog"))
+    run(model.enqueue(prompt="a", metadata=""))
     model.sent.clear()
     run(model._send_state_update())
     broadcast = model.sent[-1]
@@ -361,30 +465,29 @@ def test_get_state_reports_the_same_snapshot_that_is_broadcast(model):
 
 def test_the_snapshot_publishes_the_live_command_set(model):
     snapshot = run(model.get_state())
-    assert snapshot.ready is False
-    assert "start" not in snapshot.valid_commands  # no prompt yet
+    assert "play" not in snapshot.valid_commands  # nothing ready yet
+    assert "enqueue" in snapshot.valid_commands
+    assert snapshot.queued == 0
+    assert snapshot.queue_capacity == 3
+    assert snapshot.playing is False
+    assert snapshot.playing_clip_id is None
 
-    run(model.set_prompt(prompt="a lighthouse in fog"))
+    queued = run(model.enqueue(prompt="a", metadata="")).clip
+    entry = model._queue.get(queued["clip_id"])
+    entry.video, entry.audio = [np.zeros((2, 2, 3), np.uint8)], np.zeros((1, 10), np.int16)
     snapshot = run(model.get_state())
-    assert snapshot.ready is True
-    assert "start" in snapshot.valid_commands
-    assert (snapshot.height, snapshot.width) == clip_plan.canvas_for_choice("16:9")
-
-
-def test_the_ramp_shortens_only_the_opening_clip(model):
-    assert model._frames_for_clip(0) == clip_plan.MIN_FRAMES
-    assert model._frames_for_clip(1) == model.default_clip_frames
-    assert model._frames_for_clip(50) == model.default_clip_frames
+    assert "play" in snapshot.valid_commands
+    assert snapshot.queued == 1
 
 
 def test_a_refusal_never_masquerades_as_a_reply(model):
     """A handler must return only the type its annotation names.
 
-    `pause` is annotated `-> ChannelPaused`; a refusal that returned a
+    `enqueue` is annotated `-> ClipQueued`; a refusal that returned a
     `CommandError` from it would reach the client typed as the message the
     schema promised, with every guaranteed field undefined.
     """
-    assert run(model.pause()) is None
+    assert run(model.enqueue(prompt="", metadata="")) is None
     error = refusal(model)
     assert type(error).__name__ == "CommandError"
     assert error.reason
@@ -402,53 +505,58 @@ def test_the_runtime_exception_is_never_raised(model):
     assert in_scope is ours
 
 
-# ----------------------------------------------------------------- the channel
+# ------------------------------------------------------------ the playout loop
 #
-# ``_run_channel`` is the concurrent part of this model — a worker thread
-# building clips, an event loop pacing them out, and abort paths crossing both.
-# These tests replace only the clip *builder*, so the real queueing, ordering,
-# emission and teardown all run.
+# ``_serve`` is the concurrent part of this model — a worker building clips, an
+# event loop pacing an armed clip out, and abort paths crossing both. These
+# tests replace only the *backend*, so the real queueing, ordering, emission
+# and teardown all run.
 #
-# Clips are shrunk to a few frames so a whole channel plays in well under a
+# Clips are shrunk to a few frames so a whole playout runs in well under a
 # second; the pacer is a real 24 fps clock, so the numbers below are wall time.
 
 FRAMES_PER_CLIP = 6  # 0.25 s of content at 24 fps
 
 
+class FakeBackend:
+    """Builds tiny clips on demand; instant by default, controllable when not."""
+
+    def __init__(self):
+        self.built: list[tuple[int, str, int]] = []
+        self.fail_next: Exception | None = None
+        self.hold = False
+        self.held: list[ClipJob] = []
+
+    def submit(self, *, frames, prompt, seed, height, width) -> ClipJob:
+        self.built.append((frames, prompt, seed))
+        job = ClipJob(None)
+        if self.fail_next is not None:
+            job.error, self.fail_next = self.fail_next, None
+            job.done.set()
+        elif self.hold:
+            self.held.append(job)
+        else:
+            self.finish(job, frames)
+        return job
+
+    @staticmethod
+    def finish(job: ClipJob, frames: int = FRAMES_PER_CLIP) -> None:
+        video = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(frames)]
+        samples = np.zeros((1, round(frames / 24 * 48_000)), dtype=np.int16)
+        job.result = (video, samples)
+        job.done.set()
+
+
 @pytest.fixture
-def channel():
+def live():
+    """A FastH3 wired to a fake backend, with a connected audience."""
     instance = FastH3()
     instance._on_loop_ready()
     instance.connected.set()
-    instance.default_aspect = "16:9"
-    instance.default_clip_frames = clip_plan.frames_for_seconds(clip_plan.MAX_SECONDS)
-    instance.ramp_frames = ()
-    instance.default_seed = 1000
-    instance.num_inference_steps = 5
+    instance.config = make_config(queue_size=5)
     instance._reset_session_state()
-    instance._prompt = "a lighthouse in fog"
-    # `_run_channel` is driven directly here, so arm the session as `start` does.
-    instance._started = True
-
-    instance._jobs = queue.Queue()
-    instance._worker = threading.Thread(
-        target=instance._worker_loop, name="test-generation", daemon=True
-    )
-    instance._worker.start()
-
-    # Every clip is a handful of tiny frames; shape does not matter here.
-    instance._frames_for_clip = lambda index: FRAMES_PER_CLIP
-
-    built: list[tuple[int, str, int]] = []
-
-    def fake_generate(index, frames, prompt, seed, height, width):
-        built.append((index, prompt, seed))
-        video = [np.zeros((8, 8, 3), dtype=np.uint8) for _ in range(frames)]
-        samples = np.zeros((1, round(frames / 24 * 48_000)), dtype=np.int16)
-        return video, samples
-
-    instance._generate_clip = fake_generate
-    instance.built = built
+    instance._clip_frames = FRAMES_PER_CLIP  # tiny clips keep the tests fast
+    instance.backend = FakeBackend()
 
     emitted: list = []
 
@@ -465,6 +573,10 @@ def channel():
 
     instance.send = fake_send
     instance.messages = messages
+
+    flushes: list = []
+    instance.output.flush = lambda: flushes.append(time.monotonic())
+    instance.flushes = flushes
     return instance
 
 
@@ -472,66 +584,77 @@ def names(messages) -> list[str]:
     return [type(m).__name__ for m in messages]
 
 
-def run_channel_until(channel, stop_after_clips: int):
-    """Run a channel, stopping it once `stop_after_clips` clips have completed."""
+def drive(live, scenario):
+    """Run `_serve` against a scenario coroutine that ends the session."""
 
-    async def drive():
-        async def stopper():
-            while channel._clips_sent < stop_after_clips:
-                await asyncio.sleep(0.01)
-            channel._started = False
-            channel._stop_only = True
-            channel._do_reset = True
+    async def main():
+        async def wrapped():
+            try:
+                await scenario()
+            finally:
+                live.connected.clear()
 
-        await asyncio.gather(channel._run_channel(), stopper())
+        await asyncio.gather(live._serve(), wrapped())
 
-    asyncio.run(drive())
-
-
-async def armed_within(channel, seconds: float) -> bool:
-    """Whether `_wait_until_armed` would arm a channel inside `seconds`."""
-    try:
-        return await asyncio.wait_for(channel._wait_until_armed(), timeout=seconds)
-    except TimeoutError:
-        return False
+    asyncio.run(main())
 
 
-def test_clips_stream_in_order_and_the_channel_ends_cleanly(channel):
-    run_channel_until(channel, stop_after_clips=3)
-
-    started = [m for m in channel.messages if type(m).__name__ == "ClipStarted"]
-    assert [m.clip_index for m in started[:3]] == [0, 1, 2]
-    assert names(channel.messages)[0] == "ChannelStarted"
-    assert "ChannelStopped" in names(channel.messages)
-    assert channel._running is False
+async def eventually(predicate, timeout=2.0):
+    """Wait until `predicate()` is true, failing the test after `timeout`."""
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        assert time.monotonic() < deadline, "condition never became true"
+        await asyncio.sleep(0.005)
 
 
-def test_the_next_clip_is_built_while_the_current_one_plays(channel):
-    """This is what makes the channel endless; without it every clip is a stall."""
-    run_channel_until(channel, stop_after_clips=2)
+def test_enqueued_clips_build_in_order_and_turn_ready(live):
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="")
+        await live.enqueue(prompt="b", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 2)
 
-    # Clip 0 is emitted only after clip 1 has been asked for.
-    assert [index for index, _prompt, _seed in channel.built][:3] == [0, 1, 2]
-    assert len(channel.built) >= 3
-
-
-def test_every_frame_of_every_clip_reaches_the_wire(channel):
-    run_channel_until(channel, stop_after_clips=2)
-
-    frames = sum(output.main_video.shape[0] for output in channel.emitted)
-    # Every completed clip went out whole. The stop lands mid-clip, so the tally
-    # can exceed that by part of the clip that was interrupted.
-    assert frames >= channel._clips_sent * FRAMES_PER_CLIP
-    assert channel._clips_sent == 2
-    # The counters clients see are derived from what was actually emitted.
-    assert channel._frames_sent == frames
-    assert channel._seconds_sent == pytest.approx(frames / 24)
+    drive(live, scenario)
+    assert [prompt for _f, prompt, _s in live.backend.built] == ["a", "b"]
+    ready = [m for m in live.messages if type(m).__name__ == "QueueUpdate"]
+    assert ready, "no queue_update announced the clips turning ready"
 
 
-def test_video_and_audio_stay_locked_slice_for_slice(channel):
-    run_channel_until(channel, stop_after_clips=2)
+def test_a_played_clip_streams_whole_then_holds_on_black(live):
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="tag")
+        await eventually(lambda: live._queue.ready_count() == 1)
+        await live.play(clip_id="")
+        await eventually(lambda: "ClipFinished" in names(live.messages))
+        # No auto-play: nothing else may start on its own.
+        await asyncio.sleep(0.15)
 
-    for output in channel.emitted:
+    drive(live, scenario)
+    # `clip_queued` is the enqueue reply, not a broadcast, so it is not here.
+    assert names([m for m in live.messages if "Clip" in type(m).__name__]) == [
+        "ClipStarted",
+        "ClipFinished",
+    ]
+    frames = sum(output.main_video.shape[0] for output in live.emitted)
+    assert frames == FRAMES_PER_CLIP
+    assert live.flushes, "the stream must flush to black after the clip"
+    assert live._playing is None
+    # The full struct rides on both playout messages, metadata included.
+    started = next(m for m in live.messages if type(m).__name__ == "ClipStarted")
+    finished = next(m for m in live.messages if type(m).__name__ == "ClipFinished")
+    assert started.clip["metadata"] == "tag"
+    assert started.clip["ready"] is True
+    assert finished.clip["clip_id"] == started.clip["clip_id"]
+
+
+def test_video_and_audio_stay_locked_slice_for_slice(live):
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 1)
+        await live.play(clip_id="")
+        await eventually(lambda: "ClipFinished" in names(live.messages))
+
+    drive(live, scenario)
+    for output in live.emitted:
         video_frames = output.main_video.shape[0]
         audio_samples = output.main_audio.shape[1]
         assert output.main_video.dtype == np.uint8
@@ -540,128 +663,132 @@ def test_video_and_audio_stay_locked_slice_for_slice(channel):
         assert audio_samples == pytest.approx(video_frames * 48_000 / 24, abs=1)
 
 
-def test_the_prompt_of_a_clip_is_the_one_set_when_it_was_asked_for(channel):
-    """A prompt change lands on the next clip *submitted*, never the one in flight."""
+def test_stop_cuts_the_clip_and_keeps_the_queue(live):
+    # A two-second clip, so the stop reliably lands mid-play.
+    live._clip_frames = 48
 
-    async def drive():
-        async def change():
-            # Wait until clip 0 is streaming; clip 1 has been submitted by then.
-            while channel._clip_index < 0:
-                await asyncio.sleep(0.005)
-            channel._prompt = "a neon alley in the rain"
-            while channel._clips_sent < 3:
-                await asyncio.sleep(0.01)
-            channel._started = False
-            channel._stop_only = True
-            channel._do_reset = True
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="")
+        await live.enqueue(prompt="b", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 2)
+        await live.play(clip_id="")
+        await eventually(lambda: live.emitted)
+        await live.stop()
+        await eventually(lambda: "ClipStopped" in names(live.messages))
 
-        await asyncio.gather(channel._run_channel(), change())
-
-    asyncio.run(drive())
-
-    prompts = [prompt for _index, prompt, _seed in channel.built]
-    assert prompts[0] == "a lighthouse in fog"
-    assert prompts[1] == "a lighthouse in fog"  # already in flight when it changed
-    assert prompts[2] == "a neon alley in the rain"
+    drive(live, scenario)
+    assert "ClipFinished" not in names(live.messages)
+    assert live.flushes, "stop must flush the output"
+    # The cut clip went out only partially.
+    frames = sum(output.main_video.shape[0] for output in live.emitted)
+    assert frames < 48
+    # The other clip still waits, ready, for the next play.
+    assert live._queue.ready_count() == 1
 
 
-def test_each_clip_advances_the_seed(channel):
-    run_channel_until(channel, stop_after_clips=2)
-    seeds = [seed for _index, _prompt, seed in channel.built]
-    assert seeds[:3] == [1000, 1001, 1002]
+def test_builds_continue_while_a_clip_plays(live):
+    # A two-second clip, so the enqueue reliably lands mid-play.
+    live._clip_frames = 48
+    built_during_play = {}
+
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 1)
+        await live.play(clip_id="")
+        await eventually(lambda: live.emitted)
+        await live.enqueue(prompt="b", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 1)
+        built_during_play["value"] = live._playing is not None
+        await eventually(lambda: "ClipFinished" in names(live.messages))
+
+    drive(live, scenario)
+    # The second build was submitted and finished while the first clip streamed.
+    assert [prompt for _f, prompt, _s in live.backend.built] == ["a", "b"]
+    assert built_during_play["value"] is True
+    assert live._queue.ready_count() == 1
 
 
-def test_a_lost_audience_winds_the_channel_down(channel):
-    """No client means no GPU spend; the channel stops at the next boundary."""
+def test_a_failing_build_reports_and_the_queue_moves_on(live):
+    async def scenario():
+        live.backend.fail_next = RuntimeError("the engine fell over")
+        await live.enqueue(prompt="a", metadata="")
+        await live.enqueue(prompt="b", metadata="")
+        await eventually(lambda: "ClipFailed" in names(live.messages))
+        await eventually(lambda: live._queue.ready_count() == 1)
 
-    async def drive():
-        async def leave():
-            while channel._clips_sent < 1:
-                await asyncio.sleep(0.01)
-            channel.connected.clear()
-
-        await asyncio.gather(channel._run_channel(), leave())
-
-    asyncio.run(drive())
-
-    assert channel._running is False
-    # A lost audience is not a `stop`, so no channel_stopped is sent.
-    assert "ChannelStopped" not in names(channel.messages)
-    # The conditions survive, so reconnecting resumes the same channel.
-    assert channel._prompt == "a lighthouse in fog"
-    assert channel._started is True
+    drive(live, scenario)
+    failed = next(m for m in live.messages if type(m).__name__ == "ClipFailed")
+    assert "the engine fell over" in failed.reason
+    assert failed.clip["prompt"] == "a"
+    # The failed clip left the queue; the survivor is the second one.
+    assert [clip["prompt"] for clip in live._queue.snapshot()] == ["b"]
 
 
-def test_a_failing_clip_reports_and_returns_the_model_to_idle(channel):
-    def explode(index, frames, prompt, seed, height, width):
-        raise RuntimeError("the engine fell over")
+def test_reset_discards_a_build_still_in_flight(live):
+    async def scenario():
+        live.backend.hold = True
+        await live.enqueue(prompt="a", metadata="")
+        await eventually(lambda: live.backend.held)
+        await live.reset()
+        live.backend.finish(live.backend.held[0])
+        # The finished build has no entry to land on; nothing may surface.
+        await asyncio.sleep(0.15)
 
-    channel._generate_clip = explode
-    asyncio.run(channel._run_channel())
-
-    failures = [m for m in channel.messages if type(m).__name__ == "ChannelFailed"]
-    assert len(failures) == 1
-    assert "the engine fell over" in failures[0].reason
-    assert channel._running is False
-
-
-def test_pause_holds_the_stream_and_resume_continues_it(channel):
-    async def drive():
-        async def hold():
-            while not channel.emitted:
-                await asyncio.sleep(0.005)
-            channel._paused = True
-            # The pause is read once per slice, and a slice already waiting on
-            # the pacer is committed to going out — so it takes effect within
-            # one slice interval (EMIT_FRAMES / 24, about 0.125 s), not
-            # instantly. Wait past that before measuring.
-            await asyncio.sleep(0.25)
-            held = len(channel.emitted)
-            await asyncio.sleep(0.3)
-            assert len(channel.emitted) == held, "the stream moved while paused"
-            channel._paused = False
-            while channel._clips_sent < 1:
-                await asyncio.sleep(0.01)
-            channel._started = False
-            channel._stop_only = True
-            channel._do_reset = True
-
-        await asyncio.gather(channel._run_channel(), hold())
-
-    asyncio.run(drive())
-    assert sum(o.main_video.shape[0] for o in channel.emitted) >= FRAMES_PER_CLIP
+    drive(live, scenario)
+    assert len(live._queue) == 0
+    assert "ClipFailed" not in names(live.messages)
+    assert live._queue.ready_count() == 0
 
 
-def test_the_pacer_holds_24_fps_across_a_clip_boundary(channel):
-    """A seam must not cost time: the clock carries from one clip to the next."""
-    started = time.monotonic()
-    run_channel_until(channel, stop_after_clips=3)
-    elapsed = time.monotonic() - started
+def test_the_pacer_holds_24_fps(live):
+    elapsed = {}
 
-    content = 3 * FRAMES_PER_CLIP / 24
-    # A slice is handed over at the instant its content is due, so the run ends
-    # one slice before the content it queued finishes playing.
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 1)
+        started = time.monotonic()
+        await live.play(clip_id="")
+        await eventually(lambda: "ClipFinished" in names(live.messages))
+        elapsed["playout"] = time.monotonic() - started
+
+    drive(live, scenario)
+    content = FRAMES_PER_CLIP / 24
+    # A slice is handed over at the instant its content is due, so the playout
+    # ends one slice before the content it queued finishes playing.
     expected = content - EMIT_FRAMES / 24
     # Real-time, not faster: the metronome is what keeps the audio in sync.
-    assert elapsed >= expected * 0.95
-    # And no seam stall: each clip was built long before it was needed, so three
-    # of them must not take appreciably longer than their own content.
-    assert elapsed < content + 0.3
+    assert elapsed["playout"] >= expected * 0.95
+    assert elapsed["playout"] < content + 0.3
 
 
-def test_a_failed_channel_does_not_restart_itself(channel):
-    """`run()` re-arms from `_started`; leaving it set is an eight-GPU crash loop."""
+def test_a_lost_audience_ends_the_playout_quietly(live):
+    # A two-second clip, so the disconnect reliably lands mid-play.
+    live._clip_frames = 48
 
-    def explode(index, frames, prompt, seed, height, width):
-        raise RuntimeError("the engine fell over")
+    async def scenario():
+        await live.enqueue(prompt="a", metadata="")
+        await eventually(lambda: live._queue.ready_count() == 1)
+        await live.play(clip_id="")
+        await eventually(lambda: live.emitted)
+        # The scenario wrapper clears `connected`, which is the audience leaving.
 
-    channel._generate_clip = explode
-    assert channel._started is True
-    asyncio.run(channel._run_channel())
+    drive(live, scenario)
+    # Nobody was there to hear a finish or a stop for the cut clip.
+    assert "ClipFinished" not in names(live.messages)
+    assert "ClipStopped" not in names(live.messages)
 
-    assert channel._started is False
-    # And the arm loop agrees: it would not start another channel unattended.
-    assert asyncio.run(armed_within(channel, seconds=0.2)) is False
+
+def test_generation_is_gated_on_an_audience(live):
+    """`_serve` is the only submitter, and it runs only with a client connected."""
+
+    async def main():
+        await live.enqueue(prompt="a", metadata="")
+        live.connected.clear()
+        await asyncio.wait_for(live._serve(), timeout=1.0)
+
+    asyncio.run(main())
+    assert live.backend.built == []
+    assert live._queue.ready_count() == 0
 
 
 # ---------------------------------------------------------- published contract
@@ -674,38 +801,46 @@ def test_a_failed_channel_does_not_restart_itself(channel):
 # Every command a client can send, and the message each answers with. `None`
 # means the command is answered with a bare acknowledgement.
 EXPECTED_COMMANDS = {
+    "enqueue": "ClipQueued",
+    "get_queue": "QueueUpdate",
     "get_state": "StateUpdate",
-    "pause": "ChannelPaused",
-    "reset": "ChannelReset",
-    "resume": "ChannelResumed",
+    "play": None,
+    "reset": "SessionReset",
     "set_canvas": "CanvasAccepted",
     "set_clip_seconds": "ClipLengthAccepted",
-    "set_prompt": "PromptAccepted",
     "set_seed": "SeedAccepted",
-    "start": None,
     "stop": None,
 }
 
 EXPECTED_MESSAGES = {
     "canvas_accepted",
-    "channel_failed",
-    "channel_paused",
-    "channel_reset",
-    "channel_resumed",
-    "channel_started",
-    "channel_stopped",
-    "clip_complete",
+    "clip_failed",
+    "clip_finished",
     "clip_length_accepted",
+    "clip_queued",
     "clip_started",
+    "clip_stopped",
     "command_error",
-    "prompt_accepted",
+    "queue_update",
     "seed_accepted",
+    "session_reset",
     "state_update",
 }
 
 # Commands that can be refused. Each one has to say so in its own summary, and
 # name the message a client will actually receive.
-EXPECTED_REJECTIONS = ("set_canvas", "start", "pause", "resume", "stop")
+EXPECTED_REJECTIONS = ("enqueue", "play", "stop", "set_canvas")
+
+# The struct every clip-referencing message embeds, and its JSON types.
+EXPECTED_CLIP_INFO = {
+    "clip_id": "string",
+    "prompt": "string",
+    "metadata": "string",
+    "frames": "integer",
+    "seconds": "number",
+    "seed": "integer",
+    "ready": "boolean",
+}
 
 
 @pytest.fixture(scope="module")
@@ -718,7 +853,7 @@ def schema():
     """
     from reactor_runtime.schema import render
 
-    return render(MODEL_DIR, version="v0.1.0")
+    return render(MODEL_DIR, version="v0.2.0")
 
 
 def test_the_model_publishes_two_outbound_tracks(schema):
@@ -752,6 +887,31 @@ def test_every_message_is_published_once(schema):
     for message in EXPECTED_COMMANDS.values():
         if message is not None:
             assert message in schema["components"]["schemas"]
+
+
+def test_every_clip_message_embeds_the_full_struct(schema):
+    """`ClipInfo` rides whole on every message that references a clip."""
+    for message in ("ClipQueued", "ClipStarted", "ClipFinished", "ClipStopped", "ClipFailed"):
+        clip = schema["components"]["schemas"][message]["properties"]["clip"]
+        rendered = {
+            name: field["type"] for name, field in clip["properties"].items()
+        }
+        assert rendered == EXPECTED_CLIP_INFO, message
+        assert set(clip.get("required", [])) == set(EXPECTED_CLIP_INFO), message
+    # And the queue reports a list of the same struct.
+    items = schema["components"]["schemas"]["QueueUpdate"]["properties"]["clips"]["items"]
+    assert {name: field["type"] for name, field in items["properties"].items()} == (
+        EXPECTED_CLIP_INFO
+    )
+
+
+def test_free_text_fields_are_marked_for_moderation(schema):
+    """`enqueue` carries client free text into generated video and audio."""
+    properties = schema["paths"]["/events/enqueue"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]["properties"]
+    assert properties["prompt"]["x-reactor-moderate"] is True
+    assert properties["metadata"]["x-reactor-moderate"] is True
 
 
 def test_the_clip_length_bounds_a_client_reads_are_generatable(schema):
@@ -821,6 +981,9 @@ def test_every_command_summary_names_what_it_emits(schema):
             # A pure read: it answers, it does not emit.
             assert "state_update" in summary
             continue
+        if name == "get_queue":
+            assert "queue_update" in summary
+            continue
         assert "`state_update`" in summary, f"{name} does not say it broadcasts a snapshot"
 
 
@@ -830,12 +993,11 @@ def test_every_refusable_command_documents_its_failure(schema):
         assert "`command_error`" in summary, f"{name} does not document its failure"
 
 
-def test_a_prompt_that_is_not_set_is_null_not_empty(schema):
-    """`None` is the unset value on the wire; an empty string would be ambiguous."""
-    for message in ("StateUpdate", "PromptAccepted"):
-        prompt = schema["components"]["schemas"][message]["properties"]["prompt"]
-        types = prompt.get("anyOf") or [prompt]
-        assert any(entry.get("type") == "null" for entry in types), f"{message}.prompt: {prompt}"
+def test_the_idle_stream_id_is_null_not_empty(schema):
+    """`None` is the no-clip value on the wire; an empty string would be ambiguous."""
+    playing = schema["components"]["schemas"]["StateUpdate"]["properties"]["playing_clip_id"]
+    types = playing.get("anyOf") or [playing]
+    assert any(entry.get("type") == "null" for entry in types), playing
 
 
 def test_clip_length_prose_matches_the_published_bounds(schema):
@@ -912,6 +1074,9 @@ def test_no_weights_are_committed_alongside_the_model():
     offenders = [
         path.relative_to(MODEL_DIR)
         for path in MODEL_DIR.rglob("*")
-        if path.is_file() and path.suffix.lower() in WEIGHT_SUFFIXES
+        if path.is_file()
+        and path.suffix.lower() in WEIGHT_SUFFIXES
+        # Hidden directories (.venv, .git) are not part of the commit.
+        and not any(part.startswith(".") for part in path.relative_to(MODEL_DIR).parts)
     ]
     assert not offenders, f"weights never live in git: {offenders}"

--- a/models/fasth3/tests/test_fasth3.py
+++ b/models/fasth3/tests/test_fasth3.py
@@ -341,6 +341,16 @@ def test_each_enqueue_advances_the_seed(model):
     assert run(model.enqueue(prompt="p", metadata="")).clip["seed"] == 7
 
 
+def test_an_explicit_length_applies_to_that_clip_only(model):
+    """A per-enqueue `seconds` snaps to the grid and spares the session default."""
+    clip = run(model.enqueue(prompt="p", metadata="", seconds=8.3)).clip
+    assert clip["frames"] == clip_plan.frames_for_seconds(8.3)
+    assert clip["frames"] % 17 == 5
+    assert model._clip_frames == model.config.clip_frames  # default untouched
+    plain = run(model.enqueue(prompt="p", metadata="")).clip
+    assert plain["frames"] == model.config.clip_frames
+
+
 def test_an_explicit_seed_leaves_the_default_untouched(model):
     """Explicit and automatic seeding must not interfere with each other."""
     explicit = run(model.enqueue(prompt="p", metadata="", seed=42)).clip
@@ -970,13 +980,15 @@ def test_free_text_fields_are_marked_for_moderation(schema):
     assert properties["metadata"]["x-reactor-moderate"] is True
 
 
-def test_the_enqueue_seed_is_optional_on_the_wire(schema):
-    """Omitted or null means the session's advancing default seed."""
-    seed = schema["paths"]["/events/enqueue"]["post"]["requestBody"]["content"][
+def test_the_enqueue_seed_and_length_are_optional_on_the_wire(schema):
+    """Omitted or null means the session's defaults."""
+    properties = schema["paths"]["/events/enqueue"]["post"]["requestBody"]["content"][
         "application/json"
-    ]["schema"]["properties"]["seed"]
-    types = seed.get("anyOf") or [seed]
-    assert any(entry.get("type") == "null" for entry in types), seed
+    ]["schema"]["properties"]
+    for name in ("seed", "seconds"):
+        field = properties[name]
+        types = field.get("anyOf") or [field]
+        assert any(entry.get("type") == "null" for entry in types), (name, field)
 
 
 def test_the_clip_length_bounds_a_client_reads_are_generatable(schema):


### PR DESCRIPTION
## What the model is now

fasth3 generates 768p video clips with synchronized audio from text prompts. A client uses it as a queue plus a player: you queue generations, the model builds them ahead of time, and nothing reaches the tracks until you ask for it — unless you turn autoplay on.

**Queueing.** `enqueue` takes a `prompt`, a free-form `metadata` string, and optionally a `seed` and a per-clip `seconds` (snapped to the nearest length the model can generate), and replies immediately with the clip's full structure: a UUID, the prompt and metadata exactly as sent, the length in both frames and seconds, the seed it will generate from, and `ready: false`. The metadata is opaque to the model and is echoed back on every message that ever mentions the clip — use it to tie clips to your own records: who requested it, which group of enqueues it belongs to, text to show while it plays. When no seed is passed, the session's advancing default is used (each such enqueue bumps it by one); an explicit seed leaves the default untouched, so scripted and automatic seeding never interfere. The queue is bounded (10 clips by default, configurable per deployment); a full queue refuses further enqueues with a `command_error`.

**Building.** Builds run through the queue oldest-first on their own, including while another clip is playing. When a clip finishes building it turns `ready: true`, announced on `queue_update` — a broadcast that always carries the entire queue as full clip structures, so a UI renders the whole board from any single message. `get_queue` returns the same payload on demand.

**Popping.** `pop` removes one clip from the queue by UUID and frees its slot — for making room when something more urgent needs enqueueing. It works on built and still-generating clips alike (a build in flight is discarded on completion); the playing clip is not in the queue, so cutting it stays `stop`'s job. Replies `clip_popped` with the full clip structure.

**Playing.** By default nothing plays on its own. Bare `play` streams the oldest ready clip on `main_video` and `main_audio`; `play` with a `clip_id` streams that specific clip. First frames arrive within a fraction of a second, because the clip is already built — the wait happened at enqueue time, not at play time. Playing consumes the queue entry. When the clip ends, the stream flushes to black, `clip_finished` fires, and the session holds until the next `play`.

**Autoplay.** `set_autoplay` flips the session into hands-free mode: whenever nothing is playing and a built clip waits, the oldest one starts on its own — right after a clip finishes, or the moment a build completes while the stream is idle. A steadily fed queue plays through without a `play` per clip. While autoplay is on, `stop` acts as a skip to the next ready clip; turn autoplay off first to hold the stream.

**Stopping.** `stop` cuts the playing clip within a fraction of a second: whatever is still buffered is dropped, `clip_stopped` fires, and the session is exactly where a finished clip leaves it. The queue is untouched. `reset` is the bigger hammer — drops every queued clip, cuts playback, and restores every condition to its default, autoplay included.

**Conditions.** `set_clip_seconds` (5.167–14.375 s; the default length for enqueues that carry no `seconds`), `set_seed` (the default seed for seedless enqueues), and `set_canvas` (aspect ratio; locked while clips are queued or playing, since queued clips were built at the size in force) all apply to clips enqueued afterwards. Each clip keeps the conditions it was enqueued with, and its structure states them.

**Observability.** `state_update` carries everything except the queue's contents, including `autoplay` and `valid_commands` — the exact set the session would accept right now, so frontends enable and grey out controls without re-deriving the state machine. Every clip-referencing message (`clip_queued`, `clip_started`, `clip_finished`, `clip_stopped`, `clip_failed`, `queue_update`) embeds the complete clip structure, so a client never joins UUIDs against earlier messages. A failed build reports `clip_failed` and the queue simply moves on.

`pause`/`resume`/`set_prompt`/`start` are gone; their job is covered by choosing when to `play` (or letting autoplay do it).

## Also in this PR

- **A reference client** at `models/fasth3/client/`: drives the whole contract once over the Python SDK (local or hosted), and writes one .mp4 per clip, the raw message log, and a timing report. Doubles as the smoke test after `reactor run`.
- **The image actually builds now**: the runtime pin moves to 3.2.6, and the flash-attn-4 / runtime protobuf conflict is resolved via a resolver override (protobuf 7 satisfies both in practice; the details are commented where they live). torchvision/torchaudio are pinned to the builds matching torch 2.12.
- **The fast kernel path is restored by building it from source.** The published fastvideo-kernel wheel's sm_100a binary fails every launch on this driver ("invalid argument"); the same source compiled by the image's own CUDA 13.1 nvcc runs correctly, so the build compiles it at the pinned 0.3.5 release commit. The deployment runs the checkpoint's measured policy — sm100a VSA, regional compile, H3 fusions, FA4 — with replicated DiT and the text encoder offloaded to pinned host memory (~1 s page-in per clip), which is what fits four ranks per box.
- **Prompts are padded to one fixed token length** before they reach the engine. Regional torch.compile keys its capture on the packed sequence length, prompt tokens included, so a novel prompt length recompiled the transformer (~23 s per clip) — invisible in upstream's benchmark, which reuses one prompt. With padding, one compiled shape (captured at warm-up) serves every clip; the client-visible prompt stays the original text.
- **Four B200s instead of eight** — FastVideo's tested default for this checkpoint. With playback explicit and clips pre-built, GPU count only moves the enqueue-to-ready wait, and the count must divide H3's 56 attention heads.

## Verification

486 CPU-only tests pass (queue, command contract, playout loop with a stubbed backend — autoplay chaining included — published schema, manifest rules), and the model ran live on four B200s driven by the included client across several cycles: play-to-first-frame 0.22–0.25 s, playout wall time matching content at a strict 24 fps, stop-to-black ~0.13 s, hold-on-black verified between clips, received video/audio on disk in sync.

**Build speed matches the published number.** A 14.375 s clip builds in 14.4 s on four B200s — 1.0x realtime, level with FastVideo's 15.5 s benchmark for this configuration — and stays flat across arbitrary prompts (measured 14.4 / 14.4 / 14.5 s for two different prompts and a repeat). Enqueue-to-ready is therefore roughly the clip's own duration plus the wait behind earlier builds.


