### PR TITLE
Add the YUME 1.5 world model adapter

### DIFF
--- a/models/yume-1-5/.dockerignore
+++ b/models/yume-1-5/.dockerignore
@@ -1,0 +1,20 @@
+# Python caches and local environments
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.venv/
+venv/
+
+# Editor and operating-system state
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Source-control metadata and local model assets
+.git/
+.gitignore
+weights/

--- a/models/yume-1-5/README.md
+++ b/models/yume-1-5/README.md
@@ -1,0 +1,151 @@
+# Play YUME-1.5 through Reactor Runtime
+
+Run the public [YUME-1.5 world model](https://github.com/stdstu12/YUME) as an
+interactive Reactor backend. Start from text, an uploaded image, or an uploaded
+video; change the prompt; hold compatible translation and view keys; stream the
+generated video; and record the session.
+
+The adapter loads the distilled public
+[`stdstu123/Yume-5B-720P`](https://huggingface.co/stdstu123/Yume-5B-720P)
+checkpoint and calls the pinned upstream inference components directly.
+
+## Prerequisites
+
+- The [`reactor` CLI](https://docs.reactor.inc/deploy/platform/installation),
+  Docker, and the NVIDIA Container Toolkit.
+- One NVIDIA GPU. CPU inference is unsupported; the deployment manifest requests
+  one NVIDIA B200.
+- Sufficient persistent storage for the source checkout, 5B checkpoint, Hugging
+  Face cache, uploaded media, and generated-kernel cache, plus container image
+  and build-cache space.
+
+## Run
+
+This directory is a `reactor` workspace. Its `reactor.yaml` declares the model,
+Reactor Runtime release, GPU resources, recording settings, Python and CUDA
+versions, system packages, and Python dependencies. No handwritten Dockerfile
+is required. See Reactor's
+[build configuration](https://docs.reactor.inc/deploy/platform/build) for the
+supported manifest fields.
+
+Build the model image, expose one GPU, and start Runtime:
+
+```sh
+cd models/yume-1-5
+reactor build
+reactor run --gpus device=0
+```
+
+`reactor run` serves on `http://localhost:8080` and reuses the image produced by
+`reactor build`. It builds automatically when the local image is missing. To use
+another host GPU and port:
+
+```sh
+reactor run --gpus device=4 --port 18095
+```
+
+The first start clones the pinned YUME source and downloads the pinned public
+checkpoint. Later starts validate and reuse both from `runtime.weights_path`.
+Check readiness and inspect the generated client contract with:
+
+```sh
+curl -fsS http://localhost:8080/health
+curl -fsS http://localhost:8080/schema
+```
+
+## Runtime boundary
+
+YUME-1.5 is an autoregressive video world model. Model weights load once at
+process startup, while each session owns one rolling clean-latent history and
+random generator. Each inference turn denoises one native eight-latent tail and
+emits 29 RGB frames on `main_video`. The generated tail is retained as context
+for the next turn.
+
+The public 5B checkpoint does not expose a Transformer KV cache. The adapter
+preserves YUME's full clean latent context and its upstream temporal compression
+instead of introducing a separate cache. Prompt changes affect the next chunk
+without discarding that visual history.
+
+Generation follows the upstream synchronous inference path. Model messages are
+sent outside that path at command and chunk boundaries.
+
+## Controls
+
+Generation waits for one of the scene-selection commands:
+
+- `set_image(image, prompt, seed)` starts a fresh world from an uploaded image.
+  A blank prompt uses the configured neutral continuation description.
+- `set_video_scene(video, prompt, seed)` starts from the first 33 frames of an
+  uploaded video and requires a non-empty prompt.
+- `set_text_scene(prompt, seed)` starts without reference media and requires a
+  non-empty prompt.
+- `set_prompt(prompt)` changes text conditioning at the next chunk boundary
+  without clearing visual history.
+- `set_key_state(key, pressed)` presses or releases a persistent translation or
+  view key.
+- `release_controls` releases every held key for forthcoming chunks.
+- `reset(seed)` restarts the selected scene, releases all controls, and
+  optionally selects another seed.
+
+Translation uses `w`, `a`, `s`, and `d`; view control uses `arrow_left`,
+`arrow_right`, `arrow_up`, and `arrow_down`. Compatible keys remain held and may
+be combined: forward/backward can pair with left/right translation, pan can pair
+with tilt, and one translation combination can run simultaneously with one view
+combination. Opposite directions are rejected with `command_error`.
+
+YUME encodes these controls in its text condition. Stationary chunks explicitly
+set movement distance, angular change rate, and view rotation speed to zero;
+active translation and view controls use the released caption vocabulary and
+control values.
+
+## Image and video uploads
+
+`set_image` accepts JPEG, PNG, WebP, BMP, or TIFF files up to 25 MiB and 100
+million pixels through Reactor's upload protocol. The image anchors the first
+frame and is fitted to YUME's 1280×704 output.
+
+`set_video_scene` accepts a decodable video up to 500 MiB with at least 33
+frames. The first 33 frames initialize the continuation. This recipe does not
+provide a default image; generation begins only after the client selects text or
+uploads media.
+
+## Model messages
+
+Commands return typed, command-correlated messages for the client timeline:
+
+- `scene_queued` reports an accepted text, image, or video scene.
+- `prompt_changed`, `action_changed`, and `rollout_reset_queued` report accepted
+  prompt, held-key, and reset changes and their first affected chunk.
+- `chunk_completed` reports the prompt, exact YUME control condition, movement,
+  view, frame count, and wall-clock generation time for one completed chunk.
+- `state_update` is a complete snapshot of the selected mode and media, prompt,
+  held keys, seed, reset and generation flags, and chunk progress. A joining
+  client receives one immediately, and each successful mutation broadcasts
+  another.
+
+## Public source and model assets
+
+`yume.yaml` pins upstream source revision
+`111c3fab7fb020d1e261a68be6ec78a3fecc8d5b` and checkpoint revision
+`b117c778405246a0b932d7ec5873b01a4840da3a`. Downloads resume into the
+CLI-mounted weights directory, and startup reuses valid existing assets.
+
+The checked-in `runtime.weights_path` is
+`~/.cache/reactor_registry/yume-1-5`. To keep that stable CLI path while placing
+its contents on a larger volume, create a symlink before the first run:
+
+```sh
+export YUME_ROOT=/path/to/large-volume/yume-1-5
+mkdir -p "$YUME_ROOT" "$HOME/.cache/reactor_registry"
+ln -s "$YUME_ROOT" "$HOME/.cache/reactor_registry/yume-1-5"
+```
+
+The container engine stores image layers and build cache separately from model
+weights. Configure the engine's storage on a large volume when the system disk
+is constrained.
+
+## Recording
+
+`reactor.yaml` records `main_video` by default and allows clips up to five
+minutes. YUME-1.5 emits video without audio. Stop `reactor run` to remove the
+serving container and release its GPU memory.

--- a/models/yume-1-5/reactor.yaml
+++ b/models/yume-1-5/reactor.yaml
@@ -1,0 +1,47 @@
+$schema: reactor/v1
+
+model:
+  name: yume-1-5
+  version: v0.1.0
+  description: |
+    Explore a continuous YUME-1.5 world from text or an uploaded first frame,
+    using its released prompt-encoded keyboard and camera controls.
+  resources:
+    gpu:
+      type: NVIDIA_B200
+      count: 1
+    cpu:
+      request: "8"
+      limit: "16"
+    memory:
+      request: 64Gi
+      limit: 160Gi
+
+runtime:
+  import: yume:Yume15
+  config: yume.yaml
+  # Source, checkpoints, downloads, uploads, and compiled kernels stay here.
+  weights_path: ~/.cache/reactor_registry/yume-1-5
+  recording:
+    enabled: true
+    chunk_seconds: 1.208333
+    clip_max_seconds: 300
+    video_track: main_video
+    video:
+      codec: h264
+      preset: veryfast
+      crf: 23
+
+build:
+  runtime_version: "3.2.5"
+  python_requirements: requirements.txt
+  python_version: "3.12"
+  cuda_version: "12.8.1"
+  system_packages:
+    - build-essential
+    - ffmpeg
+    - git
+    - libgl1
+    - libglib2.0-0
+  runtime_env:
+    PYTORCH_ALLOC_CONF: expandable_segments:True

--- a/models/yume-1-5/requirements.txt
+++ b/models/yume-1-5/requirements.txt
@@ -1,0 +1,28 @@
+# Model dependencies resolved with Reactor Runtime during `reactor build`.
+# `build.runtime_version` in reactor.yaml selects the Runtime release.
+--extra-index-url https://download.pytorch.org/whl/cu128
+# Upstream used torch 2.5/cu121; B200 requires an sm_100-capable CUDA wheel.
+torch==2.7.1
+torchvision==0.22.1
+accelerate==1.0.1
+diffusers==0.32.0
+easydict==1.13
+einops==0.8.0
+ftfy==6.3.1
+flash-attn==2.8.3
+huggingface-hub==0.26.1
+imageio==2.36.0
+# Reactor Runtime 3.2.5 requires NumPy 2; YUME uses only compatible ndarray APIs.
+numpy==2.1.3
+ninja==1.13.2
+omegaconf==2.3.0
+opencv-python-headless==4.10.0.84
+pillow==10.2.0
+peft==0.13.2
+# Runtime's wire contract requires protobuf 7; YUME does not depend on removed APIs.
+protobuf==7.35.1
+PyYAML==6.0.1
+safetensors==0.5.3
+sentencepiece==0.2.0
+tokenizers==0.20.1
+transformers==4.46.1

--- a/models/yume-1-5/tests/test_yume.py
+++ b/models/yume-1-5/tests/test_yume.py
@@ -1,0 +1,155 @@
+"""Contract and rollout-boundary tests for the YUME-1.5 adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+from PIL import Image
+from reactor_runtime import UploadedFile
+from reactor_runtime.interface.model.contract import ModelContract
+
+from yume import Yume15
+from yume_assets import read_config
+from yume_backend import conditioned_prompt
+from yume_images import validate_image
+from yume_types import YumeOutput, YumeState
+
+
+def uploaded_image() -> UploadedFile:
+    stream = io.BytesIO()
+    Image.new("RGB", (32, 32), (20, 30, 40)).save(stream, format="PNG")
+    return UploadedFile(name="start.png", mime_type="image/png", data=stream.getvalue())
+
+
+def test_contract_has_only_real_upstream_controls() -> None:
+    contract = ModelContract.of(Yume15)
+    assert set(contract.commands) == {
+        "release_controls",
+        "reset",
+        "set_key_state",
+        "set_image",
+        "set_prompt",
+        "set_text_scene",
+        "set_video_scene",
+    }
+    assert "fps" not in Yume15.__dict__
+    assert Yume15.buffer_size == 29
+    assert set(YumeOutput.__tracks__) == {"main_video"}
+
+
+def test_native_fast_context_is_fixed() -> None:
+    config = read_config(Path(__file__).parents[1] / "yume.yaml")
+    assert config.frames_per_chunk == 32
+    assert config.latent_frames_per_chunk == 8
+    assert config.sample_steps == 4
+
+
+def test_conditioning_explicitly_distinguishes_stationary_and_motion() -> None:
+    stationary = conditioned_prompt("A city street", "none", "none")
+    moving = conditioned_prompt("A city street", "forward", "pan_left")
+
+    assert "Actual distance moved:0" in stationary
+    assert "Angular change rate (turn speed):0" in stationary
+    assert "View rotation speed:0" in stationary
+    assert "pushes forward" not in stationary
+    assert "Actual distance moved:4" in moving
+    assert "Angular change rate (turn speed):4" in moving
+    assert "View rotation speed:4" in moving
+
+
+def test_upload_is_decodable() -> None:
+    validate_image(uploaded_image())
+
+
+def test_blank_image_prompt_uses_neutral_configured_prompt() -> None:
+    model = Yume15()
+    model.state = YumeState()
+    model._config = read_config(Path(__file__).parents[1] / "yume.yaml")
+    model._backend = cast(Any, object())
+    model.output = cast(Any, type("Output", (), {"flush": lambda self: None})())
+
+    message = asyncio.run(model.set_image(uploaded_image(), "   ", 42))
+
+    assert model.state.prompt == model._config.default_upload_prompt
+    assert message.prompt == model._config.default_upload_prompt
+
+
+def test_one_turn_is_one_chunk_and_prompt_can_change_without_reset(
+    tmp_path: Path,
+) -> None:
+    class FakeBackend:
+        resets = 0
+        calls = 0
+
+        def reset(self, **_: object) -> None:
+            self.resets += 1
+
+        def generate_chunk(
+            self, *, prompt: str, movement: str, view: str
+        ) -> tuple[np.ndarray, str]:
+            self.calls += 1
+            return np.zeros(
+                (29, 8, 8, 3), dtype=np.uint8
+            ), f"{movement}|{view}|{prompt}"
+
+        def end_session(self) -> None:
+            return
+
+    model = Yume15()
+    model.state = YumeState()
+    model._config = read_config(Path(__file__).parents[1] / "yume.yaml")
+    model._config.runtime_dir.mkdir(parents=True, exist_ok=True)
+    backend = FakeBackend()
+    model._backend = backend
+    model._seed = 42
+    asyncio.run(model.set_image(uploaded_image(), "A forest trail", 42))
+
+    async def generate() -> tuple[np.ndarray, np.ndarray]:
+        iterator = model.inference()
+        first = await anext(iterator)
+        assert isinstance(first, YumeOutput)
+        await model.set_prompt("Rain begins")
+        second = await anext(iterator)
+        assert isinstance(second, YumeOutput)
+        return cast(np.ndarray, first.main_video), cast(np.ndarray, second.main_video)
+
+    first, second = asyncio.run(generate())
+    assert first.shape == second.shape == (29, 8, 8, 3)
+    assert backend.resets == 1
+    assert backend.calls == 2
+
+
+def test_reset_flushes_media() -> None:
+    class FakeOutput:
+        flushes = 0
+
+        def flush(self) -> None:
+            self.flushes += 1
+
+    model = Yume15()
+    model.state = YumeState()
+    output = FakeOutput()
+    model.output = cast(Any, output)
+    model._request_reset()
+    assert output.flushes == 1
+    assert model.state._reset_requested is True
+    assert model.state._pressed_keys == frozenset()
+
+
+def test_held_keys_combine_and_release_independently() -> None:
+    model = Yume15()
+    model.state = YumeState()
+    model._mode = "text_to_video"
+    asyncio.run(model.set_key_state("w", True))
+    asyncio.run(model.set_key_state("a", True))
+    asyncio.run(model.set_key_state("arrow_up", True))
+    assert model._resolve_controls(model.state._pressed_keys) == (
+        "forward_left",
+        "tilt_up",
+    )
+    asyncio.run(model.set_key_state("a", False))
+    assert model._resolve_controls(model.state._pressed_keys) == ("forward", "tilt_up")

--- a/models/yume-1-5/yume.py
+++ b/models/yume-1-5/yume.py
@@ -1,0 +1,501 @@
+"""Serve one native YUME-1.5 rolling-latent video chunk per Reactor turn."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncGenerator
+from pathlib import Path
+from typing import Literal, Protocol
+
+import numpy as np
+from reactor_runtime import (
+    ClientInfo,
+    CommandError,
+    InputField,
+    ReactorPipeline,
+    UploadedFile,
+    connected,
+    disconnected,
+    event,
+    session_ended,
+    session_started,
+)
+
+from yume_assets import (
+    YumeConfig,
+    activate_source,
+    configure_environment,
+    prepare_assets,
+    read_config,
+)
+from yume_images import (
+    materialized_image,
+    materialized_video,
+    validate_image,
+    validate_video,
+)
+from yume_types import (
+    ActionChanged,
+    ChunkCompleted,
+    Movement,
+    PromptChanged,
+    RolloutResetQueued,
+    SceneQueued,
+    StateUpdate,
+    View,
+    YumeOutput,
+    YumeState,
+)
+
+_KEYS = ["w", "a", "s", "d", "arrow_left", "arrow_right", "arrow_up", "arrow_down"]
+_MOVEMENT_KEYS = {
+    frozenset(): "none",
+    frozenset({"w"}): "forward",
+    frozenset({"s"}): "backward",
+    frozenset({"a"}): "left",
+    frozenset({"d"}): "right",
+    frozenset({"w", "a"}): "forward_left",
+    frozenset({"w", "d"}): "forward_right",
+    frozenset({"s", "a"}): "backward_left",
+    frozenset({"s", "d"}): "backward_right",
+}
+_VIEW_KEYS = {
+    frozenset(): "none",
+    frozenset({"arrow_left"}): "pan_left",
+    frozenset({"arrow_right"}): "pan_right",
+    frozenset({"arrow_up"}): "tilt_up",
+    frozenset({"arrow_down"}): "tilt_down",
+    frozenset({"arrow_up", "arrow_left"}): "tilt_up_left",
+    frozenset({"arrow_up", "arrow_right"}): "tilt_up_right",
+    frozenset({"arrow_down", "arrow_left"}): "tilt_down_left",
+    frozenset({"arrow_down", "arrow_right"}): "tilt_down_right",
+}
+
+
+class Backend(Protocol):
+    def reset(
+        self,
+        *,
+        image: Path | None,
+        video: Path | None = None,
+        prompt: str,
+        seed: int,
+        movement: Movement,
+        view: View,
+    ) -> None: ...
+    def generate_chunk(
+        self, *, prompt: str, movement: Movement, view: View
+    ) -> tuple[np.ndarray, str]: ...
+    def end_session(self) -> None: ...
+
+
+class Yume15(ReactorPipeline):
+    """Explore a continuous YUME-1.5 world from text or an uploaded first frame."""
+
+    state: YumeState
+    buffer_size = 29
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._config: YumeConfig | None = None
+        self._backend: Backend | None = None
+        self._mode: (
+            Literal["image_to_video", "video_to_video", "text_to_video"] | None
+        ) = None
+        self._image: UploadedFile | None = None
+        self._video: UploadedFile | None = None
+        self._image_name: str | None = None
+        self._seed = 42
+        self._chunk_index = 0
+        self._generating = False
+
+    def load(self, config_path: Path | None) -> None:
+        """Prepare pinned public assets and load the 5B model on one GPU."""
+        config = read_config(config_path)
+        configure_environment(config)
+        prepare_assets(config)
+        activate_source(config)
+        from yume_backend import YumeBackend
+
+        self._config = config
+        self._seed = config.seed
+        self._backend = YumeBackend(config)
+
+    @session_started
+    def on_session_started(self) -> None:
+        self.state.prompt = ""
+        self.state._pressed_keys = frozenset()
+        self.state._reset_requested = False
+        self._mode = None
+        self._image = None
+        self._video = None
+        self._image_name = None
+        self._chunk_index = 0
+        self._generating = False
+
+    @session_ended
+    def on_session_ended(self) -> None:
+        if self._backend is not None:
+            self._backend.end_session()
+        self._mode = None
+        self._image = None
+        self._video = None
+        self._image_name = None
+        self._chunk_index = 0
+
+    @connected
+    async def on_connected(self, client: ClientInfo) -> None:
+        await client.send(self._state_update())
+
+    @disconnected
+    async def on_disconnected(self) -> None:
+        self._clear_controls()
+        await self.send(self._state_update())
+
+    @event(
+        name="set_image",
+        description="Start a new world from an uploaded image. The replacement starts at the next chunk boundary. A blank `prompt` uses a neutral continuation description. Emits `scene_queued` and `state_update` on success, or `command_error` if the image is invalid.",
+    )
+    async def set_image(
+        self,
+        image: UploadedFile = InputField(  # noqa: B008
+            moderate=True,
+            description="Reference frame uploaded through the Reactor file-upload protocol. Accepts JPEG, PNG, WebP, BMP, or TIFF up to 25 MiB and 100 million pixels; YUME fits it to the output frame.",
+        ),
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            moderate=True,
+            description="Optional description of the scene and events to preserve or introduce. It conditions the first and subsequent chunks; blank selects the server's neutral image-continuation description.",
+        ),
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description="Seed used to initialize this rollout. Use `-1` to retain the session's current seed.",
+        ),
+    ) -> SceneQueued:
+        validate_image(image)
+        config = self._require_loaded()[1]
+        normalized = prompt.strip() or config.default_upload_prompt
+        if seed >= 0:
+            self._seed = seed
+        self._mode, self._image, self._video, self._image_name = (
+            "image_to_video",
+            image,
+            None,
+            image.name,
+        )
+        self.state.prompt = normalized
+        self._request_reset()
+        await self.send(self._state_update())
+        return SceneQueued(
+            mode=self._mode,
+            conditioning_name=image.name,
+            prompt=normalized,
+            seed=self._seed,
+        )
+
+    @event(
+        name="set_video_scene",
+        description="Start a new world from an uploaded video and a prompt. The replacement starts at the next chunk boundary. Emits `scene_queued` and `state_update` on success, or `command_error` if the video or prompt is invalid.",
+    )
+    async def set_video_scene(
+        self,
+        video: UploadedFile = InputField(  # noqa: B008
+            moderate=True,
+            description="Reference video uploaded through the Reactor file-upload protocol. It must be decodable, contain at least 33 frames, and be no larger than 500 MiB; the first 33 frames anchor the rollout.",
+        ),
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            moderate=True,
+            description="Non-empty description of the scene and forthcoming events. It conditions the first generated continuation and remains active for later chunks.",
+        ),
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description="Seed used to initialize this rollout. Use `-1` to retain the session's current seed.",
+        ),
+    ) -> SceneQueued:
+        validate_video(video)
+        normalized = prompt.strip()
+        if not normalized:
+            raise CommandError(
+                "prompt_required",
+                "YUME video continuation requires a non-empty prompt.",
+            )
+        if seed >= 0:
+            self._seed = seed
+        self._mode, self._image, self._video, self._image_name = (
+            "video_to_video",
+            None,
+            video,
+            video.name,
+        )
+        self.state.prompt = normalized
+        self._request_reset()
+        await self.send(self._state_update())
+        return SceneQueued(
+            mode=self._mode,
+            conditioning_name=video.name,
+            prompt=normalized,
+            seed=self._seed,
+        )
+
+    @event(
+        name="set_text_scene",
+        description="Start a new world from a text description without reference media. The replacement starts at the next chunk boundary. Emits `scene_queued` and `state_update` on success, or `command_error` if `prompt` is blank.",
+    )
+    async def set_text_scene(
+        self,
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            moderate=True,
+            description="Non-empty description of the initial scene and forthcoming events. It conditions the first and subsequent chunks until changed by `set_prompt`.",
+        ),
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description="Seed used to initialize this rollout. Use `-1` to retain the session's current seed.",
+        ),
+    ) -> SceneQueued:
+        normalized = prompt.strip()
+        if not normalized:
+            raise CommandError(
+                "prompt_required", "YUME text-to-video requires a non-empty prompt."
+            )
+        if seed >= 0:
+            self._seed = seed
+        self._mode, self._image, self._video, self._image_name = (
+            "text_to_video",
+            None,
+            None,
+            None,
+        )
+        self.state.prompt = normalized
+        self._request_reset()
+        await self.send(self._state_update())
+        return SceneQueued(
+            mode=self._mode,
+            conditioning_name=None,
+            prompt=normalized,
+            seed=self._seed,
+        )
+
+    @event(
+        name="set_prompt",
+        description="Change the scene and event description without restarting the world. It is valid after a scene is selected and applies from the next chunk boundary. Emits `prompt_changed` and `state_update` on success, or `command_error` if no scene exists or `prompt` is blank.",
+    )
+    async def set_prompt(
+        self,
+        prompt: str = InputField(
+            default="",
+            max_length=4096,
+            moderate=True,
+            description="Non-empty description used to condition forthcoming chunks. It does not alter a chunk already being generated or discard visual history.",
+        ),
+    ) -> PromptChanged:
+        self._require_scene()
+        normalized = prompt.strip()
+        if not normalized:
+            raise CommandError("prompt_required", "YUME requires a non-empty prompt.")
+        self.state.prompt = normalized
+        result = PromptChanged(prompt=normalized, applies_to_chunk=self._next_chunk())
+        await self.send(self._state_update())
+        return result
+
+    @event(
+        name="set_key_state",
+        description="Press or release one persistent movement or view key. It is valid after a scene is selected and affects the next chunk boundary. Compatible keys may be held together. Emits `action_changed` and `state_update` on success, or `command_error` for no scene or an unsupported combination.",
+    )
+    async def set_key_state(
+        self,
+        key: str = InputField(
+            default="w",
+            choices=_KEYS,
+            description="Translation key (`w`, `a`, `s`, or `d`) or camera-view key (`arrow_left`, `arrow_right`, `arrow_up`, or `arrow_down`) whose held state will change.",
+        ),
+        pressed: bool = InputField(
+            default=True,
+            description="Set to `true` to hold `key`, or `false` to release it. The resulting held-key set applies from the next chunk boundary.",
+        ),
+    ) -> ActionChanged:
+        self._require_scene()
+        updated = (
+            self.state._pressed_keys.union((key,))
+            if pressed
+            else self.state._pressed_keys.difference((key,))
+        )
+        self._resolve_controls(updated)
+        self.state._pressed_keys = updated
+        result = ActionChanged(
+            key=key,
+            pressed=pressed,
+            pressed_keys=self._ordered_keys(),
+            applies_to_chunk=self._next_chunk(),
+        )
+        await self.send(self._state_update())
+        return result
+
+    @event(
+        name="release_controls",
+        description="Release every held movement and view key. It is valid after a scene is selected and restores stationary controls from the next chunk boundary. Emits `action_changed` and `state_update` on success, or `command_error` if no scene exists.",
+    )
+    async def release_controls(self) -> ActionChanged:
+        self._require_scene()
+        self._clear_controls()
+        result = ActionChanged(
+            key="all",
+            pressed=False,
+            pressed_keys=[],
+            applies_to_chunk=self._next_chunk(),
+        )
+        await self.send(self._state_update())
+        return result
+
+    @event(
+        name="reset",
+        description="Restart the selected scene and discard its generated history. It is valid after a scene is selected and begins at the next chunk boundary with all controls released. Emits `rollout_reset_queued` and `state_update` on success, or `command_error` if no scene exists.",
+    )
+    async def reset(
+        self,
+        seed: int = InputField(
+            default=-1,
+            ge=-1,
+            le=2_147_483_647,
+            description="Seed used to restart the rollout. Use `-1` to retain the session's current seed; the value is read when the reset begins.",
+        ),
+    ) -> RolloutResetQueued:
+        self._require_scene()
+        if seed >= 0:
+            self._seed = seed
+        replaced = self._chunk_index
+        self._request_reset()
+        await self.send(self._state_update())
+        return RolloutResetQueued(seed=self._seed, replaced_chunks=replaced)
+
+    async def inference(self) -> AsyncGenerator[YumeOutput | None, None]:
+        """Generate exactly one native eight-latent continuation per turn."""
+        backend, config = self._require_loaded()
+        while True:
+            if self._mode is None:
+                yield None
+                continue
+            if self.state._reset_requested:
+                self.state._reset_requested = False
+                if self._mode == "image_to_video":
+                    assert self._image is not None
+                    with materialized_image(
+                        self._image, config.runtime_dir
+                    ) as image_path:
+                        backend.reset(
+                            image=image_path,
+                            video=None,
+                            prompt=self.state.prompt,
+                            seed=self._seed,
+                            movement="none",
+                            view="none",
+                        )
+                elif self._mode == "video_to_video":
+                    assert self._video is not None
+                    with materialized_video(
+                        self._video, config.runtime_dir
+                    ) as video_path:
+                        backend.reset(
+                            image=None,
+                            video=video_path,
+                            prompt=self.state.prompt,
+                            seed=self._seed,
+                            movement="none",
+                            view="none",
+                        )
+                else:
+                    backend.reset(
+                        image=None,
+                        video=None,
+                        prompt=self.state.prompt,
+                        seed=self._seed,
+                        movement="none",
+                        view="none",
+                    )
+                self._chunk_index = 0
+            movement, view = self._resolve_controls(self.state._pressed_keys)
+            prompt = self.state.prompt
+            self._generating = True
+            await self.send(self._state_update())
+            started = time.perf_counter()
+            try:
+                frames, exact_prompt = backend.generate_chunk(
+                    prompt=prompt, movement=movement, view=view
+                )
+            finally:
+                self._generating = False
+            self._chunk_index += 1
+            await self.send(
+                ChunkCompleted(
+                    chunk=self._chunk_index,
+                    frames=int(frames.shape[0]),
+                    generation_seconds=round(time.perf_counter() - started, 3),
+                    prompt=prompt,
+                    conditioned_prompt=exact_prompt,
+                    movement=movement,
+                    view=view,
+                )
+            )
+            await self.send(self._state_update())
+            yield YumeOutput(main_video=np.ascontiguousarray(frames))
+
+    def _request_reset(self) -> None:
+        self.output.flush()
+        self._clear_controls()
+        self.state._reset_requested = True
+        self._chunk_index = 0
+
+    def _require_scene(self) -> None:
+        if self._mode is None:
+            raise CommandError("scene_required", "Select an image or text scene first.")
+
+    def _require_loaded(self) -> tuple[Backend, YumeConfig]:
+        if self._backend is None or self._config is None:
+            raise RuntimeError("YUME was not loaded")
+        return self._backend, self._config
+
+    def _next_chunk(self) -> int:
+        return (
+            1
+            if self.state._reset_requested
+            else self._chunk_index + 1 + int(self._generating)
+        )
+
+    def _clear_controls(self) -> None:
+        self.state._pressed_keys = frozenset()
+
+    def _ordered_keys(self) -> list[str]:
+        return [key for key in _KEYS if key in self.state._pressed_keys]
+
+    def _resolve_controls(self, keys: frozenset[str]) -> tuple[Movement, View]:
+        movement_keys = frozenset(key for key in keys if key in {"w", "a", "s", "d"})
+        view_keys = keys.difference(movement_keys)
+        if movement_keys not in _MOVEMENT_KEYS or view_keys not in _VIEW_KEYS:
+            raise CommandError(
+                "unsupported_key_combination",
+                "YUME cannot hold opposite movement keys or opposite view keys together.",
+            )
+        return _MOVEMENT_KEYS[movement_keys], _VIEW_KEYS[view_keys]
+
+    def _state_update(self) -> StateUpdate:
+        return StateUpdate(
+            mode=self._mode or "uninitialized",
+            conditioning_name=self._image_name,
+            prompt=self.state.prompt,
+            pressed_keys=self._ordered_keys(),
+            seed=self._seed,
+            reset_queued=self.state._reset_requested,
+            generating=self._generating,
+            completed_chunks=self._chunk_index,
+            next_chunk=None if self._mode is None else self._next_chunk(),
+        )

--- a/models/yume-1-5/yume.yaml
+++ b/models/yume-1-5/yume.yaml
@@ -1,0 +1,24 @@
+source:
+  path: source/YUME
+  url: https://github.com/stdstu12/YUME.git
+  revision: 111c3fab7fb020d1e261a68be6ec78a3fecc8d5b
+
+assets:
+  cache_dir: cache/huggingface
+  checkpoint_path: weights/Yume-5B-720P
+  checkpoint_repo: stdstu123/Yume-5B-720P
+  checkpoint_revision: b117c778405246a0b932d7ec5873b01a4840da3a
+  runtime_dir: runtime
+
+inference:
+  width: 1280
+  height: 704
+  frames_per_chunk: 32
+  latent_frames_per_chunk: 8
+  sample_steps: 4
+  shift: 7.0
+  seed: 42
+  default_upload_prompt: >-
+    The scene remains stable and continues naturally from the input image with
+    coherent visual details.
+  warmup_chunks: 0

--- a/models/yume-1-5/yume_assets.py
+++ b/models/yume-1-5/yume_assets.py
@@ -1,0 +1,134 @@
+"""YUME source, checkpoint, cache, and inference configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from reactor_runtime import get_weights_path
+
+
+@dataclass(frozen=True)
+class YumeConfig:
+    source_path: Path
+    source_url: str
+    source_revision: str
+    checkpoint_path: Path
+    checkpoint_repo: str
+    checkpoint_revision: str
+    cache_dir: Path
+    runtime_dir: Path
+    width: int
+    height: int
+    frames_per_chunk: int
+    latent_frames_per_chunk: int
+    sample_steps: int
+    shift: float
+    seed: int
+    default_upload_prompt: str
+    warmup_chunks: int
+
+
+def read_config(path: Path | None) -> YumeConfig:
+    """Read and strictly validate the native YUME-5B rollout settings."""
+    if path is None:
+        raise ValueError("YUME requires yume.yaml")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    source, assets, inference = raw["source"], raw["assets"], raw["inference"]
+    config = YumeConfig(
+        source_path=_local_path(source["path"]),
+        source_url=str(source["url"]),
+        source_revision=str(source["revision"]),
+        checkpoint_path=_local_path(assets["checkpoint_path"]),
+        checkpoint_repo=str(assets["checkpoint_repo"]),
+        checkpoint_revision=str(assets["checkpoint_revision"]),
+        cache_dir=_local_path(assets["cache_dir"]),
+        runtime_dir=_local_path(assets["runtime_dir"]),
+        width=int(inference["width"]),
+        height=int(inference["height"]),
+        frames_per_chunk=int(inference["frames_per_chunk"]),
+        latent_frames_per_chunk=int(inference["latent_frames_per_chunk"]),
+        sample_steps=int(inference["sample_steps"]),
+        shift=float(inference["shift"]),
+        seed=int(inference["seed"]),
+        default_upload_prompt=str(inference["default_upload_prompt"]).strip(),
+        warmup_chunks=int(inference["warmup_chunks"]),
+    )
+    if (config.width, config.height) != (1280, 704):
+        raise ValueError("YUME-5B public checkpoint uses 1280x704 generation")
+    if config.frames_per_chunk != 32 or config.latent_frames_per_chunk != 8:
+        raise ValueError(
+            "YUME's native continuation window is 32 pixel / 8 latent frames"
+        )
+    if config.sample_steps <= 0 or config.warmup_chunks < 0:
+        raise ValueError("sample_steps must be positive and warmup_chunks non-negative")
+    if not config.default_upload_prompt:
+        raise ValueError("default_upload_prompt must be non-empty")
+    return config
+
+
+def configure_environment(config: YumeConfig) -> None:
+    """Keep every mutable model/tool cache on the NVMe volume."""
+    paths = {
+        "HF_HOME": config.cache_dir,
+        "HUGGINGFACE_HUB_CACHE": config.cache_dir / "hub",
+        "TRANSFORMERS_CACHE": config.cache_dir / "transformers",
+        "XDG_CACHE_HOME": config.runtime_dir / "xdg",
+        "TRITON_CACHE_DIR": config.runtime_dir / "triton",
+        "TORCHINDUCTOR_CACHE_DIR": config.runtime_dir / "torchinductor",
+        "CUDA_CACHE_PATH": config.runtime_dir / "cuda",
+    }
+    for key, value in paths.items():
+        value.mkdir(parents=True, exist_ok=True)
+        os.environ.setdefault(key, str(value))
+    if os.environ.get("HF_KEY") and not os.environ.get("HF_TOKEN"):
+        os.environ["HF_TOKEN"] = os.environ["HF_KEY"]
+    os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+
+def prepare_assets(config: YumeConfig) -> None:
+    """Ensure immutable upstream source and checkpoint snapshots exist."""
+    config.runtime_dir.mkdir(parents=True, exist_ok=True)
+    if not (config.source_path / ".git").is_dir():
+        config.source_path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "clone", config.source_url, str(config.source_path)], check=True
+        )
+    actual = subprocess.run(
+        ["git", "-C", str(config.source_path), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if actual != config.source_revision:
+        raise RuntimeError(
+            f"YUME source is {actual}; expected {config.source_revision}"
+        )
+    required = config.checkpoint_path / "diffusion_pytorch_model.safetensors"
+    if not required.is_file():
+        from huggingface_hub import snapshot_download
+
+        snapshot_download(
+            repo_id=config.checkpoint_repo,
+            revision=config.checkpoint_revision,
+            local_dir=config.checkpoint_path,
+            cache_dir=config.cache_dir,
+        )
+
+
+def activate_source(config: YumeConfig) -> None:
+    """Import the pinned upstream checkout without modifying it."""
+    root = str(config.source_path.resolve())
+    if root in sys.path:
+        sys.path.remove(root)
+    sys.path.insert(0, root)
+
+
+def _local_path(value: object) -> Path:
+    """Resolve one configured path under Reactor's mounted weights root."""
+    path = Path(str(value)).expanduser()
+    return (path if path.is_absolute() else get_weights_path() / path).resolve()

--- a/models/yume-1-5/yume_backend.py
+++ b/models/yume-1-5/yume_backend.py
@@ -1,0 +1,322 @@
+"""Faithful single-GPU extraction of YUME-5B's rolling-latent sampler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+
+from yume_assets import YumeConfig
+from yume_types import Movement, View
+
+MOVEMENT_TEXT: dict[Movement, str] = {
+    "none": "The camera's movement direction remains stationary (·).",
+    "forward": "The camera pushes forward (W).",
+    "backward": "The camera pulls back (S).",
+    "left": "The camera moves to the left (A).",
+    "right": "The camera moves to the right (D).",
+    "forward_left": "The camera pushes forward and moves to the left (W+A).",
+    "forward_right": "The camera pushes forward and moves to the right (W+D).",
+    "backward_left": "The camera pulls back and moves to the left (S+A).",
+    "backward_right": "The camera pulls back and moves to the right (S+D).",
+}
+VIEW_TEXT: dict[View, str] = {
+    "none": "The rotation direction of the camera remains stationary (·).",
+    "pan_left": "The camera pans to the left (←).",
+    "pan_right": "The camera pans to the right (→).",
+    "tilt_up": "The camera tilts up (↑).",
+    "tilt_down": "The camera tilts down (↓).",
+    "tilt_up_left": "The camera tilts up and pans to the left (↑←).",
+    "tilt_up_right": "The camera tilts up and pans to the right (↑→).",
+    "tilt_down_left": "The camera tilts down and pans to the left (↓←).",
+    "tilt_down_right": "The camera tilts down and pans to the right (↓→).",
+}
+
+
+def conditioned_prompt(prompt: str, movement: Movement, view: View) -> str:
+    """Encode controls in the caption format used to train and sample YUME."""
+    distance = 0 if movement == "none" else 4
+    rotation = 0 if view == "none" else 4
+    return " ".join(
+        (
+            "First-person perspective.",
+            MOVEMENT_TEXT[movement],
+            VIEW_TEXT[view],
+            f"Actual distance moved:{distance} at 100 meters per second.",
+            f"Angular change rate (turn speed):{rotation}.",
+            f"View rotation speed:{rotation}.",
+            prompt.strip(),
+        )
+    )
+
+
+class YumeBackend:
+    """Own YUME weights and its clean rolling latent/pixel continuation state."""
+
+    def __init__(self, config: YumeConfig) -> None:
+        if not torch.cuda.is_available():
+            raise RuntimeError("YUME-5B requires CUDA")
+        from wan23 import Yume
+        from wan23.configs import WAN_CONFIGS
+
+        self.config = config
+        self.device = torch.device("cuda")
+        self.dtype = torch.bfloat16
+        self.wan = Yume(
+            config=WAN_CONFIGS["ti2v-5B"],
+            checkpoint_dir=str(config.checkpoint_path),
+            device_id=torch.cuda.current_device(),
+        )
+        self.transformer = (
+            self.wan.model.to(self.device, dtype=self.dtype)
+            .eval()
+            .requires_grad_(False)
+        )
+        self.wan.vae.model.to(self.device)
+        for parameter in self.wan.vae.model.parameters():
+            parameter.data = parameter.data.to(self.dtype)
+        self.model_input_latent: torch.Tensor | None = None
+        self.model_input_pixels: torch.Tensor | None = None
+        self.mode: str | None = None
+        self.chunk_index = 0
+        self.generator = torch.Generator(device=self.device)
+
+    @torch.inference_mode()
+    def reset(
+        self,
+        *,
+        image: Path | None,
+        video: Path | None = None,
+        prompt: str,
+        seed: int,
+        movement: Movement,
+        view: View,
+    ) -> None:
+        """Initialize image or text mode while preserving upstream 32/8 context semantics."""
+        self.generator.manual_seed(seed)
+        self.model_input_latent = None
+        self.model_input_pixels = None
+        self.mode = (
+            "video_to_video"
+            if video is not None
+            else ("image_to_video" if image is not None else "text_to_video")
+        )
+        self.chunk_index = 0
+        if image is None and video is None:
+            return
+        if video is not None:
+            visible = self._load_video(video)
+        else:
+            assert image is not None
+            rgb = (
+                Image.open(image)
+                .convert("RGB")
+                .resize(
+                    (self.config.width, self.config.height), Image.Resampling.BILINEAR
+                )
+            )
+            pixels = (
+                torch.from_numpy(np.asarray(rgb).copy())
+                .permute(2, 0, 1)
+                .float()
+                .div(127.5)
+                .sub(1)
+                .to(self.device)
+            )
+            visible = torch.zeros(
+                (3, 33, self.config.height, self.config.width), device=self.device
+            )
+            visible[:, 0] = pixels
+        model_pixels = torch.cat(
+            [visible[:, :1].repeat(1, 16, 1, 1), visible[:, :33]], dim=1
+        )
+        with torch.autocast("cuda", dtype=self.dtype):
+            first = self.wan.vae.encode(
+                [model_pixels[:, : -self.config.frames_per_chunk]]
+            )[0]
+            second = self.wan.vae.encode(
+                [model_pixels[:, -self.config.frames_per_chunk :]]
+            )[0]
+        self.model_input_pixels = model_pixels
+        self.model_input_latent = torch.cat([first, second], dim=1)
+
+    def _load_video(self, path: Path) -> torch.Tensor:
+        """Match sample_5b.py's first 33 frames at its assumed 30 FPS."""
+        import av
+
+        with av.open(str(path)) as container:
+            images = [frame.to_image() for frame in container.decode(video=0)]
+        if len(images) < 33:
+            raise ValueError("YUME video conditioning requires at least 33 frames")
+        tensors = []
+        for image in images[:33]:
+            rgb = image.convert("RGB").resize(
+                (self.config.width, self.config.height), Image.Resampling.BICUBIC
+            )
+            tensors.append(torch.from_numpy(np.asarray(rgb).copy()).permute(2, 0, 1))
+        return (
+            torch.stack(tensors)
+            .permute(1, 0, 2, 3)
+            .float()
+            .div(127.5)
+            .sub(1)
+            .to(self.device)
+        )
+
+    @torch.inference_mode()
+    def generate_chunk(
+        self, *, prompt: str, movement: Movement, view: View
+    ) -> tuple[np.ndarray, str]:
+        """Denoise only the newest eight latents, decode one 32-frame chunk, and retain clean context."""
+        from wan23.utils.utils import masks_like
+
+        text = conditioned_prompt(prompt, movement, view)
+        latent_frames = self.config.latent_frames_per_chunk
+        if self.mode == "text_to_video" and self.model_input_latent is None:
+            arg_c, _arg_null, noise = self.wan.generate(
+                text,
+                frame_num=self.config.frames_per_chunk,
+                max_area=self.config.width * self.config.height,
+                latent_frame_zero=latent_frames,
+                sampling_steps=self.config.sample_steps,
+                shift=self.config.shift,
+                seed=self.generator.initial_seed(),
+                offload_model=False,
+            )
+            latent = noise.to(self.dtype)
+            mask2 = None
+        else:
+            if self.model_input_latent is None:
+                raise RuntimeError("YUME rollout was not initialized")
+            continuing = self.chunk_index > 0
+            frame_num = (
+                (self.model_input_latent.shape[1] - 1) * 4
+                + 1
+                + self.config.frames_per_chunk
+                if continuing
+                else self.model_input_pixels.shape[1]
+            )
+            img = (
+                self.model_input_latent
+                if continuing
+                else self.model_input_latent[:, :-latent_frames]
+            )
+            arg_c, _arg_null, noise, mask2, _img = self.wan.generate(
+                text,
+                img=img,
+                frame_num=frame_num,
+                max_area=self.config.width * self.config.height,
+                latent_frame_zero=latent_frames,
+                sampling_steps=self.config.sample_steps,
+                shift=self.config.shift,
+                seed=self.generator.initial_seed(),
+                offload_model=False,
+            )
+            if continuing:
+                fresh = torch.randn(
+                    (
+                        self.wan.vae.model.z_dim,
+                        self.model_input_latent.shape[1] + latent_frames,
+                        self.model_input_latent.shape[2],
+                        self.model_input_latent.shape[3],
+                    ),
+                    generator=self.generator,
+                    device=self.device,
+                    dtype=self.dtype,
+                )
+                latent = torch.cat(
+                    [self.model_input_latent, fresh[:, -latent_frames:]], dim=1
+                )
+                _mask1, mask2 = masks_like(
+                    [latent], zero=True, latent_frame_zero=latent_frames
+                )
+            else:
+                latent = torch.cat(
+                    [
+                        self.model_input_latent[:, :-latent_frames],
+                        noise[:, -latent_frames:],
+                    ],
+                    dim=1,
+                ).to(self.dtype)
+
+        sigmas = _sampling_sigmas(self.config.sample_steps, self.config.shift)
+        for index, sigma in enumerate(sigmas):
+            timestep = torch.tensor([sigma * 1000], device=self.device)
+            if mask2 is None:
+                tvec = timestep
+            else:
+                clean_ts = mask2[0][0][:-latent_frames, ::2, ::2].flatten()
+                tvec = torch.cat(
+                    [
+                        clean_ts,
+                        clean_ts.new_ones(arg_c["seq_len"] - clean_ts.numel())
+                        * timestep,
+                    ]
+                ).unsqueeze(0)
+            with torch.autocast("cuda", dtype=self.dtype):
+                kwargs = {"flag": False} if mask2 is None else {}
+                prediction = self.transformer(
+                    [latent], t=tvec, latent_frame_zero=latent_frames, **kwargs, **arg_c
+                )[0]
+            next_sigma = 0.0 if index + 1 == len(sigmas) else sigmas[index + 1]
+            tail = (
+                latent[:, -latent_frames:]
+                + (next_sigma - sigma) * prediction[:, -latent_frames:]
+            )
+            latent = torch.cat([latent[:, :-latent_frames], tail], dim=1)
+
+        with torch.autocast("cuda", dtype=self.dtype):
+            video = self.wan.vae.decode([latent[:, -latent_frames:]])[0][
+                :, -self.config.frames_per_chunk :
+            ]
+        if self.model_input_latent is None:
+            self.model_input_latent = latent[:, -latent_frames:]
+            self.model_input_pixels = video[:, -self.config.frames_per_chunk :]
+        elif self.chunk_index == 0:
+            self.model_input_latent = torch.cat(
+                [
+                    self.model_input_latent[:, :-latent_frames],
+                    latent[:, -latent_frames:],
+                ],
+                dim=1,
+            )
+            self.model_input_pixels = torch.cat(
+                [
+                    self.model_input_pixels[:, : -self.config.frames_per_chunk],
+                    video[:, -self.config.frames_per_chunk :],
+                ],
+                dim=1,
+            )
+        else:
+            self.model_input_latent = torch.cat(
+                [self.model_input_latent, latent[:, -latent_frames:]], dim=1
+            )
+            self.model_input_pixels = torch.cat(
+                [self.model_input_pixels, video[:, -self.config.frames_per_chunk :]],
+                dim=1,
+            )
+        self.chunk_index += 1
+        frames = (
+            video.clamp(-1, 1)
+            .add(1)
+            .mul(127.5)
+            .byte()
+            .permute(1, 2, 3, 0)
+            .cpu()
+            .numpy()
+        )
+        return frames, text
+
+    def end_session(self) -> None:
+        self.model_input_latent = None
+        self.model_input_pixels = None
+        self.mode = None
+        self.chunk_index = 0
+        torch.cuda.empty_cache()
+
+
+def _sampling_sigmas(steps: int, shift: float) -> np.ndarray:
+    sigma = np.linspace(1, 0, steps + 1)[:steps]
+    return shift * sigma / (1 + (shift - 1) * sigma)

--- a/models/yume-1-5/yume_images.py
+++ b/models/yume-1-5/yume_images.py
@@ -1,0 +1,94 @@
+"""Validation and temporary materialization for uploaded YUME images."""
+
+from __future__ import annotations
+
+import io
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+from PIL import Image, UnidentifiedImageError
+from reactor_runtime import CommandError, UploadedFile
+
+MAX_BYTES = 25 * 1024 * 1024
+MAX_PIXELS = 100_000_000
+FORMATS = {"BMP", "JPEG", "PNG", "TIFF", "WEBP"}
+MAX_VIDEO_BYTES = 500 * 1024 * 1024
+
+
+def validate_image(image: UploadedFile) -> None:
+    """Accept only bounded image formats decoded by the upstream PIL path."""
+    if not image.mime_type.startswith("image/") or not image.data:
+        raise CommandError("invalid_image", f"{image.name} is not a non-empty image.")
+    if image.size > MAX_BYTES:
+        raise CommandError("image_too_large", f"{image.name} exceeds 25 MiB.")
+    try:
+        with Image.open(io.BytesIO(image.data)) as decoded:
+            if decoded.format not in FORMATS:
+                raise CommandError(
+                    "unsupported_media", "Use JPEG, PNG, WebP, BMP, or TIFF."
+                )
+            width, height = decoded.size
+            if width <= 0 or height <= 0 or width * height > MAX_PIXELS:
+                raise CommandError(
+                    "image_too_large", f"{image.name} exceeds {MAX_PIXELS} pixels."
+                )
+            decoded.verify()
+    except CommandError:
+        raise
+    except (
+        Image.DecompressionBombError,
+        UnidentifiedImageError,
+        OSError,
+        ValueError,
+    ) as error:
+        raise CommandError(
+            "invalid_image", f"{image.name} cannot be decoded."
+        ) from error
+
+
+def validate_video(video: UploadedFile) -> None:
+    """Accept a bounded decodable video with at least 33 conditioning frames."""
+    if not video.mime_type.startswith("video/") or not video.data:
+        raise CommandError("invalid_video", f"{video.name} is not a non-empty video.")
+    if video.size > MAX_VIDEO_BYTES:
+        raise CommandError("video_too_large", f"{video.name} exceeds 500 MiB.")
+    try:
+        import av
+
+        with av.open(io.BytesIO(video.data)) as container:
+            for count, _frame in enumerate(container.decode(video=0), start=1):
+                if count >= 33:
+                    return
+    except (av.AVError, IndexError, OSError, ValueError) as error:
+        raise CommandError(
+            "invalid_video", f"{video.name} cannot be decoded."
+        ) from error
+    raise CommandError(
+        "video_too_short", f"{video.name} must contain at least 33 frames."
+    )
+
+
+@contextmanager
+def materialized_image(image: UploadedFile, runtime_dir: Path) -> Iterator[Path]:
+    """Yield a local path consumable by PIL and remove it afterwards."""
+    suffix = Path(image.name).suffix.lower() or ".png"
+    with tempfile.NamedTemporaryFile(
+        prefix="yume-upload-", suffix=suffix, dir=runtime_dir
+    ) as temporary:
+        temporary.write(image.data)
+        temporary.flush()
+        yield Path(temporary.name)
+
+
+@contextmanager
+def materialized_video(video: UploadedFile, runtime_dir: Path) -> Iterator[Path]:
+    """Yield a temporary local video path accepted by PyAV."""
+    suffix = Path(video.name).suffix.lower() or ".mp4"
+    with tempfile.NamedTemporaryFile(
+        prefix="yume-video-", suffix=suffix, dir=runtime_dir
+    ) as temporary:
+        temporary.write(video.data)
+        temporary.flush()
+        yield Path(temporary.name)

--- a/models/yume-1-5/yume_types.py
+++ b/models/yume-1-5/yume_types.py
@@ -1,0 +1,164 @@
+"""Public Reactor contract for YUME-1.5."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from reactor_runtime import (
+    InputField,
+    InputState,
+    MessageField,
+    ModelMessage,
+    Output,
+    Video,
+)
+
+Movement = Literal[
+    "none",
+    "forward",
+    "backward",
+    "left",
+    "right",
+    "forward_left",
+    "forward_right",
+    "backward_left",
+    "backward_right",
+]
+View = Literal[
+    "none",
+    "pan_left",
+    "pan_right",
+    "tilt_up",
+    "tilt_down",
+    "tilt_up_left",
+    "tilt_up_right",
+    "tilt_down_left",
+    "tilt_down_right",
+]
+
+
+class YumeOutput(Output):
+    """Carry the next 29-frame continuation on `main_video`."""
+
+    main_video: Video
+
+
+class YumeState(InputState):
+    """Store the prompt exposed through Reactor's generated state command."""
+
+    prompt: str = InputField(
+        default="",
+        max_length=4096,
+        moderate=True,
+        description="Scene and event description for forthcoming chunks. Scene commands initialize it, and the generated setter or `set_prompt` changes it at the next chunk boundary without restarting the world.",
+    )
+    _pressed_keys: frozenset[str] = frozenset()
+    _reset_requested: bool = False
+
+
+class StateUpdate(ModelMessage):
+    """Emitted on connection, after every state mutation, and after each completed chunk."""
+
+    mode: Literal[
+        "uninitialized", "image_to_video", "video_to_video", "text_to_video"
+    ] = MessageField(
+        description="How the current world was initialized, or `uninitialized` before any scene has been selected."
+    )
+    conditioning_name: str | None = MessageField(
+        description="Filename of the image or video anchoring the current or queued world, or null for text-only and uninitialized sessions."
+    )
+    prompt: str = MessageField(
+        description="Scene and event description currently scheduled for forthcoming chunks."
+    )
+    pressed_keys: list[str] = MessageField(
+        description="Ordered keys held for forthcoming chunks. W/A/S/D control translation, while arrow keys control pan and tilt; compatible keys can be combined."
+    )
+    seed: int = MessageField(
+        description="Seed used to initialize the current rollout or its queued replacement."
+    )
+    reset_queued: bool = MessageField(
+        description="Whether the next chunk boundary will restart from the selected scene and discard accumulated history."
+    )
+    generating: bool = MessageField(
+        description="Whether a continuation chunk is currently being generated."
+    )
+    completed_chunks: int = MessageField(
+        description="Number of chunks completed since the current world was initialized or last reset."
+    )
+    next_chunk: int | None = MessageField(
+        description="One-based index of the first chunk affected by a newly accepted prompt or control change, or null before scene selection."
+    )
+
+
+class SceneQueued(ModelMessage):
+    """Emitted when a text, image, or video scene is accepted for a fresh rollout."""
+
+    mode: Literal["image_to_video", "video_to_video", "text_to_video"] = MessageField(
+        description="Initialization mode selected for the fresh rollout."
+    )
+    conditioning_name: str | None = MessageField(
+        description="Filename of the uploaded image or video, or null for a text-only scene."
+    )
+    prompt: str = MessageField(
+        description="Normalized scene and event description selected for the fresh rollout."
+    )
+    seed: int = MessageField(description="Seed that will initialize the fresh rollout.")
+
+
+class ActionChanged(ModelMessage):
+    """Emitted after one control key changes state or all controls are released."""
+
+    key: str = MessageField(description="Changed key, or `all` when `release_controls` released the complete set.")
+    pressed: bool = MessageField(
+        description="Whether `key` is held after the change; always false when `key` is `all`."
+    )
+    pressed_keys: list[str] = MessageField(
+        description="Complete ordered set of movement and view keys held after the change."
+    )
+    applies_to_chunk: int = MessageField(
+        description="One-based index of the first chunk that will use the resulting held-key set."
+    )
+
+
+class PromptChanged(ModelMessage):
+    """Emitted when a new prompt is accepted for forthcoming chunks."""
+
+    prompt: str = MessageField(
+        description="Normalized scene and event description accepted for forthcoming chunks."
+    )
+    applies_to_chunk: int = MessageField(
+        description="One-based index of the first chunk that will use the new prompt."
+    )
+
+
+class RolloutResetQueued(ModelMessage):
+    """Emitted when the selected scene is accepted for restart at the next boundary."""
+
+    seed: int = MessageField(description="Seed that will initialize the restarted rollout.")
+    replaced_chunks: int = MessageField(
+        description="Number of completed chunks whose accumulated history the reset will discard."
+    )
+
+
+class ChunkCompleted(ModelMessage):
+    """Emitted after one 29-frame continuation chunk completes."""
+
+    chunk: int = MessageField(description="One-based index of the completed chunk in the current rollout.")
+    frames: int = MessageField(
+        description="Number of RGB frames delivered for this chunk on `main_video`; currently 29."
+    )
+    generation_seconds: float = MessageField(
+        description="Wall-clock seconds spent producing this chunk, including video decoding."
+    )
+    prompt: str = MessageField(
+        description="Scene and event description used for this chunk, excluding YUME's generated control text."
+    )
+    conditioned_prompt: str = MessageField(
+        description="Exact text condition used for this chunk, including YUME's movement, view, and speed controls."
+    )
+    movement: Movement = MessageField(
+        description="Translation direction applied throughout this completed chunk."
+    )
+    view: View = MessageField(
+        description="Pan and tilt direction applied throughout this completed chunk."
+    )


### PR DESCRIPTION
## Summary

- add a Reactor Runtime adapter for the distilled YUME-1.5 5B checkpoint
- support text, image, and video scene initialization
- expose persistent combinable WASD translation and arrow-key view controls
- preserve YUME's autoregressive clean-latent history across native 29-frame chunks
- add typed commands, model messages, state snapshots, upload validation, and recording
- document the manifest-driven `reactor build` / `reactor run` workflow without a handwritten Dockerfile
- keep source, checkpoints, uploads, and runtime caches under `runtime.weights_path`

## Validation

- `ruff check` passes
- 8 tests pass
- Reactor schema renders successfully
- tested image-conditioned multi-chunk generation on one NVIDIA B200