### PR TITLE
Declare the RLDX-1 manifest as reactor/v2

### DIFF
--- a/models/rldx-1/reactor.yaml
+++ b/models/rldx-1/reactor.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) 2026 Reactor Technologies, Inc. All rights reserved.
 # Reactor model specification for RLDX-1 with guided RTC.
-$schema: reactor/v1
+$schema: reactor/v2
 
 model:
   name: rldx-1


### PR DESCRIPTION
## Why

`reactor.yaml` for RLDX-1 landed in #50 with `$schema: reactor/v1`. The CLI
still reads v1, but only through its upgrade path: `reactor validate` on the
file today prints `legacy schema (deprecated); regenerate with reactor init or
migrate to the current $schema`, and every `publish`/`deploy` from the folder
carries that note.

## What this changes

Only the header. A v1 model document differs from v2 in two placements —
`recording:` nests under `runtime:` and a plan's `instances:` under
`deployment:` — and this file already has no `recording:` block and already
nests its plan, so the `$schema` bump is the whole migration. Under v2 the
CLI parses the document directly, with no upgrade step and no deprecation
diagnostic. The image build is untouched, so `model.version` stays put.

## Verification

`reactor validate` in `models/rldx-1` reports `✓ reactor.yaml` (CLI
v1.20260903.24657); before the change it reported the legacy-schema warning.

Signed-off-by: Dere-Wah <derexcontact@gmail.com>
Co-authored-by: Cursor <cursoragent@cursor.com>