### PR TITLE
Add the Open-Oasis interactive world model

### DIFF
--- a/models/open-oasis/.dockerignore
+++ b/models/open-oasis/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+tests/
+test_outputs/
+*.pyc

--- a/models/open-oasis/README.md
+++ b/models/open-oasis/README.md
@@ -1,0 +1,177 @@
+# Play Open-Oasis through Reactor Runtime
+
+Run the public [Open-Oasis](https://github.com/etched-ai/open-oasis) 500M
+autoregressive Minecraft model as an interactive Reactor backend. A client can
+start from an uploaded image, consecutive frames from an uploaded video, or the
+built-in upstream scene; hold native keyboard and mouse controls; apply camera
+motion; stream generated video; and record the session.
+
+The adapter checks out an exact tested Open-Oasis revision in the generated
+model image and calls its released sampler directly.
+
+## Prerequisites
+
+- The [`reactor` CLI](https://docs.reactor.inc/platform/installation) and
+  Docker.
+- An NVIDIA GPU, NVIDIA driver, and NVIDIA Container Toolkit. CPU inference is
+  unsupported. The recipe requests one B200, although the 500M checkpoint can
+  share a sufficiently large GPU with other services.
+- About 5 GB in Reactor's persistent weights cache for the model and VAE
+  checkpoints, plus Docker image and build-cache space for CUDA dependencies.
+
+## Run
+
+This directory is a `reactor` workspace. `reactor.yaml` declares the model,
+Reactor Runtime, CUDA and Python versions, system packages, Python dependencies,
+recording, persistent weights directory, and the pinned upstream checkout. The
+CLI generates the complete serving image from that manifest; this recipe does
+not contain or require a Dockerfile. See Reactor's
+[build configuration](https://docs.reactor.inc/platform/build) for the
+supported YAML fields.
+
+Validate the workspace, build the generated image, and expose one GPU to the
+container:
+
+```sh
+cd models/open-oasis
+reactor validate
+reactor build
+reactor run --gpus device=0
+```
+
+`--gpus device=4` selects host GPU 4 and presents it as device 0 inside the
+container. `reactor run` reuses the image from `reactor build` and builds it
+automatically when the local tag is missing. Run `reactor build` again after
+changing adapter code, dependencies, or `reactor.yaml`.
+
+The first startup downloads the pinned model and VAE checkpoints. Later starts
+reuse them from the CLI-mounted weights cache. Set `HF_KEY` when the Hugging Face
+environment requires authentication and forward it without placing its value on
+the command line:
+
+```sh
+export HF_KEY=hf_your_read_token
+reactor run --gpus device=0 -e HF_KEY
+```
+
+The default endpoint is `http://localhost:8080`. Pass `--port` to use another
+port:
+
+```sh
+reactor run --gpus device=0 --port 18098 -e HF_KEY
+```
+
+Connect from the [Reactor Sandbox](https://reactor-sandbox.vercel.app/) using
+**Local (Direct)**, or check readiness and the generated contract directly:
+
+```sh
+curl -fsS http://localhost:8080/health
+curl -fsS http://localhost:8080/schema
+```
+
+## Controls
+
+Generation waits for `set_image`, `set_video`, or `random_scene`; connecting
+never selects a default image.
+
+- `set_key_state(key, pressed)` holds or releases `w`, `a`, `s`, `d`, `space`,
+  `shift`, `ctrl`, `e`, `escape`, `f`, `q`, or hotbar keys `1`-`9`.
+- `set_mouse_button_state(button, pressed)` holds or releases `left`, `right`,
+  or `middle`.
+- `mouse_move(camera_x, camera_y)` adds normalized camera movement for the next
+  generated frame.
+- `release_controls` releases every held key and mouse button and discards
+  queued camera movement.
+- `set_image(image)` starts a fresh rollout from one uploaded Minecraft frame.
+- `set_video(video, offset, prompt_frames)` starts from 1-32 consecutive frames
+  of an uploaded video.
+- `random_scene` explicitly selects the official upstream sample image.
+- `reset(seed)` restarts the selected context and optionally replaces the seed.
+
+Keyboard keys and mouse buttons remain held until released. Camera movement is
+consumed after one generated frame. A press followed by a release before the
+next inference boundary is retained as a one-frame pulse, so short browser input
+is not lost while inference is running. Resetting or selecting new visual
+context clears all controls.
+
+## Starting context
+
+`set_image` uses Reactor's upload protocol and accepts a decodable `image/*`
+file. EXIF orientation is applied before the image is resized to Open-Oasis's
+native 640x360 frame shape.
+
+`set_video` accepts a decodable `video/*` upload and selects consecutive source
+frames beginning at `offset`. The upload must contain at least
+`offset + prompt_frames` frames. Supplying multiple frames preserves the model's
+released video-conditioning path and gives the initial causal window motion
+history that a single image cannot provide.
+
+Open-Oasis has no text encoder or prompt-conditioned inference path. The Reactor
+contract therefore exposes image and video uploads but does not invent a text
+prompt input. Uploaded context is discarded when the viewer disconnects, so a
+new connection waits for its own upload or an explicit `random_scene` command.
+
+## Runtime boundary
+
+Open-Oasis is an autoregressive video world model. Each Reactor inference turn
+samples and emits exactly one new RGB frame while retaining the generated visual
+history and aligned 25-dimensional VPT action history for the next turn. The
+output queue holds one complete one-frame turn, keeping command-to-frame latency
+bounded.
+
+The released 500M sampler does not expose an incremental transformer KV cache.
+For fidelity, each turn uses its native bounded causal window of up to 32 latent
+frames and actions. The adapter preserves the upstream DDIM schedule,
+stabilization step, latent scaling, noise clamp, and VAE path instead of
+substituting a different cache implementation.
+
+Model reset and per-frame sampling run in worker threads so the asynchronous
+Reactor command loop remains responsive during GPU inference. Image and video
+decoding also run outside that loop. Commands received while one frame is being
+generated are sampled by a subsequent frame.
+
+## Model messages
+
+Every accepted command returns its own typed result and broadcasts a complete
+`state_update` snapshot:
+
+- `action_changed` reports held keys, held mouse buttons, and camera movement
+  queued for the next frame.
+- `conditioning_changed` reports the selected context source, filename or
+  built-in identifier, and accepted prompt-frame count.
+- `rollout_reset` reports the selected seed and retained starting context.
+- `state_update` reports the complete shared controls, seed, and context
+  selection. A joining viewer receives the same snapshot immediately.
+
+Message delivery remains outside the model's blocking inference work.
+
+## Public source and model assets
+
+`open_oasis.yaml` pins the upstream source and Hugging Face checkpoint
+revisions. The YAML-generated image installs the source under `/opt/open-oasis`.
+The model and VAE checkpoints remain outside the image in
+`runtime.weights_path`; Reactor mounts that path at the same absolute location
+inside the container and exports it as `REACTOR_WEIGHTS_PATH`.
+
+The checked-in configuration stores persistent assets under
+`/opt/dlami/nvme/.cache_hf/reactor_registry/open-oasis/weights`. Change
+`runtime.weights_path` before building when another host volume should own the
+checkpoints. Docker image layers and build cache are managed by the host Docker
+daemon separately; configure Docker's data root on a large volume when the
+system disk is constrained.
+
+## Recording
+
+`reactor.yaml` records `main_video` as H.264 in four-second chunks and allows
+clips up to five minutes. The model emits video without generated audio.
+
+## Notes
+
+- `inference.context_frames: 32` preserves the released model's default causal
+  memory window.
+- `inference.ddim_steps: 10` preserves the released sampling schedule.
+- Selecting the same starting context and seed reproduces the same initial
+  rollout conditions; later actions determine the generated trajectory.
+- Ending a session releases controls and uploaded context while retaining loaded
+  model weights for the next session.
+- Stop `reactor run` to remove the container and release its GPU memory.

--- a/models/open-oasis/README.md
+++ b/models/open-oasis/README.md
@@ -125,10 +125,10 @@ frames and actions. The adapter preserves the upstream DDIM schedule,
 stabilization step, latent scaling, noise clamp, and VAE path instead of
 substituting a different cache implementation.
 
-Model reset and per-frame sampling run in worker threads so the asynchronous
-Reactor command loop remains responsive during GPU inference. Image and video
-decoding also run outside that loop. Commands received while one frame is being
-generated are sampled by a subsequent frame.
+Model reset and per-frame sampling use Reactor's synchronous inference boundary,
+matching the other cookbook world-model adapters. Image and video decoding run
+outside the asynchronous command loop so upload preparation does not delay
+unrelated commands. Controls are sampled at the start of each generated frame.
 
 ## Model messages
 

--- a/models/open-oasis/open_oasis.py
+++ b/models/open-oasis/open_oasis.py
@@ -1,0 +1,483 @@
+"""Serve the original Open-Oasis 500M sampler as a playable Reactor world."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+import numpy as np
+from open_oasis_assets import (
+    decode_image,
+    decode_video,
+    download_checkpoints,
+    prepare_source,
+    read_config,
+)
+from open_oasis_backend import OpenOasisBackend
+from open_oasis_types import (
+    KEYS,
+    MOUSE_BUTTONS,
+    ActionChanged,
+    ConditioningChanged,
+    OpenOasisConfig,
+    OpenOasisOutput,
+    OpenOasisState,
+    RolloutReset,
+    StateUpdate,
+)
+from reactor_runtime import (
+    ClientInfo,
+    CommandError,
+    InputField,
+    ReactorPipeline,
+    UploadedFile,
+    connected,
+    disconnected,
+    event,
+    session_ended,
+    session_started,
+)
+from reactor_runtime.log import get_logger
+
+logger = get_logger(__name__)
+_KEY_ACTION = {
+    "e": "inventory",
+    "escape": "ESC",
+    **{str(i): f"hotbar.{i}" for i in range(1, 10)},
+    "w": "forward",
+    "s": "back",
+    "a": "left",
+    "d": "right",
+    "space": "jump",
+    "shift": "sneak",
+    "ctrl": "sprint",
+    "f": "swapHands",
+    "q": "drop",
+}
+_MOUSE_ACTION = {"left": "attack", "right": "use", "middle": "pickItem"}
+_ACTION_KEYS = [
+    "inventory",
+    "ESC",
+    *[f"hotbar.{i}" for i in range(1, 10)],
+    "forward",
+    "back",
+    "left",
+    "right",
+    "cameraX",
+    "cameraY",
+    "jump",
+    "sneak",
+    "sprint",
+    "swapHands",
+    "attack",
+    "use",
+    "pickItem",
+    "drop",
+]
+_IMAGE_FIELD = InputField(
+    moderate=True,
+    description=(
+        "Minecraft starting frame uploaded through Reactor's file-upload flow. The file "
+        "must have an `image/*` media type and decode successfully; EXIF orientation is "
+        "applied before it is resized to 640x360. It replaces the previous image or video "
+        "context at the next inference boundary."
+    ),
+)
+_VIDEO_FIELD = InputField(
+    moderate=True,
+    description=(
+        "Minecraft visual context uploaded through Reactor's file-upload flow. The file "
+        "must have a `video/*` media type and contain every frame requested by `offset` and "
+        "`prompt_frames`; accepted frames replace the previous context at the next inference "
+        "boundary."
+    ),
+)
+
+
+class OpenOasis(ReactorPipeline):
+    """Generate one action-conditioned Minecraft frame per model step."""
+
+    state: OpenOasisState
+    buffer_size = 1
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config: OpenOasisConfig | None = None
+        self._backend: OpenOasisBackend | None = None
+        self._source: Path | None = None
+        self._conditioning: np.ndarray | None = None
+        self._conditioning_name = "none"
+
+    def load(self, config_path: Path | None) -> None:
+        config = read_config(config_path)
+        source = prepare_source(config)
+        model_path, vae_path = download_checkpoints(config)
+        self._config = config
+        self._source = source
+        self._backend = OpenOasisBackend(config, model_path, vae_path)
+        logger.info(
+            "Open-Oasis ready",
+            revision=config.source_revision,
+            ddim_steps=config.ddim_steps,
+            context_frames=config.context_frames,
+        )
+
+    @session_started
+    def on_session_started(self) -> None:
+        if self._config is None:
+            raise RuntimeError("Open-Oasis was not loaded")
+        self.state._seed = self._config.seed
+        self.state._reset_requested = True
+        self._conditioning = None
+        self._conditioning_name = "none"
+        self._clear_controls()
+
+    @connected
+    async def on_connected(self, client: ClientInfo) -> None:
+        await client.send(self._state_update())
+
+    @disconnected
+    async def on_disconnected(self) -> None:
+        """Discard viewer-owned visual context and controls after disconnect."""
+        self.output.flush()
+        self._conditioning = None
+        self._conditioning_name = "none"
+        self.state._reset_requested = True
+        self._clear_controls()
+        await self.send(self._state_update())
+
+    @session_ended
+    def on_session_ended(self) -> None:
+        self._conditioning = None
+        self._conditioning_name = "none"
+        self.state._reset_requested = True
+        self._clear_controls()
+
+    @event(
+        name="set_key_state",
+        description=(
+            "Hold or release one Minecraft keyboard key for subsequent frames. Valid while "
+            "the session is active; a newly pressed key is also preserved for one frame if it "
+            "is released before inference samples it. Emits `action_changed` and broadcasts "
+            "`state_update`. Unsupported values are rejected before state changes."
+        ),
+    )
+    async def set_key_state(
+        self,
+        key: str = InputField(
+            default="w",
+            choices=KEYS,
+            description=(
+                "Minecraft keyboard key to hold or release. WASD moves; `space` jumps; `shift` "
+                "sneaks; `ctrl` sprints; `e` opens inventory; `escape` pauses; `f` swaps "
+                "hands; `q` drops; and 1-9 selects a hotbar slot. The state starts with the "
+                "next generated frame and persists until another `set_key_state` changes it "
+                "or controls are cleared."
+            ),
+        ),
+        pressed: bool = InputField(
+            default=True,
+            description=(
+                "Set true to hold `key` on subsequent generated frames or false to release it."
+            ),
+        ),
+    ) -> ActionChanged:
+        if pressed and key not in self.state._pressed_keys:
+            self.state._pending_key_pulses = self.state._pending_key_pulses.union(
+                (key,)
+            )
+        self.state._pressed_keys = (
+            self.state._pressed_keys.union((key,))
+            if pressed
+            else self.state._pressed_keys.difference((key,))
+        )
+        await self.send(self._state_update())
+        return self._action_changed()
+
+    @event(
+        name="set_mouse_button_state",
+        description=(
+            "Hold or release one Minecraft mouse button for subsequent frames. Valid while "
+            "the session is active; a newly pressed button is also preserved for one frame if "
+            "it is released before inference samples it. Emits `action_changed` and broadcasts "
+            "`state_update`. Unsupported values are rejected before state changes."
+        ),
+    )
+    async def set_mouse_button_state(
+        self,
+        button: str = InputField(
+            default="left",
+            choices=MOUSE_BUTTONS,
+            description=(
+                "Minecraft mouse button to hold or release: `left` attacks, `right` uses, and "
+                "`middle` picks the targeted item. The state starts with the next generated "
+                "frame and persists until another `set_mouse_button_state` changes it or "
+                "controls are cleared."
+            ),
+        ),
+        pressed: bool = InputField(
+            default=True,
+            description=(
+                "Set true to hold `button` on subsequent generated frames or false to release "
+                "it."
+            ),
+        ),
+    ) -> ActionChanged:
+        if pressed and button not in self.state._pressed_mouse_buttons:
+            self.state._pending_mouse_pulses = self.state._pending_mouse_pulses.union(
+                (button,)
+            )
+        self.state._pressed_mouse_buttons = (
+            self.state._pressed_mouse_buttons.union((button,))
+            if pressed
+            else self.state._pressed_mouse_buttons.difference((button,))
+        )
+        await self.send(self._state_update())
+        return self._action_changed()
+
+    @event(
+        name="mouse_move",
+        description=(
+            "Queue normalized camera movement for the next generated frame. Valid while the "
+            "session is active; calls before that frame accumulate and clamp each axis to "
+            "[-1, 1], and movement is consumed after one frame. Emits `action_changed` and "
+            "broadcasts `state_update`. Out-of-range values are rejected before state changes."
+        ),
+    )
+    async def mouse_move(
+        self,
+        camera_x: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Relative horizontal camera movement in [-1, 1] to add to the next generated "
+                "frame. Negative turns left, positive turns right, and repeated calls "
+                "accumulate and clamp to that range."
+            ),
+        ),
+        camera_y: float = InputField(
+            default=0.0,
+            ge=-1.0,
+            le=1.0,
+            description=(
+                "Relative vertical camera movement in [-1, 1] to add to the next generated "
+                "frame. Negative and positive move pitch in opposite trained directions; "
+                "repeated calls accumulate and clamp to that range."
+            ),
+        ),
+    ) -> ActionChanged:
+        self.state._camera_x = float(np.clip(self.state._camera_x + camera_x, -1, 1))
+        self.state._camera_y = float(np.clip(self.state._camera_y + camera_y, -1, 1))
+        await self.send(self._state_update())
+        return self._action_changed()
+
+    @event(
+        name="release_controls",
+        description=(
+            "Release every held keyboard key and mouse button and discard queued camera "
+            "movement. Valid while the session is active and takes effect on the next generated "
+            "frame. Emits `action_changed` and broadcasts `state_update`."
+        ),
+    )
+    async def release_controls(self) -> ActionChanged:
+        self._clear_controls()
+        await self.send(self._state_update())
+        return self._action_changed()
+
+    @event(
+        name="set_image",
+        description=(
+            "Select an uploaded Minecraft image as the starting frame for a fresh rollout. "
+            "Valid any time during a session; the image replaces prior causal context at the "
+            "next inference boundary and clears all controls. Emits `conditioning_changed` and "
+            "broadcasts `state_update` on success, or `command_error` when the upload is "
+            "mislabeled or undecodable."
+        ),
+    )
+    async def set_image(
+        self,
+        image: UploadedFile = _IMAGE_FIELD,
+    ) -> ConditioningChanged:
+        if not image.mime_type.startswith("image/"):
+            raise CommandError(
+                "unsupported_media", "set_image requires an image upload"
+            )
+        try:
+            self._conditioning = await asyncio.to_thread(decode_image, image.data)
+        except (OSError, ValueError) as error:
+            raise CommandError("invalid_image", str(error)) from error
+        return await self._select_conditioning("image", image.name)
+
+    @event(
+        name="set_video",
+        description=(
+            "Select consecutive frames from an uploaded video as the starting context for a "
+            "fresh rollout. Valid any time during a session; the frames replace prior causal "
+            "context at the next inference boundary and clear all controls. Emits "
+            "`conditioning_changed` and broadcasts `state_update` on success, or "
+            "`command_error` when the upload is mislabeled, undecodable, or too short."
+        ),
+    )
+    async def set_video(
+        self,
+        video: UploadedFile = _VIDEO_FIELD,
+        offset: int = InputField(
+            default=0,
+            ge=0,
+            description=(
+                "Zero-based source frame at which the consecutive starting context begins. "
+                "Applied when `set_video` queues the fresh rollout."
+            ),
+        ),
+        prompt_frames: int = InputField(
+            default=1,
+            ge=1,
+            le=32,
+            description=(
+                "Number of consecutive source frames to use as starting context, from 1 "
+                "through 32. The upload must contain at least `offset + prompt_frames` frames."
+            ),
+        ),
+    ) -> ConditioningChanged:
+        if not video.mime_type.startswith("video/"):
+            raise CommandError("unsupported_media", "set_video requires a video upload")
+        try:
+            self._conditioning = await asyncio.to_thread(
+                decode_video, video, offset, prompt_frames
+            )
+        except (OSError, RuntimeError, ValueError) as error:
+            raise CommandError("invalid_video", str(error)) from error
+        return await self._select_conditioning("video", video.name)
+
+    @event(
+        name="random_scene",
+        description=(
+            "Select the built-in Open-Oasis Minecraft sample as the starting frame for a fresh "
+            "rollout. Valid any time during a session; it replaces uploaded context at the next "
+            "inference boundary and clears all controls. Emits `conditioning_changed` and "
+            "broadcasts `state_update` on success."
+        ),
+    )
+    async def random_scene(self) -> ConditioningChanged:
+        assert self._source is not None
+        self._conditioning = await asyncio.to_thread(
+            decode_image,
+            (self._source / "sample_data/sample_image_0.png").read_bytes(),
+        )
+        return await self._select_conditioning("built_in", "official_sample")
+
+    @event(
+        name="reset",
+        description=(
+            "Restart the selected starting context. Valid any time during a session; the reset "
+            "takes effect at the next inference boundary and clears all controls. Emits "
+            "`rollout_reset` and broadcasts `state_update` on success; out-of-range seeds are "
+            "rejected before state changes. If no context is selected, the model remains idle "
+            "until `set_image`, `set_video`, or `random_scene` supplies one."
+        ),
+    )
+    async def reset(
+        self,
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description=(
+                "Random seed for the restarted rollout in [-1, 2147483647]. Use -1 to retain "
+                "the current seed; a non-negative value replaces it when the reset is queued."
+            ),
+        ),
+    ) -> RolloutReset:
+        if seed >= 0:
+            self.state._seed = seed
+        self._queue_reset()
+        await self.send(self._state_update())
+        return RolloutReset(seed=self.state._seed, conditioning=self._conditioning_name)
+
+    async def inference(self) -> AsyncGenerator[OpenOasisOutput | None, None]:
+        if self._backend is None:
+            raise RuntimeError("Open-Oasis was not loaded")
+        while True:
+            if self._conditioning is None:
+                yield None
+                continue
+            if self.state._reset_requested:
+                await asyncio.to_thread(
+                    self._backend.reset,
+                    self._conditioning,
+                    self.state._seed,
+                )
+                self.state._reset_requested = False
+                yield OpenOasisOutput(
+                    main_video=np.ascontiguousarray(self._conditioning[-1])
+                )
+                continue
+            action = self._build_action()
+            # Consume only pulses included in this snapshot. Commands arriving while the
+            # worker generates are latched for the following frame.
+            self.state._pending_key_pulses = frozenset()
+            self.state._pending_mouse_pulses = frozenset()
+            frame = await asyncio.to_thread(self._backend.generate_one, action)
+            self.state._camera_x = self.state._camera_y = 0.0
+            yield OpenOasisOutput(main_video=np.ascontiguousarray(frame))
+
+    async def _select_conditioning(self, source: str, name: str) -> ConditioningChanged:
+        self._conditioning_name = name
+        self._queue_reset()
+        await self.send(self._state_update())
+        assert self._conditioning is not None
+        return ConditioningChanged(
+            source=source, selection=name, prompt_frames=len(self._conditioning)
+        )
+
+    def _queue_reset(self) -> None:
+        self.output.flush()
+        self.state._reset_requested = True
+        self._clear_controls()
+
+    def _clear_controls(self) -> None:
+        self.state._pressed_keys = frozenset()
+        self.state._pressed_mouse_buttons = frozenset()
+        self.state._pending_key_pulses = frozenset()
+        self.state._pending_mouse_pulses = frozenset()
+        self.state._camera_x = self.state._camera_y = 0.0
+
+    def _build_action(self) -> np.ndarray:
+        values = np.zeros(25, dtype=np.float32)
+        for key in self.state._pressed_keys.union(self.state._pending_key_pulses):
+            values[_ACTION_KEYS.index(_KEY_ACTION[key])] = 1
+        for button in self.state._pressed_mouse_buttons.union(
+            self.state._pending_mouse_pulses
+        ):
+            values[_ACTION_KEYS.index(_MOUSE_ACTION[button])] = 1
+        values[_ACTION_KEYS.index("cameraX")] = self.state._camera_x
+        values[_ACTION_KEYS.index("cameraY")] = self.state._camera_y
+        return values
+
+    def _action_changed(self) -> ActionChanged:
+        return ActionChanged(
+            pressed_keys=[key for key in KEYS if key in self.state._pressed_keys],
+            pressed_mouse_buttons=[
+                button
+                for button in MOUSE_BUTTONS
+                if button in self.state._pressed_mouse_buttons
+            ],
+            camera_x=self.state._camera_x,
+            camera_y=self.state._camera_y,
+        )
+
+    def _state_update(self) -> StateUpdate:
+        return StateUpdate(
+            pressed_keys=[key for key in KEYS if key in self.state._pressed_keys],
+            pressed_mouse_buttons=[
+                button
+                for button in MOUSE_BUTTONS
+                if button in self.state._pressed_mouse_buttons
+            ],
+            camera_x=self.state._camera_x,
+            camera_y=self.state._camera_y,
+            seed=self.state._seed,
+            conditioning=self._conditioning_name,
+        )

--- a/models/open-oasis/open_oasis.py
+++ b/models/open-oasis/open_oasis.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import Iterator
 from pathlib import Path
 
 import numpy as np
@@ -396,7 +396,7 @@ class OpenOasis(ReactorPipeline):
         await self.send(self._state_update())
         return RolloutReset(seed=self.state._seed, conditioning=self._conditioning_name)
 
-    async def inference(self) -> AsyncGenerator[OpenOasisOutput | None, None]:
+    def inference(self) -> Iterator[OpenOasisOutput | None]:
         if self._backend is None:
             raise RuntimeError("Open-Oasis was not loaded")
         while True:
@@ -404,22 +404,17 @@ class OpenOasis(ReactorPipeline):
                 yield None
                 continue
             if self.state._reset_requested:
-                await asyncio.to_thread(
-                    self._backend.reset,
-                    self._conditioning,
-                    self.state._seed,
-                )
+                self._backend.reset(self._conditioning, self.state._seed)
                 self.state._reset_requested = False
                 yield OpenOasisOutput(
                     main_video=np.ascontiguousarray(self._conditioning[-1])
                 )
                 continue
             action = self._build_action()
-            # Consume only pulses included in this snapshot. Commands arriving while the
-            # worker generates are latched for the following frame.
+            # Consume only pulses included in this inference snapshot.
             self.state._pending_key_pulses = frozenset()
             self.state._pending_mouse_pulses = frozenset()
-            frame = await asyncio.to_thread(self._backend.generate_one, action)
+            frame = self._backend.generate_one(action)
             self.state._camera_x = self.state._camera_y = 0.0
             yield OpenOasisOutput(main_video=np.ascontiguousarray(frame))
 

--- a/models/open-oasis/open_oasis.yaml
+++ b/models/open-oasis/open_oasis.yaml
@@ -1,0 +1,13 @@
+source:
+  path: /opt/open-oasis
+  revision: f59deef2c019c212bd0c5a3a5b986a51f3701847
+checkpoint:
+  repo_id: Etched/oasis-500m
+  revision: 4ca7d2d811f4f0c6fd1d5719bf83f14af3446c0c
+  model_filename: oasis500m.safetensors
+  vae_filename: vit-l-20.safetensors
+inference:
+  seed: 0
+  ddim_steps: 10
+  context_frames: 32
+  fps: 20

--- a/models/open-oasis/open_oasis_assets.py
+++ b/models/open-oasis/open_oasis_assets.py
@@ -1,0 +1,103 @@
+"""Pinned source, checkpoints, and uploaded visual conditioning."""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import yaml
+from open_oasis_types import OpenOasisConfig
+from PIL import Image, ImageOps
+from reactor_runtime import UploadedFile, get_weights_path
+
+
+def read_config(path: Path | None) -> OpenOasisConfig:
+    if path is None:
+        raise ValueError("Open-Oasis requires open_oasis.yaml")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return OpenOasisConfig(
+        source_path=os.environ.get(
+            "OPEN_OASIS_PATH",
+            os.path.expandvars(str(raw["source"]["path"])),
+        ),
+        source_revision=str(raw["source"]["revision"]),
+        checkpoint_repo_id=str(raw["checkpoint"]["repo_id"]),
+        checkpoint_revision=str(raw["checkpoint"]["revision"]),
+        model_filename=str(raw["checkpoint"]["model_filename"]),
+        vae_filename=str(raw["checkpoint"]["vae_filename"]),
+        seed=int(raw["inference"]["seed"]),
+        ddim_steps=int(raw["inference"]["ddim_steps"]),
+        context_frames=int(raw["inference"]["context_frames"]),
+        fps=float(raw["inference"]["fps"]),
+    )
+
+
+def prepare_source(config: OpenOasisConfig) -> Path:
+    root = Path(config.source_path)
+    if not (root / ".git").exists():
+        root.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "clone", "https://github.com/etched-ai/open-oasis.git", str(root)],
+            check=True,
+        )
+    revision = subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", "HEAD"], text=True
+    ).strip()
+    if revision != config.source_revision:
+        raise RuntimeError(
+            f"Open-Oasis source revision {revision} does not match pinned {config.source_revision}"
+        )
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    return root
+
+
+def download_checkpoints(config: OpenOasisConfig) -> tuple[Path, Path]:
+    from huggingface_hub import hf_hub_download
+
+    cache = get_weights_path() / "huggingface"
+    cache.mkdir(parents=True, exist_ok=True)
+    kwargs = {
+        "repo_id": config.checkpoint_repo_id,
+        "revision": config.checkpoint_revision,
+        "cache_dir": cache,
+        "token": os.environ.get("HF_KEY"),
+    }
+    return (
+        Path(hf_hub_download(filename=config.model_filename, **kwargs)),
+        Path(hf_hub_download(filename=config.vae_filename, **kwargs)),
+    )
+
+
+def decode_image(data: bytes) -> np.ndarray:
+    with Image.open(io.BytesIO(data)) as image:
+        image = (
+            ImageOps.exif_transpose(image)
+            .convert("RGB")
+            .resize((640, 360), Image.Resampling.BILINEAR)
+        )
+        return np.asarray(image, dtype=np.uint8)[None]
+
+
+def decode_video(upload: UploadedFile, offset: int, count: int) -> np.ndarray:
+    from torchvision.io import read_video
+
+    suffix = Path(upload.name).suffix or ".mp4"
+    with tempfile.NamedTemporaryFile(suffix=suffix) as handle:
+        handle.write(upload.data)
+        handle.flush()
+        frames = read_video(handle.name, pts_unit="sec", output_format="TCHW")[0]
+    frames = frames[offset : offset + count]
+    if len(frames) != count:
+        raise ValueError(f"video contains fewer than {offset + count} frames")
+    from torch.nn import functional
+
+    frames = functional.interpolate(
+        frames.float(), size=(360, 640), mode="bilinear", align_corners=False
+    )
+    return frames.clamp(0, 255).byte().permute(0, 2, 3, 1).cpu().numpy()

--- a/models/open-oasis/open_oasis_backend.py
+++ b/models/open-oasis/open_oasis_backend.py
@@ -1,0 +1,129 @@
+"""Faithful one-frame sampler built from the pinned Open-Oasis implementation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from open_oasis_types import OpenOasisConfig
+
+SCALING_FACTOR = 0.07843137255
+
+
+class OpenOasisBackend:
+    def __init__(
+        self, config: OpenOasisConfig, model_path: Path, vae_path: Path
+    ) -> None:
+        import torch
+        from dit import DiT_models
+        from safetensors.torch import load_model
+        from utils import sigmoid_beta_schedule
+        from vae import VAE_models
+
+        if not torch.cuda.is_available():
+            raise RuntimeError("Open-Oasis requires CUDA")
+        self.torch = torch
+        self.config = config
+        self.device = torch.device("cuda:0")
+        self.model = DiT_models["DiT-S/2"]()
+        load_model(self.model, str(model_path))
+        self.model.to(self.device).eval()
+        self.vae = VAE_models["vit-l-20-shallow-encoder"]()
+        load_model(self.vae, str(vae_path))
+        self.vae.to(self.device).eval()
+        betas = sigmoid_beta_schedule(1000).float().to(self.device)
+        self.alphas_cumprod = torch.cumprod(1.0 - betas, dim=0).reshape(1000, 1, 1, 1)
+        self.noise_range = torch.linspace(
+            -1, 999, config.ddim_steps + 1, device=self.device
+        )
+        self.latents: Any = None
+        self.actions: Any = None
+        self.generator: Any = None
+
+    def reset(self, frames: np.ndarray, seed: int) -> None:
+        torch = self.torch
+        tensor = (
+            torch.from_numpy(np.array(frames, copy=True))
+            .to(self.device)
+            .permute(0, 3, 1, 2)
+            .float()
+            .div(255)
+        )
+        with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+            latent = self.vae.encode(tensor * 2 - 1).mean * SCALING_FACTOR
+        h, w = tensor.shape[-2:]
+        self.latents = (
+            latent.reshape(
+                1, len(frames), h // self.vae.patch_size, w // self.vae.patch_size, -1
+            )
+            .permute(0, 1, 4, 2, 3)
+            .contiguous()
+        )
+        self.actions = torch.zeros((1, len(frames), 25), device=self.device)
+        self.generator = torch.Generator(device=self.device).manual_seed(seed)
+
+    def generate_one(self, action: np.ndarray) -> np.ndarray:
+        torch = self.torch
+        if self.latents is None:
+            raise RuntimeError("Open-Oasis context is not initialized")
+        next_action = torch.from_numpy(action).to(self.device).reshape(1, 1, 25)
+        self.actions = torch.cat((self.actions, next_action), dim=1)
+        noise = torch.randn(
+            (1, 1, *self.latents.shape[-3:]),
+            generator=self.generator,
+            device=self.device,
+        ).clamp(-20, 20)
+        self.latents = torch.cat((self.latents, noise), dim=1)
+
+        for noise_idx in reversed(range(1, self.config.ddim_steps + 1)):
+            length = self.latents.shape[1]
+            t_ctx = torch.full(
+                (1, length - 1), 14, dtype=torch.long, device=self.device
+            )
+            t_last = torch.full(
+                (1, 1),
+                self.noise_range[noise_idx],
+                dtype=torch.long,
+                device=self.device,
+            )
+            t_next_last = torch.full(
+                (1, 1),
+                self.noise_range[noise_idx - 1],
+                dtype=torch.long,
+                device=self.device,
+            )
+            t_next_last = torch.where(t_next_last < 0, t_last, t_next_last)
+            t = torch.cat((t_ctx, t_last), dim=1)[:, -self.config.context_frames :]
+            t_next = torch.cat((t_ctx, t_next_last), dim=1)[
+                :, -self.config.context_frames :
+            ]
+            current = self.latents[:, -self.config.context_frames :].clone()
+            actions = self.actions[:, -self.config.context_frames :]
+            with torch.inference_mode(), torch.autocast("cuda", dtype=torch.float16):
+                velocity = self.model(current, t, actions)
+            alpha = self.alphas_cumprod[t]
+            start = alpha.sqrt() * current - (1 - alpha).sqrt() * velocity
+            predicted_noise = ((1 / alpha).sqrt() * current - start) / (
+                1 / alpha - 1
+            ).sqrt()
+            alpha_next = self.alphas_cumprod[t_next].clone()
+            alpha_next[:, :-1] = 1
+            if noise_idx == 1:
+                alpha_next[:, -1:] = 1
+            prediction = (
+                alpha_next.sqrt() * start + predicted_noise * (1 - alpha_next).sqrt()
+            )
+            self.latents[:, -1:] = prediction[:, -1:]
+
+        latent = (
+            self.latents[:, -1]
+            .permute(0, 2, 3, 1)
+            .reshape(1, -1, self.latents.shape[2])
+        )
+        # Upstream decodes in float32 (unlike its half-precision encoder and DiT).
+        with torch.inference_mode():
+            frame = (self.vae.decode(latent / SCALING_FACTOR) + 1) / 2
+        self.latents = self.latents[:, -self.config.context_frames :]
+        self.actions = self.actions[:, -self.config.context_frames :]
+        return frame[0].clamp(0, 1).mul(255).byte().permute(1, 2, 0).cpu().numpy()

--- a/models/open-oasis/open_oasis_types.py
+++ b/models/open-oasis/open_oasis_types.py
@@ -1,0 +1,175 @@
+"""Public Reactor schema and adapter configuration for Open-Oasis."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from reactor_runtime import InputState, MessageField, ModelMessage, Output, Video
+
+KEYS = [
+    "w",
+    "a",
+    "s",
+    "d",
+    "space",
+    "shift",
+    "ctrl",
+    "e",
+    "escape",
+    "f",
+    "q",
+    "1",
+    "2",
+    "3",
+    "4",
+    "5",
+    "6",
+    "7",
+    "8",
+    "9",
+]
+MOUSE_BUTTONS = ["left", "right", "middle"]
+
+
+@dataclass(frozen=True)
+class OpenOasisConfig:
+    source_path: str
+    source_revision: str
+    checkpoint_repo_id: str
+    checkpoint_revision: str
+    model_filename: str
+    vae_filename: str
+    seed: int
+    ddim_steps: int
+    context_frames: int
+    fps: float
+
+
+class OpenOasisOutput(Output):
+    """Stream exactly one newly generated Minecraft frame on `main_video`."""
+
+    main_video: Video
+
+
+class ActionChanged(ModelMessage):
+    """Emitted after a player-control command updates the shared input state."""
+
+    pressed_keys: list[str] = MessageField(
+        description=(
+            "Keyboard keys held after the command is processed. Each key applies to every "
+            "generated frame until `set_key_state` releases it or another command clears "
+            "controls."
+        )
+    )
+    pressed_mouse_buttons: list[str] = MessageField(
+        description=(
+            "Mouse buttons held after the command is processed. Each button applies to every "
+            "generated frame until `set_mouse_button_state` releases it or another command "
+            "clears controls."
+        )
+    )
+    camera_x: float = MessageField(
+        description=(
+            "Accumulated horizontal camera movement queued for the next generated frame, from "
+            "-1 to 1. It returns to zero after that frame is sampled."
+        )
+    )
+    camera_y: float = MessageField(
+        description=(
+            "Accumulated vertical camera movement queued for the next generated frame, from -1 "
+            "to 1. It returns to zero after that frame is sampled."
+        )
+    )
+
+
+class ConditioningChanged(ModelMessage):
+    """Emitted after a starting-context command queues a fresh rollout."""
+
+    source: str = MessageField(
+        description=(
+            "Starting-context source accepted by the command: `built_in`, `image`, or `video`."
+        )
+    )
+    selection: str = MessageField(
+        description=(
+            "Built-in sample identifier or uploaded filename selected for the fresh rollout. "
+            "The selection takes effect at the next inference boundary."
+        )
+    )
+    prompt_frames: int = MessageField(
+        description=(
+            "Number of consecutive visual frames that will initialize the fresh rollout: one "
+            "for `set_image` and `random_scene`, or the accepted `prompt_frames` for `set_video`."
+        )
+    )
+
+
+class RolloutReset(ModelMessage):
+    """Emitted after `reset` queues the selected starting context to restart."""
+
+    seed: int = MessageField(
+        description=(
+            "Random seed selected for the restarted rollout. It is the existing seed when "
+            "`reset.seed` is -1, or the supplied non-negative value otherwise."
+        )
+    )
+    conditioning: str = MessageField(
+        description=(
+            "Built-in sample identifier or uploaded filename retained for the restarted "
+            "rollout, or `none` when no starting context has been selected."
+        )
+    )
+
+
+class StateUpdate(ModelMessage):
+    """Emitted when a viewer connects and after observable Open-Oasis state changes."""
+
+    pressed_keys: list[str] = MessageField(
+        description=(
+            "Keyboard keys currently held for subsequent generated frames. `reset` and "
+            "starting-context commands clear this list."
+        )
+    )
+    pressed_mouse_buttons: list[str] = MessageField(
+        description=(
+            "Mouse buttons currently held for subsequent generated frames. `reset` and "
+            "starting-context commands clear this list."
+        )
+    )
+    camera_x: float = MessageField(
+        description=(
+            "Accumulated horizontal camera movement queued for the next generated frame, from "
+            "-1 to 1; zero means no queued horizontal movement."
+        )
+    )
+    camera_y: float = MessageField(
+        description=(
+            "Accumulated vertical camera movement queued for the next generated frame, from -1 "
+            "to 1; zero means no queued vertical movement."
+        )
+    )
+    seed: int = MessageField(
+        description=(
+            "Random seed selected for the current or queued rollout. A non-negative `seed` "
+            "passed to `reset` replaces it; -1 retains it."
+        )
+    )
+    conditioning: str = MessageField(
+        description=(
+            "Built-in sample identifier or uploaded filename selected for the current or queued "
+            "rollout, or `none` while waiting for `set_image`, `set_video`, or `random_scene`."
+        )
+    )
+
+
+class OpenOasisState(InputState):
+    """Controls shared by one autoregressive Minecraft world."""
+
+    _pressed_keys: frozenset[str] = frozenset()
+    _pressed_mouse_buttons: frozenset[str] = frozenset()
+    _pending_key_pulses: frozenset[str] = frozenset()
+    _pending_mouse_pulses: frozenset[str] = frozenset()
+    _camera_x: float = 0.0
+    _camera_y: float = 0.0
+    _seed: int = 0
+    _reset_requested: bool = True

--- a/models/open-oasis/reactor.yaml
+++ b/models/open-oasis/reactor.yaml
@@ -1,0 +1,37 @@
+$schema: reactor/v2
+model:
+  name: open-oasis-500m
+  version: v0.1.0
+  description: Stream an autoregressive Minecraft world from image or video context using Open-Oasis's native keyboard, mouse-button, and camera actions.
+  resources:
+    gpu: {type: NVIDIA_B200, count: 1}
+    cpu: {request: "4", limit: "12"}
+    memory: {request: 24Gi, limit: 64Gi}
+runtime:
+  import: open_oasis:OpenOasis
+  config: open_oasis.yaml
+  weights_path: /opt/dlami/nvme/.cache_hf/reactor_registry/open-oasis/weights
+  recording:
+    enabled: true
+    chunk_seconds: 4
+    clip_max_seconds: 300
+    video_track: main_video
+    video: {codec: h264, preset: veryfast, crf: 23}
+build:
+  runtime_version: "3.2.5"
+  python_requirements: requirements.txt
+  cuda_version: "12.8.1"
+  python_version: "3.12"
+  python_indexes:
+    - https://download.pytorch.org/whl/cu128
+    - https://pypi.org/simple
+  system_packages: [ffmpeg, git]
+  runtime_env:
+    OPEN_OASIS_PATH: /opt/open-oasis
+  run:
+    - >-
+      git init /opt/open-oasis
+      && git -C /opt/open-oasis fetch --depth 1
+      https://github.com/etched-ai/open-oasis.git
+      f59deef2c019c212bd0c5a3a5b986a51f3701847
+      && git -C /opt/open-oasis checkout --detach FETCH_HEAD

--- a/models/open-oasis/requirements.txt
+++ b/models/open-oasis/requirements.txt
@@ -1,0 +1,11 @@
+av==18.0.0
+diffusers==0.35.1
+einops==0.8.1
+huggingface-hub==0.34.4
+numpy==2.2.6
+pillow==11.3.0
+pyyaml==6.0.3
+safetensors==0.6.2
+torch==2.7.1+cu128
+timm==1.0.19
+torchvision==0.22.1+cu128

--- a/models/open-oasis/tests/test_open_oasis.py
+++ b/models/open-oasis/tests/test_open_oasis.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import sys
-import threading
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -123,7 +122,7 @@ def test_new_connection_waits_and_disconnect_discards_upload() -> None:
 
     assert model._conditioning is None
     assert model._conditioning_name == "none"
-    assert asyncio.run(anext(model.inference())) is None
+    assert next(model.inference()) is None
 
 
 def test_playback_contract_uses_one_frame_chunks_without_explicit_fps() -> None:
@@ -141,30 +140,3 @@ def test_press_and_release_before_sampling_still_produces_one_frame_pulse() -> N
 
     model.state._pending_key_pulses = frozenset()
     assert model._build_action()[11] == 0
-
-
-def test_command_is_processed_while_worker_thread_runs_inference() -> None:
-    class BlockingBackend:
-        def __init__(self) -> None:
-            self.entered = threading.Event()
-            self.release = threading.Event()
-
-        def reset(self, _conditioning, _seed) -> None:
-            self.entered.set()
-            assert self.release.wait(timeout=2)
-
-    async def exercise() -> None:
-        model = ready_model()
-        backend = BlockingBackend()
-        model._backend = backend  # type: ignore[assignment]
-        inference = asyncio.create_task(anext(model.inference()))
-        assert await asyncio.to_thread(backend.entered.wait, 1)
-
-        reply = await asyncio.wait_for(model.set_key_state("w", True), timeout=0.1)
-        assert reply.pressed_keys == ["w"]
-
-        backend.release.set()
-        output = await asyncio.wait_for(inference, timeout=1)
-        assert output is not None
-
-    asyncio.run(exercise())

--- a/models/open-oasis/tests/test_open_oasis.py
+++ b/models/open-oasis/tests/test_open_oasis.py
@@ -1,0 +1,170 @@
+"""Contract, native actions, uploads, and one-frame boundaries for Open-Oasis."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+from reactor_runtime.interface.model.contract import ModelContract
+
+MODEL_DIR = Path(__file__).parents[1]
+sys.path.insert(0, str(MODEL_DIR))
+
+from open_oasis import OpenOasis
+from open_oasis_assets import decode_image
+from open_oasis_types import OpenOasisState
+
+
+def ready_model() -> OpenOasis:
+    model = OpenOasis()
+    model.state = OpenOasisState()
+    model._config = SimpleNamespace(seed=0)
+    model._source = Path("/unused")
+    model._conditioning = np.zeros((1, 360, 640, 3), dtype=np.uint8)
+    model.send = lambda _message: _awaitable()  # type: ignore[method-assign]
+    model.output = SimpleNamespace(flush=lambda: None)
+    return model
+
+
+async def _awaitable() -> None:
+    return None
+
+
+def test_schema_is_complete_and_precise() -> None:
+    contract = ModelContract.of(OpenOasis)
+    assert set(contract.commands) == {
+        "mouse_move",
+        "random_scene",
+        "release_controls",
+        "reset",
+        "set_image",
+        "set_video",
+        "set_key_state",
+        "set_mouse_button_state",
+    }
+    assert all("Emits" in command.description for command in contract.commands.values())
+    assert all(
+        field.info.description
+        for command in contract.commands.values()
+        for field in command.command.__command_fields__.values()
+    )
+    document = contract.render_schema().to_openapi()
+    assert document["x-reactor"]["tracks"] == [
+        {"name": "main_video", "kind": "video", "direction": "out"}
+    ]
+    assert set(document["webhooks"]) == {
+        "action_changed",
+        "conditioning_changed",
+        "rollout_reset",
+        "state_update",
+    }
+    assert (
+        document["paths"]["/events/set_video"]["post"]["requestBody"]["content"][
+            "application/json"
+        ]["schema"]["properties"]["prompt_frames"]["maximum"]
+        == 32
+    )
+
+
+def test_native_actions_cover_all_twenty_five_dimensions() -> None:
+    model = ready_model()
+    model.state._pressed_keys = frozenset({"w", "space", "e", "9"})
+    model.state._pressed_mouse_buttons = frozenset({"left", "right", "middle"})
+    model.state._camera_x = -0.5
+    model.state._camera_y = 0.75
+    action = model._build_action()
+    assert action.shape == (25,)
+    assert np.count_nonzero(action) == 9
+    assert action[15] == -0.5 and action[16] == 0.75
+
+
+def test_camera_accumulates_then_release_clears_everything() -> None:
+    model = ready_model()
+    asyncio.run(model.set_key_state("w", True))
+    asyncio.run(model.mouse_move(0.75, -0.8))
+    reply = asyncio.run(model.mouse_move(0.75, -0.8))
+    assert reply.camera_x == 1 and reply.camera_y == -1
+    released = asyncio.run(model.release_controls())
+    assert released.pressed_keys == [] and released.camera_x == 0
+
+
+def test_uploaded_image_is_rgb_native_resolution() -> None:
+    import io
+
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new("RGBA", (40, 20), (2, 4, 8, 128)).save(buffer, format="PNG")
+    frame = decode_image(buffer.getvalue())
+    assert frame.shape == (1, 360, 640, 3)
+    assert frame.dtype == np.uint8
+
+
+def test_conditioning_upload_is_moderated() -> None:
+    fields = ModelContract.of(OpenOasis).commands
+    assert fields["set_image"].command.__command_fields__["image"].info.moderate
+    assert fields["set_video"].command.__command_fields__["video"].info.moderate
+
+
+def test_new_connection_waits_and_disconnect_discards_upload() -> None:
+    model = ready_model()
+    model._backend = object()  # type: ignore[assignment]
+    model.on_session_started()
+    assert model._conditioning is None
+    assert model._conditioning_name == "none"
+
+    model._conditioning = np.zeros((1, 360, 640, 3), dtype=np.uint8)
+    model._conditioning_name = "uploaded.png"
+    asyncio.run(model.on_disconnected())
+
+    assert model._conditioning is None
+    assert model._conditioning_name == "none"
+    assert asyncio.run(anext(model.inference())) is None
+
+
+def test_playback_contract_uses_one_frame_chunks_without_explicit_fps() -> None:
+    assert "fps" not in OpenOasis.__dict__
+    assert OpenOasis.buffer_size == 1
+
+
+def test_press_and_release_before_sampling_still_produces_one_frame_pulse() -> None:
+    model = ready_model()
+    asyncio.run(model.set_key_state("w", True))
+    asyncio.run(model.set_key_state("w", False))
+
+    assert model.state._pressed_keys == frozenset()
+    assert model._build_action()[11] == 1
+
+    model.state._pending_key_pulses = frozenset()
+    assert model._build_action()[11] == 0
+
+
+def test_command_is_processed_while_worker_thread_runs_inference() -> None:
+    class BlockingBackend:
+        def __init__(self) -> None:
+            self.entered = threading.Event()
+            self.release = threading.Event()
+
+        def reset(self, _conditioning, _seed) -> None:
+            self.entered.set()
+            assert self.release.wait(timeout=2)
+
+    async def exercise() -> None:
+        model = ready_model()
+        backend = BlockingBackend()
+        model._backend = backend  # type: ignore[assignment]
+        inference = asyncio.create_task(anext(model.inference()))
+        assert await asyncio.to_thread(backend.entered.wait, 1)
+
+        reply = await asyncio.wait_for(model.set_key_state("w", True), timeout=0.1)
+        assert reply.pressed_keys == ["w"]
+
+        backend.release.set()
+        output = await asyncio.wait_for(inference, timeout=1)
+        assert output is not None
+
+    asyncio.run(exercise())


### PR DESCRIPTION
## Summary

- add an Open-Oasis 500M Reactor adapter with native Minecraft keyboard, mouse-button, and camera controls
- support uploaded image and multi-frame video conditioning without selecting a default image
- preserve the upstream 32-frame autoregressive context and released sampling behavior
- run GPU inference and media decoding in worker threads so commands remain responsive
- add complete command, message, and state-update schemas
- define the complete Dockerfile-free serving image through `reactor.yaml`
- add a cookbook-standard README covering deployment, controls, runtime boundaries, assets, and recording

## Validation

- `reactor build` completed successfully
- `reactor run` tested on an NVIDIA B200
- 17 interactive actions accepted with no rejected commands
- recorded and visually inspected a 25-second, 753-frame rollout
- 9 tests passed
- Ruff passed
- `reactor validate` passed