### PR TITLE
fix(fasth3): float64 mean in continuity color-match (fixes exposure b…

### DIFF
--- a/models/fasth3/fasth3.py
+++ b/models/fasth3/fasth3.py
@@ -2603,12 +2603,50 @@ class FastH3(ReactorModel):
 
         import fasth3_seam as seam
 
-        stacked = np.stack(frames_list)
         if index == 0 or self._clip0_reference is None:
-            self._clip0_reference = seam.reference_rgb(stacked[-1])
+            self._clip0_reference = seam.reference_rgb(np.asarray(frames_list[-1]))
             return frames_list
-        matched = seam.color_match_to_reference(stacked, self._clip0_reference)
-        return [np.ascontiguousarray(frame) for frame in matched]
+        matched = self._colour_match_gpu(frames_list, self._clip0_reference)
+        if matched is not None:
+            return matched
+        # CPU fallback (no CUDA, or the GPU path raised): same exposure math, in
+        # pure numpy. A contiguous (N,H,W,3) block's rows are already contiguous,
+        # so list() hands out zero-copy per-frame views the seam/anchor can use.
+        stacked = np.stack(frames_list)
+        return list(seam.color_match_to_reference(stacked, self._clip0_reference))
+
+    def _colour_match_gpu(self, frames_list: list, reference) -> list | None:
+        """On-GPU exposure lock: the ~3.8s single-threaded numpy fp32 round-trip
+        at 768p collapses to ~0.26s here (12x), and it is what makes the clip
+        playout-ready sooner.
+
+        The math is identical to :func:`fasth3_seam.color_match_to_reference`: one
+        per-channel additive offset (clip mean -> the clip-0 reference), then a
+        clamp and truncate to uint8. The clip mean is reduced in int64/float64 —
+        a device float32 mean over ~10^8 samples collapses exactly as the numpy
+        one does. Returns a list of per-frame uint8 arrays, or ``None`` if CUDA
+        is unavailable or the path fails, so the caller runs the CPU fallback.
+        """
+        try:
+            import numpy as np
+            import torch
+
+            if not torch.cuda.is_available():
+                return None
+            stacked = np.stack(frames_list)
+            with torch.no_grad():
+                t = torch.from_numpy(stacked).to("cuda", non_blocking=True)
+                tgt = torch.from_numpy(np.asarray(reference, np.float32)).to("cuda")
+                n = t.numel() // t.shape[-1]
+                src = (
+                    t.reshape(-1, 3).sum(dim=0, dtype=torch.int64).to(torch.float64) / n
+                ).to(torch.float32)
+                out = (t.to(torch.float32) + (tgt - src)).clamp_(0.0, 255.0).to(torch.uint8)
+                result = out.cpu().numpy()
+            return list(result)
+        except Exception:  # A colour-match must never fail a clip.
+            logger.exception("GPU colour-match failed; falling back to CPU numpy")
+            return None
 
     @staticmethod
     def _stage_times(result) -> dict:

--- a/models/fasth3/fasth3_seam.py
+++ b/models/fasth3/fasth3_seam.py
@@ -65,7 +65,7 @@ def reference_rgb(frame_u8: np.ndarray) -> np.ndarray:
     Locked once to clip 0's last frame and held constant for the whole chain, so
     exposure stays anchored instead of ratcheting.
     """
-    return frame_u8.reshape(-1, 3).mean(axis=0).astype(np.float32)
+    return frame_u8.reshape(-1, 3).mean(axis=0, dtype=np.float64).astype(np.float32)
 
 
 def color_match_to_reference(frames_u8: np.ndarray, target_rgb: np.ndarray) -> np.ndarray:
@@ -77,7 +77,11 @@ def color_match_to_reference(frames_u8: np.ndarray, target_rgb: np.ndarray) -> n
     the chain, which is what stops exposure drift from compounding.
     """
     f = frames_u8.astype(np.float32)
-    src = f.reshape(-1, 3).mean(axis=0)
+    # Reduce in float64: a float32 mean over a whole clip (~10^8 samples)
+    # saturates the 24-bit mantissa and collapses — at 124f/768p it returns
+    # ~33.6 instead of the true ~124.5, which would shove every continuation
+    # clip ~90 levels brighter and blow the highlights to white.
+    src = frames_u8.reshape(-1, 3).mean(axis=0, dtype=np.float64).astype(np.float32)
     f += (target_rgb - src).astype(np.float32)[None, None, None, :]
     return np.clip(f, 0.0, 255.0).astype(np.uint8)
 


### PR DESCRIPTION
…lowout)

color_match_to_reference computed the clip mean with a float32 reduction over the whole clip (~1e8 samples at 768p/124f), which saturates the 24-bit mantissa: computed mean collapses to ~33.56 vs true ~124.5 at 124 frames. The exposure-lock then shoves every continuation clip ~90 levels brighter, clipping ~19% of pixels to white — the opposite of its job.

Not caught by tests: they run on 8x8 clips (384 rows), far below the ~66M-row saturation threshold.

Fix: compute the mean in float64 (CPU fallback) + a guarded GPU fast-path (_colour_match_gpu, 12.5x faster, 0 LSB vs float64 ground truth). Continuity-guarded; hard-cut path untouched.

STANDALONE-VERIFIED ONLY: GPU/CPU paths bit-exact vs float64 truth, seam unit tests pass, 25-clip no-ratchet sim OK. NOT yet verified end-to-end through _run_channel (reactor_runtime not installed on this node) — needs a serving-node pass before merge.